### PR TITLE
ViewBuilder

### DIFF
--- a/jmix-core/src/main/java/io/jmix/core/FluentLoader.java
+++ b/jmix-core/src/main/java/io/jmix/core/FluentLoader.java
@@ -23,6 +23,7 @@ import io.jmix.core.queryconditions.Condition;
 
 import javax.persistence.TemporalType;
 import java.util.*;
+import java.util.function.Consumer;
 
 public class FluentLoader<E extends Entity<K>, K> {
 
@@ -33,6 +34,7 @@ public class FluentLoader<E extends Entity<K>, K> {
 
     private View view;
     private String viewName;
+    private ViewBuilder viewBuilder;
     private boolean softDeletion = true;
     private boolean dynamicAttributes;
 
@@ -65,9 +67,17 @@ public class FluentLoader<E extends Entity<K>, K> {
             loadContext.setView(view);
         else if (!Strings.isNullOrEmpty(viewName))
             loadContext.setView(viewName);
+        else if (viewBuilder != null)
+            loadContext.setView(viewBuilder.build());
 
         loadContext.setSoftDeletion(softDeletion);
         loadContext.setLoadDynamicAttributes(dynamicAttributes);
+    }
+
+    private void createViewBuilder() {
+        if (viewBuilder == null) {
+            viewBuilder = AppBeans.getPrototype(ViewBuilder.NAME, entityClass);
+        }
     }
 
     /**
@@ -115,6 +125,18 @@ public class FluentLoader<E extends Entity<K>, K> {
      */
     public FluentLoader<E, K> view(String viewName) {
         this.viewName = viewName;
+        return this;
+    }
+
+    public FluentLoader<E, K> view(Consumer<ViewBuilder> viewBuilderConfigurer) {
+        createViewBuilder();
+        viewBuilderConfigurer.accept(viewBuilder);
+        return this;
+    }
+
+    public FluentLoader<E, K> viewProperties(String... properties) {
+        createViewBuilder();
+        viewBuilder.addAll(properties);
         return this;
     }
 
@@ -199,6 +221,18 @@ public class FluentLoader<E extends Entity<K>, K> {
          */
         public ById<E, K> view(String viewName) {
             loader.viewName = viewName;
+            return this;
+        }
+
+        public ById<E, K> view(Consumer<ViewBuilder> viewBuilderConfigurer) {
+            loader.createViewBuilder();
+            viewBuilderConfigurer.accept(loader.viewBuilder);
+            return this;
+        }
+
+        public ById<E, K> viewProperties(String... properties) {
+            loader.createViewBuilder();
+            loader.viewBuilder.addAll(properties);
             return this;
         }
 
@@ -301,6 +335,18 @@ public class FluentLoader<E extends Entity<K>, K> {
          */
         public ByQuery<E, K> view(String viewName) {
             loader.viewName = viewName;
+            return this;
+        }
+
+        public ByQuery<E, K> view(Consumer<ViewBuilder> viewBuilderConfigurer) {
+            loader.createViewBuilder();
+            viewBuilderConfigurer.accept(loader.viewBuilder);
+            return this;
+        }
+
+        public ByQuery<E, K> viewProperties(String... properties) {
+            loader.createViewBuilder();
+            loader.viewBuilder.addAll(properties);
             return this;
         }
 

--- a/jmix-core/src/main/java/io/jmix/core/ViewBuilder.java
+++ b/jmix-core/src/main/java/io/jmix/core/ViewBuilder.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2019 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core;
+
+import io.jmix.core.entity.Entity;
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.metamodel.model.MetaProperty;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.print.attribute.standard.MediaSize;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+@Component(ViewBuilder.NAME)
+@Scope(BeanDefinition.SCOPE_PROTOTYPE)
+public class ViewBuilder {
+
+    public static final String NAME = "jmix_ViewBuilder";
+
+    @Inject
+    protected BeanLocator beanLocator;
+    @Inject
+    protected Metadata metadata;
+    @Inject
+    protected ViewRepository viewRepository;
+
+    protected Class<? extends Entity> entityClass;
+    protected MetaClass metaClass;
+    protected Set<String> properties = new LinkedHashSet<>();
+    protected Map<String, ViewBuilder> builders = new HashMap<>();
+    protected Map<String, View> views = new HashMap<>();
+    protected Map<String, FetchMode> fetchModes = new HashMap<>();
+    protected boolean systemProperties;
+
+    public static ViewBuilder of(Class<? extends Entity> entityClass) {
+        return AppBeans.getPrototype(ViewBuilder.class, entityClass);
+    }
+
+    protected ViewBuilder(Class<? extends Entity> entityClass) {
+        this.entityClass = entityClass;
+    }
+
+    @PostConstruct
+    protected void postConstruct() {
+        metaClass = metadata.getClassNN(entityClass);
+    }
+
+    public View build() {
+        View view = new View(entityClass, systemProperties);
+        for (String property : properties) {
+            ViewBuilder builder = builders.get(property);
+            if (builder == null) {
+                View refView = views.get(property);
+                if (refView == null) {
+                    view.addProperty(property);
+                } else {
+                    FetchMode fetchMode = fetchModes.get(property);
+                    if (fetchMode == null) {
+                        view.addProperty(property, refView);
+                    } else {
+                        view.addProperty(property, refView, fetchMode);
+                    }
+                }
+            } else {
+                view.addProperty(property, builder.build());
+            }
+        }
+        return view;
+    }
+
+    public ViewBuilder add(String property) {
+        String[] parts = property.split("\\.");
+        String propName = parts[0];
+        MetaProperty metaProperty = metaClass.getPropertyNN(propName);
+        properties.add(propName);
+        if (metaProperty.getRange().isClass()) {
+            if (!builders.containsKey(propName)) {
+                Class<Entity> refClass = metaProperty.getRange().asClass().getJavaClass();
+                builders.put(propName, beanLocator.getPrototype(ViewBuilder.class, refClass));
+            }
+        }
+        if (parts.length > 1) {
+            ViewBuilder nestedBuilder = builders.get(propName);
+            if (nestedBuilder == null)
+                throw new IllegalStateException("Builder not found for property " + propName);
+            String nestedProp = Arrays.stream(parts).skip(1).collect(Collectors.joining("."));
+            nestedBuilder.add(nestedProp);
+        }
+        return this;
+    }
+
+    public ViewBuilder add(String property, Consumer<ViewBuilder> consumer) {
+        properties.add(property);
+        Class<Entity> refClass = metaClass.getPropertyNN(property).getRange().asClass().getJavaClass();
+        ViewBuilder builder = beanLocator.getPrototype(ViewBuilder.class, refClass);
+        consumer.accept(builder);
+        builders.put(property, builder);
+        return this;
+    }
+
+    public ViewBuilder add(String property, String viewName) {
+        properties.add(property);
+        View view = viewRepository.getView(metaClass.getPropertyNN(property).getRange().asClass(), viewName);
+        views.put(property, view);
+        return this;
+    }
+
+    public ViewBuilder add(String property, String viewName, FetchMode fetchMode) {
+        add(property, viewName);
+        fetchModes.put(property, fetchMode);
+        return this;
+    }
+
+    public ViewBuilder addAll(String... properties) {
+        for (String property : properties) {
+            add(property);
+        }
+        return this;
+    }
+
+    public ViewBuilder addSystem() {
+        this.systemProperties = true;
+        return this;
+    }
+
+    public ViewBuilder addView(View view) {
+        for (ViewProperty viewProperty : view.getProperties()) {
+            add(viewProperty.getName());
+        }
+        return this;
+    }
+
+    public ViewBuilder addView(String viewName) {
+        addView(viewRepository.getView(metaClass, viewName));
+        return this;
+    }
+}

--- a/jmix-core/src/test/java/io/jmix/core/FluentLoaderViewBuilderTest.java
+++ b/jmix-core/src/test/java/io/jmix/core/FluentLoaderViewBuilderTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2019 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core;
+
+import com.sample.addon1.TestAddon1Configuration;
+import com.sample.app.TestAppConfiguration;
+import com.sample.app.entity.Pet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.inject.Inject;
+
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {JmixCoreConfiguration.class, TestAddon1Configuration.class, TestAppConfiguration.class})
+public class FluentLoaderViewBuilderTest {
+
+    @Inject
+    DataManager dataManager;
+
+    @Test
+    public void testUsage() {
+        UUID petId = UUID.randomUUID();
+
+        dataManager.load(Pet.class)
+                .id(petId)
+                .view(viewBuilder -> viewBuilder.addAll(
+                        "name",
+                        "owner.name",
+                        "owner.address.city"))
+                /*.one()*/;
+
+        dataManager.load(Pet.class)
+                .view(viewBuilder -> viewBuilder.addView(View.MINIMAL).addAll(
+                        "owner.name",
+                        "owner.address.city"))
+                .id(petId)
+                /*.one()*/;
+
+        dataManager.load(Pet.class)
+                .id(petId)
+                .viewProperties(
+                        "name",
+                        "owner.name",
+                        "owner.address.city")
+                /*.one()*/;
+
+        dataManager.load(Pet.class)
+                .query("...")
+                .view(viewBuilder -> viewBuilder.addView(View.LOCAL).addAll(
+                        "owner.name",
+                        "owner.address.city"))
+                /*.list()*/;
+
+        dataManager.load(Pet.class)
+                .query("...")
+                .viewProperties(
+                        "name",
+                        "owner.name",
+                        "owner.address.city")
+                /*.list()*/;
+    }
+
+    @Test
+    public void testLoadContext() {
+        LoadContext<Pet> loadContext = dataManager.load(Pet.class)
+                .view(viewBuilder -> viewBuilder.addAll(
+                        "name",
+                        "owner.name",
+                        "owner.address.city"))
+                .createLoadContext();
+
+        View view = loadContext.getView();
+        assertFalse(containsSystemProperties(view));
+        checkPetView(view);
+
+        loadContext = dataManager.load(Pet.class)
+                .view(viewBuilder -> viewBuilder.addView(View.LOCAL).addAll(
+                        "owner.name",
+                        "owner.address.city"))
+                .createLoadContext();
+
+        view = loadContext.getView();
+        assertTrue(containsSystemProperties(view));
+        checkPetView(view);
+
+        loadContext = dataManager.load(Pet.class)
+                .view(viewBuilder -> viewBuilder.addView(View.LOCAL).addAll(
+                        "owner.name",
+                        "owner.address.city"))
+                .createLoadContext();
+
+        view = loadContext.getView();
+        assertTrue(containsSystemProperties(view));
+        checkPetView(view);
+
+        loadContext = dataManager.load(Pet.class)
+                .viewProperties(
+                        "name",
+                        "owner.name",
+                        "owner.address.city")
+                .createLoadContext();
+
+        view = loadContext.getView();
+        assertFalse(containsSystemProperties(view));
+        checkPetView(view);
+
+        loadContext = dataManager.load(Pet.class)
+                .view(viewBuilder -> viewBuilder.addView(View.LOCAL))
+                .viewProperties(
+                        "owner.name",
+                        "owner.address.city")
+                .createLoadContext();
+
+        view = loadContext.getView();
+        assertTrue(containsSystemProperties(view));
+        checkPetView(view);
+    }
+
+    private void checkPetView(View view) {
+        assertTrue(view.containsProperty("name"));
+
+        assertNotNull(view.getProperty("owner"));
+        View ownerView = view.getProperty("owner").getView();
+        assertNotNull(ownerView);
+        assertFalse(containsSystemProperties(ownerView));
+        assertTrue(ownerView.containsProperty("name"));
+        assertTrue(ownerView.containsProperty("address"));
+
+        View addressView = ownerView.getProperty("address").getView();
+        assertTrue(addressView.containsProperty("city"));
+    }
+
+    private boolean containsSystemProperties(View view) {
+        return view.containsProperty("id")
+                && view.containsProperty("version")
+                && view.containsProperty("deleteTs")
+                && view.containsProperty("deletedBy")
+                && view.containsProperty("createTs")
+                && view.containsProperty("createdBy")
+                && view.containsProperty("updateTs")
+                && view.containsProperty("updatedBy");
+    }
+}

--- a/jmix-core/src/test/java/io/jmix/core/ViewBuilderTest.java
+++ b/jmix-core/src/test/java/io/jmix/core/ViewBuilderTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2019 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core;
+
+import com.sample.addon1.TestAddon1Configuration;
+import com.sample.app.TestAppConfiguration;
+import com.sample.app.entity.Owner;
+import com.sample.app.entity.Pet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = {JmixCoreConfiguration.class, TestAddon1Configuration.class, TestAppConfiguration.class})
+public class ViewBuilderTest {
+
+    @Test
+    public void testBuild() {
+        View view = ViewBuilder.of(Pet.class).build();
+
+        assertNotNull(view);
+        assertFalse(containsSystemProperties(view));
+        assertFalse(view.containsProperty("name"));
+    }
+
+    @Test
+    public void testProperty() {
+        View view = ViewBuilder.of(Pet.class).add("name").build();
+
+        assertFalse(containsSystemProperties(view));
+        assertTrue(view.containsProperty("name"));
+    }
+
+    @Test
+    public void testRefProperty() {
+        View view = ViewBuilder.of(Pet.class).add("owner").build();
+
+        assertFalse(containsSystemProperties(view));
+
+        assertNotNull(view.getProperty("owner"));
+        View ownerView = view.getProperty("owner").getView();
+        assertNotNull(ownerView);
+        assertFalse(containsSystemProperties(ownerView));
+        assertFalse(ownerView.containsProperty("name"));
+    }
+
+    @Test
+    public void testInlineRefProperty() {
+        View view = ViewBuilder.of(Pet.class)
+                .add("owner.name")
+                .build();
+
+        assertFalse(containsSystemProperties(view));
+
+        assertNotNull(view.getProperty("owner"));
+        View ownerView = view.getProperty("owner").getView();
+        assertNotNull(ownerView);
+        assertFalse(containsSystemProperties(ownerView));
+        assertTrue(ownerView.containsProperty("name"));
+    }
+
+    @Test
+    public void testRefView() {
+        View view = ViewBuilder.of(Pet.class)
+                .add("owner", builder -> builder.add("name"))
+                .build();
+
+        assertFalse(containsSystemProperties(view));
+
+        assertNotNull(view.getProperty("owner"));
+        View ownerView = view.getProperty("owner").getView();
+        assertNotNull(ownerView);
+        assertFalse(containsSystemProperties(ownerView));
+        assertTrue(ownerView.containsProperty("name"));
+    }
+
+    @Test
+    public void testRefLocalView() {
+        View view = ViewBuilder.of(Pet.class)
+                .add("owner", View.LOCAL)
+                .build();
+
+        assertFalse(containsSystemProperties(view));
+
+        assertNotNull(view.getProperty("owner"));
+        View ownerView = view.getProperty("owner").getView();
+        assertNotNull(ownerView);
+        assertTrue(containsSystemProperties(ownerView));
+        assertTrue(ownerView.containsProperty("name"));
+        assertFalse(ownerView.containsProperty("address"));
+    }
+
+    @Test
+    public void testProperties() {
+        View view = ViewBuilder.of(Pet.class).addAll("name", "nick").build();
+
+        assertFalse(containsSystemProperties(view));
+        assertTrue(view.containsProperty("name"));
+    }
+
+    @Test
+    public void testSystem() {
+        View view = ViewBuilder.of(Pet.class).addSystem().addAll("name").build();
+
+        assertTrue(containsSystemProperties(view));
+        assertTrue(view.containsProperty("name"));
+    }
+
+    @Test
+    public void testMinimal() {
+        View view = ViewBuilder.of(Pet.class).addView(View.MINIMAL).build();
+
+        assertFalse(containsSystemProperties(view));
+        assertTrue(view.containsProperty("name"));
+    }
+
+    @Test
+    public void testLocal() {
+        View petView = ViewBuilder.of(Pet.class).addView(View.LOCAL).build();
+
+        assertTrue(containsSystemProperties(petView));
+        assertTrue(petView.containsProperty("name"));
+
+        View ownerView = ViewBuilder.of(Owner.class).addView(View.LOCAL).build();
+        assertTrue(containsSystemProperties(ownerView));
+        assertTrue(ownerView.containsProperty("name"));
+        assertFalse(ownerView.containsProperty("address"));
+    }
+
+    @Test
+    public void testBase() {
+        View view = ViewBuilder.of(Pet.class).addView(View.BASE).build();
+
+        assertTrue(containsSystemProperties(view));
+        assertTrue(view.containsProperty("name"));
+    }
+
+    @Test
+    public void testLocalAndRef() {
+        View view = ViewBuilder.of(Pet.class)
+                .addView(View.LOCAL)
+                .add("owner")
+                .build();
+
+        assertTrue(containsSystemProperties(view));
+        assertTrue(view.containsProperty("name"));
+
+        assertNotNull(view.getProperty("owner"));
+        View ownerView = view.getProperty("owner").getView();
+        assertNotNull(ownerView);
+        assertFalse(containsSystemProperties(ownerView));
+        assertFalse(ownerView.containsProperty("name"));
+        assertFalse(ownerView.containsProperty("address"));
+
+        view = ViewBuilder.of(Pet.class)
+                .addView(View.LOCAL)
+                .add("owner.name")
+                .add("owner.address.city")
+                .build();
+
+        assertTrue(containsSystemProperties(view));
+        assertTrue(view.containsProperty("name"));
+
+        assertNotNull(view.getProperty("owner"));
+        ownerView = view.getProperty("owner").getView();
+        assertNotNull(ownerView);
+        assertFalse(containsSystemProperties(ownerView));
+        assertTrue(ownerView.containsProperty("name"));
+        assertTrue(ownerView.containsProperty("address"));
+
+        View addressView = ownerView.getProperty("address").getView();
+        assertTrue(addressView.containsProperty("city"));
+    }
+
+    private boolean containsSystemProperties(View view) {
+        return view.containsProperty("id")
+                && view.containsProperty("version")
+                && view.containsProperty("deleteTs")
+                && view.containsProperty("deletedBy")
+                && view.containsProperty("createTs")
+                && view.containsProperty("createdBy")
+                && view.containsProperty("updateTs")
+                && view.containsProperty("updatedBy");
+    }
+
+}


### PR DESCRIPTION
## Main use cases

### Standalone

```java
// single attribute
View view = ViewBuilder.of(Pet.class).add("name").build();

// reference attributes
View view = ViewBuilder.of(Pet.class)
        .add("owner.name")
        .add("owner.email")
        .build();

// all local and some reference attributes
View view = ViewBuilder.of(Pet.class)
        .addView(View.LOCAL)
        .add("owner.name")
        .add("owner.address.city")
        .build();

// all many at once
View view = ViewBuilder.of(Pet.class)
        .addAll("name", "owner.name", "owner.address.city")
        .build();

// configure nested view
View view = ViewBuilder.of(Pet.class)
        .add("owner", builder -> builder.addSystem().add("name"))
        .build();
```

See also [ViewBuilderTest.java](https://github.com/jmix-framework/jmix/blob/2eefa416c133ca3d41f1c63e21850224fb4e8ebe/jmix-core/src/test/java/io/jmix/core/ViewBuilderTest.java)

### With DataManager's fluent loader

```java
// explicit view builder 
dataManager.load(Pet.class)
        .id(petId)
        .view(viewBuilder -> viewBuilder.addAll(
                "name",
                "owner.name",
                "owner.address.city"))
        .one();

// implicit view builder 
dataManager.load(Pet.class)
        .query("...")
        .viewProperties(
                "name",
                "owner.name",
                "owner.address.city")
        .list();
```

See also [FluentLoaderViewBuilderTest.java](https://github.com/jmix-framework/jmix/blob/2eefa416c133ca3d41f1c63e21850224fb4e8ebe/jmix-core/src/test/java/io/jmix/core/FluentLoaderViewBuilderTest.java)