### PR TITLE
add german translations for notifications, graphql and business-calendar

### DIFF
--- a/jmix-translations/content/io/jmix/businesscalendar/messages_de.properties
+++ b/jmix-translations/content/io/jmix/businesscalendar/messages_de.properties
@@ -1,0 +1,32 @@
+#
+# Copyright 2021 Haulmont.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.jmix.businesscalendar.entities/BusinessDayEntity.calendar=Kalender
+io.jmix.businesscalendar.entities/BusinessDayEntity.dayOfWeek=Wochentag
+io.jmix.businesscalendar.entities/BusinessDayEntity.endTime=Endzeit
+io.jmix.businesscalendar.entities/BusinessDayEntity.fixedDate=Festes Datum
+io.jmix.businesscalendar.entities/BusinessDayEntity.startTime=Startzeit
+io.jmix.businesscalendar.entities/CalendarEntity.businessDays=Arbeitstage
+io.jmix.businesscalendar.entities/CalendarEntity.code=Code
+io.jmix.businesscalendar.entities/CalendarEntity.holidays=Feiertage
+io.jmix.businesscalendar.entities/CalendarEntity.name=Name
+io.jmix.businesscalendar.entities/HolidayEntity.calendar=Kalender
+io.jmix.businesscalendar.entities/HolidayEntity.cronExpression=Cron Ausdruck
+io.jmix.businesscalendar.entities/HolidayEntity.dayOfMonth=Tag des Monates
+io.jmix.businesscalendar.entities/HolidayEntity.description=Beschreibung
+io.jmix.businesscalendar.entities/HolidayEntity.fixedDate=Festes Datum
+io.jmix.businesscalendar.entities/HolidayEntity.isWeekly=Ist wöchentlicher Feiertag
+io.jmix.businesscalendar.entities/HolidayEntity.monthValue=Monatswert

--- a/jmix-translations/content/io/jmix/businesscalendarui/messages_de.properties
+++ b/jmix-translations/content/io/jmix/businesscalendarui/messages_de.properties
@@ -1,0 +1,86 @@
+#
+# Copyright 2021 Haulmont.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# menu config
+menu-config.buscal_BusinessCalendarModel.browse=Geschäftskalender
+
+# model
+io.jmix.businesscalendarui.model/calendarSource.annotatedClass=Annotierte Klasse
+io.jmix.businesscalendarui.model/calendarSource.database=Datenbank
+
+io.jmix.businesscalendarui.model/BusinessCalendarModel=Geschäftskalender
+io.jmix.businesscalendarui.model/BusinessCalendarModel.code=Code
+io.jmix.businesscalendarui.model/BusinessCalendarModel.name=Name
+io.jmix.businesscalendarui.model/BusinessCalendarModel.source=Quelle
+
+io.jmix.businesscalendarui.model/HolidayModel=Feiertag
+io.jmix.businesscalendarui.model/HolidayModel.cronExpression=Cron Ausdruck
+io.jmix.businesscalendarui.model/HolidayModel.fixedDate=Datum
+io.jmix.businesscalendarui.model/HolidayModel.monthValue=Monat
+io.jmix.businesscalendarui.model/HolidayModel.dayValue=Tag
+io.jmix.businesscalendarui.model/HolidayModel.type=Typ
+io.jmix.businesscalendarui.model/HolidayModel.value=Wert
+io.jmix.businesscalendarui.model/HolidayModel.description=Beschreibung
+
+io.jmix.businesscalendarui.model/BusinessDayModel.startTime=Startzeit
+io.jmix.businesscalendarui.model/BusinessDayModel.endTime=Endzeit
+
+io.jmix.businesscalendarui.model/ScheduledBusinessDayModel.dayOfWeek=Wochentag
+io.jmix.businesscalendarui.model/ScheduledBusinessDayModel.businessDays=Arbeitstage
+
+io.jmix.businesscalendarui.model/AdditionalBusinessDayModel.fixedDate=Datum
+io.jmix.businesscalendarui.model/AdditionalBusinessDayModel.businessDay=Arbeitstag
+
+# screen
+io.jmix.businesscalendarui.screen.calendar/calendarBrowse.caption=Geschäftskalender
+io.jmix.businesscalendarui.screen.calendar/calendarEntityEdit.caption=Geschäftskalender bearbeiten
+io.jmix.businesscalendarui.screen.calendar/calendarEntityEdit.uniqueCode=Code muss eindeutig sein
+io.jmix.businesscalendarui.screen.calendar/holidayEdit.caption=Feiertag bearbeiten
+io.jmix.businesscalendarui.screen.calendar/holidayType=Feiertagstyp
+io.jmix.businesscalendarui.screen.calendar/weeklyCronExpression=Wochentag
+io.jmix.businesscalendarui.screen.calendar/cronExpression=Cron-basierter Feiertag
+io.jmix.businesscalendarui.screen.calendar/fixedDay=Festes Datum Feiertag
+io.jmix.businesscalendarui.screen.calendar/repeatableDate=Jährlicher Feiertag
+io.jmix.businesscalendarui.screen.calendar/monthValue=Monat
+io.jmix.businesscalendarui.screen.calendar/dayValue=Tag
+io.jmix.businesscalendarui.screen.calendar/dayOfWeek=Wochentag
+io.jmix.businesscalendarui.screen.calendar/incorrectCronExpressionCaption=Ungültiger Cron-Ausdruck
+io.jmix.businesscalendarui.screen.calendar/incorrectCronExpressionDescription=Bitte einen gültigen Quartz Cron-Ausdruck angeben
+io.jmix.businesscalendarui.screen.calendar/businessDayEdit.workingDayScheduleCaption=Arbeitszeitenplan bearbeiten
+io.jmix.businesscalendarui.screen.calendar/businessDayEdit.additionalDayScheduleCaption=Zusätzlichen Arbeitstag bearbeiten
+io.jmix.businesscalendarui.screen.calendar/incorrectTime.caption=Ungültige Zeiteinstellungen
+io.jmix.businesscalendarui.screen.calendar/incorrectTime.description=Startzeit darf nicht vor Endzeit liegen
+io.jmix.businesscalendarui.screen.calendar/workingTimeOverlapping.caption=Ungültige Arbeitszeiteinstellungen
+io.jmix.businesscalendarui.screen.calendar/workingTimeOverlapping.description=Arbeitszeit Perioden dürfen sich nicht überschneiden
+io.jmix.businesscalendarui.screen.calendar/workingScheduleTableCaption=Arbeitszeitplan
+io.jmix.businesscalendarui.screen.calendar/additionalBusinessDaysTableCaption=Zusätzliche Arbeitstage
+io.jmix.businesscalendarui.screen.calendar/holidaysTabCaption=Feiertage
+io.jmix.businesscalendarui.screen.calendar/workingScheduleTabCaption=Arbeitszeitplan
+io.jmix.businesscalendarui.screen.calendar/additionalBusinessDaysTabCaption=Zusätzliche Arbeitstage
+io.jmix.businesscalendarui.screen.calendar/businessHours=Geschäftszeiten
+io.jmix.businesscalendarui.screen.calendar/addAnotherIntervalLabel=Weiteres Intervall hinzufügen
+io.jmix.businesscalendarui.screen.calendar/cronExpressionHelpText=Cron-Ausdruck ist eine Folge von sechs bis sieben durch Leerzeichen getrennte Felder: Sekunde, Minute, Stunde, Tag, Monat, Wochentag  und Jahr (optional). \
+                Der Monat und der Wochentag können durch ihre ersten Buchstaben (Englische Namen) ausgedrückt werden. Beispiele:\
+                <ul>\
+                    <li>* * * ? * SUN - jeder Sonntag</li>\
+                    <li>* * * L * ? - der letzter Tag jedes Monats</li>\
+                    <li>* * * ? * 6L - letzter Freitag jedes Monats</li>\
+                    <li>* * * ? 9 6#3 - Dritter Freitag im September</li>\
+                    <li>* * * 25 12 ? - Weihnachten jeden Jahres</li>\
+                </ul>
+
+
+

--- a/jmix-translations/content/io/jmix/graphql/messages_de.properties
+++ b/jmix-translations/content/io/jmix/graphql/messages_de.properties
@@ -1,0 +1,18 @@
+#
+# Copyright 2021 Haulmont.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.jmix.graphql/gqlApiAccessDenied=Benutzer ist nicht berechtigt die GraphQL API zu benutzen
+io.jmix.graphql/gqlQueryAccessDenied=Benutzer ist nicht berechtigt die folgende Anfrage auszuführen: %s

--- a/jmix-translations/content/io/jmix/notifications/messages_de.properties
+++ b/jmix-translations/content/io/jmix/notifications/messages_de.properties
@@ -1,0 +1,37 @@
+#
+# Copyright 2022 Haulmont.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.jmix.notifications.entity/ContentType=Content Typ
+io.jmix.notifications.entity/ContentType.HTML=HTML
+io.jmix.notifications.entity/ContentType.PLAIN=Plain
+
+io.jmix.notifications.entity/InAppNotification=Benachrichtigung
+io.jmix.notifications.entity/InAppNotification.createdDate=Angelegt am
+io.jmix.notifications.entity/InAppNotification.createdBy=Angelegt von
+io.jmix.notifications.entity/InAppNotification.id=ID
+io.jmix.notifications.entity/InAppNotification.subject=Subjekt
+io.jmix.notifications.entity/InAppNotification.body=Nachricht
+io.jmix.notifications.entity/InAppNotification.recipient=Empfänger
+io.jmix.notifications.entity/InAppNotification.readStatus=Gelesen Status
+io.jmix.notifications.entity/InAppNotification.type=Typ
+io.jmix.notifications.entity/InAppNotification.contentType=Content Typ
+io.jmix.notifications/NotificationReadStatus.READ=Gelesen
+io.jmix.notifications/NotificationReadStatus.UNREAD=Ungelesen
+io.jmix.notifications/NotificationReadStatus=Benachrichtigungsstatus
+io.jmix.notifications.channel.impl/InAppNotificationChannel=In-App Kanal
+io.jmix.notifications.channel.impl/EmailNotificationChannel=Email Kanal
+
+

--- a/jmix-translations/content/io/jmix/notificationsui/messages_de.properties
+++ b/jmix-translations/content/io/jmix/notificationsui/messages_de.properties
@@ -1,0 +1,44 @@
+#
+# Copyright 2022 Haulmont.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+io.jmix.notifications.entity/ContentType=Content Typ
+
+io.jmix.notificationsui.screen/markAsRead=Als gelesen markieren
+io.jmix.notificationsui.screen/markAsUnread=Als ungelesen markieren
+io.jmix.notificationsui.screen/markAllAsRead=alle als gelesen markieren
+io.jmix.notificationsui.screen/inputUsername=Empfänger-Benutzernamen eingeben
+
+io.jmix.notificationsui.screen.createnotification/createNotificationScreen.caption=Benachrichtigung anlegen
+io.jmix.notificationsui.screen.createnotification/subject=Subjekt
+io.jmix.notificationsui.screen.createnotification/type=Typ
+io.jmix.notificationsui.screen.createnotification/recipients=Empfänger
+io.jmix.notificationsui.screen.createnotification/channels=Kanäle
+io.jmix.notificationsui.screen.createnotification/body=Nachricht
+io.jmix.notificationsui.screen.inappnotification/inAppNotificationBrowse.caption=Benachrichtigungen
+io.jmix.notificationsui.screen.inappnotification/inAppNotificationBrowse.menu=Benachrichtigungen
+io.jmix.notificationsui.screen.inappnotification/inAppNotificationEdit.caption=Benachrichtigung bearbeiten
+io.jmix.notificationsui.screen.inappnotification/inAppNotificationView.caption=Benachrichtigung ansehen
+io.jmix.notificationsui.screen.inappnotification/recipient=Empfänger
+io.jmix.notificationsui.screen.inappnotification/type=Typ
+io.jmix.notificationsui.screen.inappnotification/body=Nachricht
+io.jmix.notificationsui.screen.inappnotification/createNewNotification=Neue Benachrichtigung anlegen
+io.jmix.notificationsui.screen.inappnotification/ShowMode=Ansicht
+io.jmix.notificationsui.screen.inappnotification/ShowMode.ALL=Alle
+io.jmix.notificationsui.screen.inappnotification/ShowMode.NEW=Neu
+io.jmix.notificationsui.screen.inappnotification/userInAppNotificationScreen.caption=Benachrichtigungen
+io.jmix.notificationsui.screen.inappnotification/subject=Subjekt
+io.jmix.notificationsui.screen.inappnotification/date=Datum
+io.jmix.notificationsui.screen.inappnotification/noNotifications=Keine Benachrichtigungen


### PR DESCRIPTION
## Changes

* german translations for `graphql`, `notifications` and `business-calendar`