### PR TITLE
refactor messages tests in core module

### DIFF
--- a/modules/core/src/test/groovy/messages/MessageToolsTest.groovy
+++ b/modules/core/src/test/groovy/messages/MessageToolsTest.groovy
@@ -16,6 +16,7 @@
 
 package messages
 
+import test_support.TestLocales
 import test_support.addon1.TestAddon1Configuration
 import test_support.AppContextTestExecutionListener
 import test_support.app.TestAppConfiguration
@@ -29,9 +30,13 @@ import spock.lang.Specification
 
 import org.springframework.beans.factory.annotation.Autowired
 
+import static test_support.TestLocales.*
+
 @ContextConfiguration(classes = [CoreConfiguration, TestAddon1Configuration, TestAppConfiguration])
-@TestExecutionListeners(value = AppContextTestExecutionListener,
-        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@TestExecutionListeners(
+    value = AppContextTestExecutionListener,
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS
+)
 class MessageToolsTest extends Specification {
 
     @Autowired
@@ -39,9 +44,6 @@ class MessageToolsTest extends Specification {
 
     @Autowired
     Metadata metadata
-
-    static final LOC_EN = Locale.ENGLISH
-    static final Locale LOC_RU = Locale.forLanguageTag('ru')
 
     def "test loadString"() {
         expect:

--- a/modules/core/src/test/groovy/messages/MessagesTest.groovy
+++ b/modules/core/src/test/groovy/messages/MessagesTest.groovy
@@ -16,6 +16,7 @@
 
 package messages
 
+import spock.lang.Subject
 import test_support.addon1.TestAddon1Configuration
 import test_support.AppContextTestExecutionListener
 import test_support.app.TestAppConfiguration
@@ -29,16 +30,17 @@ import spock.lang.Specification
 
 import org.springframework.beans.factory.annotation.Autowired
 
+import static test_support.TestLocales.*
+
 @ContextConfiguration(classes = [CoreConfiguration, TestAddon1Configuration, TestAppConfiguration])
-@TestExecutionListeners(value = AppContextTestExecutionListener,
-        mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+@TestExecutionListeners(
+    value = AppContextTestExecutionListener,
+    mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS
+)
 class MessagesTest extends Specification {
 
     @Autowired
     Messages messages
-
-    static final LOC_EN = Locale.ENGLISH
-    static final Locale LOC_RU = Locale.forLanguageTag('ru')
 
     def "get message"() {
         expect:
@@ -55,6 +57,7 @@ class MessagesTest extends Specification {
         messages.getMessage(PetType.BIRD, LOC_EN) == 'Bird'
         messages.getMessage(PetType.BIRD, LOC_RU) == 'Птица'
     }
+
 
     def "get nonexistent message"() {
         expect:

--- a/modules/core/src/test/groovy/messages/MessagesTest.groovy
+++ b/modules/core/src/test/groovy/messages/MessagesTest.groovy
@@ -16,7 +16,6 @@
 
 package messages
 
-import spock.lang.Subject
 import test_support.addon1.TestAddon1Configuration
 import test_support.AppContextTestExecutionListener
 import test_support.app.TestAppConfiguration

--- a/modules/core/src/test/java/test_support/TestLocales.java
+++ b/modules/core/src/test/java/test_support/TestLocales.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support;
+
+import java.util.Locale;
+
+public class TestLocales {
+
+    public static final Locale LOC_EN = Locale.ENGLISH;
+    public static final Locale LOC_RU = Locale.forLanguageTag("ru");
+}


### PR DESCRIPTION
This PR improves the readability of some of the messages tests of the core module.

It adds a dedicated Test helper class in the `test_support` package for the definition of the locales used in the tests