### PR TITLE
fix #1422 - correct handling of URL encoded query parameters

### DIFF
--- a/jmix-ui/ui/src/main/java/io/jmix/ui/sys/ControllerUtils.java
+++ b/jmix-ui/ui/src/main/java/io/jmix/ui/sys/ControllerUtils.java
@@ -47,7 +47,7 @@ public final class ControllerUtils {
         try {
             StringBuilder baseUrl = new StringBuilder(location.toURL().toExternalForm());
             if (location.getQuery() != null) {
-                baseUrl.delete(baseUrl.indexOf("?" + location.getQuery()), baseUrl.length());
+                baseUrl.delete(baseUrl.indexOf("?" + location.getRawQuery()), baseUrl.length());
             } else if (location.getFragment() != null) {
                 baseUrl.delete(baseUrl.indexOf("#" + location.getRawFragment()), baseUrl.length());
             }

--- a/jmix-ui/ui/src/test/groovy/util/ControllerUtilsTest.groovy
+++ b/jmix-ui/ui/src/test/groovy/util/ControllerUtilsTest.groovy
@@ -41,5 +41,10 @@ class ControllerUtilsTest extends Specification {
         URI encodedUrl = new URI("http://localhost:8080/#login?redirectTo=employees%2Fview")
         then:
         ControllerUtils.getLocationWithoutParams(encodedUrl) == "http://localhost:8080/"
+
+        when:
+        URI encodedUrlFromOidcFlow = new URI("http://localhost:8080/?iss=https%3A%2F%2Ftenant.oidcprovider.com")
+        then:
+        ControllerUtils.getLocationWithoutParams(encodedUrlFromOidcFlow) == "http://localhost:8080/"
     }
 }


### PR DESCRIPTION
This PR fixes #1422.

### Changes
* `ControllerUtils::getLocationWithoutParams` now tries to remove the raw query string from the string instead of the URL decoded variant from `java.net.URI` (logic is now similar as for the fragment part removal)