### PR TITLE
refactor some tests of the core module to be more groovyish

### DIFF
--- a/modules/core/src/test/groovy/entity_scanning/EntitiesScannerTest.groovy
+++ b/modules/core/src/test/groovy/entity_scanning/EntitiesScannerTest.groovy
@@ -28,8 +28,10 @@ import test_support.AppContextTestExecutionListener
 import test_support.base.TestBaseConfiguration
 
 @ContextConfiguration(classes = [CoreConfiguration, TestBaseConfiguration])
-@TestExecutionListeners(value = AppContextTestExecutionListener,
-        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@TestExecutionListeners(
+    value = AppContextTestExecutionListener,
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS
+)
 class EntitiesScannerTest extends Specification {
 
     @Autowired
@@ -44,9 +46,12 @@ class EntitiesScannerTest extends Specification {
         then:
 
         scanner != null
-        scanner.applicationContext != null
-        scanner.metadataReaderFactory != null
-        scanner.basePackages == ['io.jmix.core', 'test_support.base']
+
+        with (scanner) {
+            applicationContext != null
+            metadataReaderFactory != null
+            basePackages == ['io.jmix.core', 'test_support.base']
+        }
 
         when:
 
@@ -54,6 +59,8 @@ class EntitiesScannerTest extends Specification {
 
         then:
 
-        entityDefList.find { it == 'test_support.base.entity.BaseUuidEntity' } != null
+        entityDefList.any { entity ->
+            entity == 'test_support.base.entity.BaseUuidEntity'
+        }
     }
 }

--- a/modules/core/src/test/groovy/fetch_plans/FetchPlanRepositoryTest.groovy
+++ b/modules/core/src/test/groovy/fetch_plans/FetchPlanRepositoryTest.groovy
@@ -31,14 +31,17 @@ import spock.lang.Specification
 import org.springframework.beans.factory.annotation.Autowired
 
 @ContextConfiguration(classes = [CoreConfiguration, TestAddon1Configuration, TestAppConfiguration])
-@TestExecutionListeners(value = AppContextTestExecutionListener,
-        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@TestExecutionListeners(
+    value = AppContextTestExecutionListener,
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS
+)
 class FetchPlanRepositoryTest extends Specification {
 
     @Autowired
     FetchPlanRepository repository
 
     def "fetchPlan is deployed from add-on's fetch-plans.xml file"() {
+
         when:
 
         def fetchPlan = repository.getFetchPlan(TestAddon1Entity, 'test-fp-1')
@@ -50,21 +53,29 @@ class FetchPlanRepositoryTest extends Specification {
 
     def "predefined fetch plans do not contain system properties"() {
 
+        given:
+
         def localFetchPlan = repository.getFetchPlan(Pet.class, FetchPlan.LOCAL)
 
         expect:
+
         !containsSystemProperties(localFetchPlan)
 
     }
 
     private boolean containsSystemProperties(FetchPlan fetchPlan) {
-        return fetchPlan.containsProperty("id") ||
-            fetchPlan.containsProperty("version") ||
-            fetchPlan.containsProperty("deleteTs") ||
-            fetchPlan.containsProperty("deletedBy") ||
-            fetchPlan.containsProperty("createTs") ||
-            fetchPlan.containsProperty("createdBy") ||
-            fetchPlan.containsProperty("updateTs") ||
-            fetchPlan.containsProperty("updatedBy")
+
+        def systemProperties = [
+            "id",
+            "version",
+            "deleteTs",
+            "deletedBy",
+            "createTs",
+            "createdBy",
+            "updateTs",
+            "updatedBy",
+        ]
+
+        systemProperties.any { systemProperty -> fetchPlan.containsProperty(systemProperty) }
     }
 }

--- a/modules/core/src/test/groovy/format_strings/TestFormatStringsRegistry.groovy
+++ b/modules/core/src/test/groovy/format_strings/TestFormatStringsRegistry.groovy
@@ -24,10 +24,21 @@ import java.util.Locale
 class TestFormatStringsRegistry extends FormatStringsRegistryImpl {
 
     TestFormatStringsRegistry() {
-        setFormatStrings(Locale.ENGLISH, new FormatStrings(
+        setFormatStrings(
+            Locale.ENGLISH,
+            new FormatStrings(
                 '.' as char, ',' as char,
-                '#,##0', '#,##0.###', '#,##0.##',
-                'dd/MM/yyyy', 'dd/MM/yyyy HH:mm', 'dd/MM/yyyy HH:mm', 'HH:mm', 'HH:mm',
-                'True', 'False'))
+                '#,##0',
+                '#,##0.###',
+                '#,##0.##',
+                'dd/MM/yyyy',
+                'dd/MM/yyyy HH:mm',
+                'dd/MM/yyyy HH:mm',
+                'HH:mm',
+                'HH:mm',
+                'True',
+                'False'
+            )
+        )
     }
 }

--- a/modules/core/src/test/groovy/format_strings/TestFormatStringsRegistry.groovy
+++ b/modules/core/src/test/groovy/format_strings/TestFormatStringsRegistry.groovy
@@ -24,21 +24,10 @@ import java.util.Locale
 class TestFormatStringsRegistry extends FormatStringsRegistryImpl {
 
     TestFormatStringsRegistry() {
-        setFormatStrings(
-            Locale.ENGLISH,
-            new FormatStrings(
+        setFormatStrings(Locale.ENGLISH, new FormatStrings(
                 '.' as char, ',' as char,
-                '#,##0',
-                '#,##0.###',
-                '#,##0.##',
-                'dd/MM/yyyy',
-                'dd/MM/yyyy HH:mm',
-                'dd/MM/yyyy HH:mm',
-                'HH:mm',
-                'HH:mm',
-                'True',
-                'False'
-            )
-        )
+                '#,##0', '#,##0.###', '#,##0.##',
+                'dd/MM/yyyy', 'dd/MM/yyyy HH:mm', 'dd/MM/yyyy HH:mm', 'HH:mm', 'HH:mm',
+                'True', 'False'))
     }
 }


### PR DESCRIPTION
This PR improves the readability of some of the groovy tests of the `core` module.

It contains only small refactorings for

* `/entity_scanning/EntitiesScannerTest.groovy`
* `/fetch_plans/FetchPlanRepositoryTest.groovy`
