### PR TITLE
ControllerUtils - getLocationWithoutParams from encoded url fix... #1018

### DIFF
--- a/jmix-ui/ui/src/main/java/io/jmix/ui/sys/ControllerUtils.java
+++ b/jmix-ui/ui/src/main/java/io/jmix/ui/sys/ControllerUtils.java
@@ -49,7 +49,7 @@ public final class ControllerUtils {
             if (location.getQuery() != null) {
                 baseUrl.delete(baseUrl.indexOf("?" + location.getQuery()), baseUrl.length());
             } else if (location.getFragment() != null) {
-                baseUrl.delete(baseUrl.indexOf("#" + location.getFragment()), baseUrl.length());
+                baseUrl.delete(baseUrl.indexOf("#" + location.getRawFragment()), baseUrl.length());
             }
             String baseUrlString = baseUrl.toString();
             return baseUrlString.endsWith("/") ? baseUrlString : baseUrlString + "/";

--- a/jmix-ui/ui/src/test/groovy/util/ControllerUtilsTest.groovy
+++ b/jmix-ui/ui/src/test/groovy/util/ControllerUtilsTest.groovy
@@ -36,5 +36,10 @@ class ControllerUtilsTest extends Specification {
         URI debugUrl = new URI("http://localhost:8080/app/?debug#!")
         then:
         ControllerUtils.getLocationWithoutParams(debugUrl) == "http://localhost:8080/app/"
+
+        when:
+        URI encodedUrl = new URI("http://localhost:8080/#login?redirectTo=employees%2Fview")
+        then:
+        ControllerUtils.getLocationWithoutParams(encodedUrl) == "http://localhost:8080/"
     }
 }


### PR DESCRIPTION
Fixes issue:
https://github.com/jmix-framework/jmix/issues/1018

ControllerUtils - getLocationWithoutParams from encoded url was failing:

when:
URI encodedUrl = new URI("http://localhost:8080/#login?redirectTo=employees%2Fview")
then:
ControllerUtils.getLocationWithoutParams(encodedUrl) == "http://localhost:8080/"

Now all tests pass successfully...