### PR TITLE
Export All functionality in the Excel export action

### DIFF
--- a/jmix-translations/content/io/jmix/uiexport/messages.properties
+++ b/jmix-translations/content/io/jmix/uiexport/messages.properties
@@ -27,11 +27,13 @@ excelExporter.doubleFormat=#,##0.00##############
 
 jsonExporter.caption=JSON
 
-actions.exportSelectedTitle=Confirm export
-actions.exportSelectedCaption=Do you want to export only selected rows?
-actions.export.ALL_ROWS=All rows
-actions.export.SELECTED_ROWS=Selected rows
 actions.warningExport.title = Warning
 actions.warningExport.message = Exported table contains more than 65536 records. Because of XLS format limitation, \
   all records beyond 65536 will be ignored.
 
+io.jmix.uiexport.action/exportConfirmationDialog.caption=Confirmation
+io.jmix.uiexport.action/exportConfirmationDialog.message=Which rows would you like to export?
+
+io.jmix.uiexport.exporter/ExportMode.ALL_ROWS=All rows
+io.jmix.uiexport.exporter/ExportMode.CURRENT_PAGE=Current page
+io.jmix.uiexport.exporter/ExportMode.SELECTED_ROWS=Selected rows

--- a/jmix-translations/content/io/jmix/uiexport/messages_ru.properties
+++ b/jmix-translations/content/io/jmix/uiexport/messages_ru.properties
@@ -27,10 +27,13 @@ excelExporter.doubleFormat=#,##0.00##############
 
 jsonExporter.caption=JSON
 
-actions.exportSelectedTitle=Подтверждение
-actions.exportSelectedCaption=Экспортировать в Excel только выбранные строки?
-actions.export.ALL_ROWS=Все строки
-actions.export.SELECTED_ROWS=Выбранные строки
 actions.warningExport.title = Внимание
 actions.warningExport.message = Количество записей в экспортируемой таблице свыше 65536. Поскольку XLS не \
   поддерживает такое количество строк, все записи после 65536 строки проигнорированы.
+
+io.jmix.uiexport.action/exportConfirmationDialog.caption=Подтверждение
+io.jmix.uiexport.action/exportConfirmationDialog.message=Какие записи экспортировать?
+
+io.jmix.uiexport.exporter/ExportMode.ALL_ROWS=Все
+io.jmix.uiexport.exporter/ExportMode.CURRENT_PAGE=Текущая страница
+io.jmix.uiexport.exporter/ExportMode.SELECTED_ROWS=Выделенные

--- a/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/ExportActionProperties.java
+++ b/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/ExportActionProperties.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.uiexport;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * Export actions configuration interface
+ */
+@ConfigurationProperties(prefix = "jmix.ui.exportaction")
+@ConstructorBinding
+public class ExportActionProperties {
+
+    /**
+     * Loading batch size used when exporting all records.
+     */
+    int exportAllBatchSize;
+
+    /**
+     * Excel exporting configuration.
+     */
+    ExcelExporterProperties excel;
+
+    /**
+     * @see #exportAllBatchSize
+     */
+    public int getExportAllBatchSize() {
+        return exportAllBatchSize;
+    }
+
+
+    public ExportActionProperties(@DefaultValue("1000") int exportAllBatchSize,
+                                  @DefaultValue ExcelExporterProperties excel) {
+        this.exportAllBatchSize = exportAllBatchSize;
+        this.excel = excel;
+    }
+
+    public ExcelExporterProperties getExcel() {
+        return excel;
+    }
+
+    public static class ExcelExporterProperties {
+
+        /**
+         * Whether to use POI SXSSF API for building XLSX files.
+         */
+        boolean useSxssf;
+
+        public ExcelExporterProperties(@DefaultValue("true") boolean useSxssf) {
+            this.useSxssf = useSxssf;
+        }
+
+        /**
+         * @see #useSxssf
+         */
+        public boolean isUseSxssf() {
+            return useSxssf;
+        }
+    }
+}

--- a/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/UiExportConfiguration.java
+++ b/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/UiExportConfiguration.java
@@ -20,6 +20,7 @@ import io.jmix.core.annotation.JmixModule;
 import io.jmix.core.impl.scanning.AnnotationScanMetadataReaderFactory;
 import io.jmix.ui.UiConfiguration;
 import io.jmix.ui.sys.ActionsConfiguration;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -29,6 +30,7 @@ import java.util.Collections;
 
 @Configuration
 @ComponentScan
+@ConfigurationPropertiesScan
 @JmixModule(dependsOn = UiConfiguration.class)
 public class UiExportConfiguration {
 

--- a/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/action/ExcelExportAction.java
+++ b/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/action/ExcelExportAction.java
@@ -44,4 +44,9 @@ public class ExcelExportAction extends ExportAction {
     public String getIcon() {
         return icons.get(JmixIcon.EXCEL_ACTION);
     }
+
+    @Override
+    protected boolean isExportAllEnabled() {
+        return true;
+    }
 }

--- a/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/exporter/ExportMode.java
+++ b/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/exporter/ExportMode.java
@@ -18,7 +18,19 @@ package io.jmix.uiexport.exporter;
 
 public enum ExportMode {
 
-    ALL,
-    SELECTED
+    /**
+     * Export all records in the database
+     */
+    ALL_ROWS,
+
+    /**
+     * Export only records loaded to the current page of a table or a data grid
+     */
+    CURRENT_PAGE,
+
+    /**
+     * Export only records selected in a table or a data grid
+     */
+    SELECTED_ROWS
 
 }

--- a/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/exporter/excel/AllRecordsExporter.java
+++ b/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/exporter/excel/AllRecordsExporter.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2022 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.uiexport.exporter.excel;
+
+import io.jmix.core.*;
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.querycondition.Condition;
+import io.jmix.core.querycondition.LogicalCondition;
+import io.jmix.core.querycondition.PropertyCondition;
+import io.jmix.ui.component.data.DataUnit;
+import io.jmix.ui.component.data.meta.ContainerDataUnit;
+import io.jmix.ui.model.CollectionContainer;
+import io.jmix.ui.model.CollectionLoader;
+import io.jmix.ui.model.DataLoader;
+import io.jmix.ui.model.HasLoader;
+import io.jmix.uiexport.ExportActionProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Class is used by {@link io.jmix.uiexport.action.ExportAction} for exporting all records from the database.
+ */
+@Component("ui_AllRecordsExporter")
+public class AllRecordsExporter {
+
+    private MetadataTools metadataTools;
+
+    private DataManager dataManager;
+
+    private PlatformTransactionManager platformTransactionManager;
+
+    private ExportActionProperties exportActionProperties;
+
+    public AllRecordsExporter(MetadataTools metadataTools,
+                              DataManager dataManager,
+                              PlatformTransactionManager platformTransactionManager,
+                              ExportActionProperties exportActionProperties) {
+        this.metadataTools = metadataTools;
+        this.dataManager = dataManager;
+        this.platformTransactionManager = platformTransactionManager;
+        this.exportActionProperties = exportActionProperties;
+    }
+
+    /**
+     * Method loads all entity instances associated with the given {@code dataUnit} and applies the
+     * {@code excelRowCreator} function to each loaded entity instance. Creation of the output file row is the
+     * responsibility of the function. Data is loaded in batches, the batch size is configured by the
+     * {@link ExportActionProperties#getExportAllBatchSize()}.
+     *
+     * @param dataUnit        data unit linked with the data
+     * @param excelRowCreator function that is being applied to each loaded instance
+     */
+    protected void exportAll(DataUnit dataUnit, Consumer<RowCreationContext> excelRowCreator) {
+        if (!(dataUnit instanceof ContainerDataUnit)) {
+            throw new RuntimeException("Cannot export all rows. DataUnit must be an instance of ContainerDataUnit.");
+        }
+        CollectionContainer collectionContainer = ((ContainerDataUnit) dataUnit).getContainer();
+        if (!(collectionContainer instanceof HasLoader)) {
+            throw new RuntimeException("Cannot export all rows. Collection container must be an instance of HasLoader.");
+        }
+
+        DataLoader dataLoader = ((HasLoader) collectionContainer).getLoader();
+        if (!(dataLoader instanceof CollectionLoader)) {
+            throw new RuntimeException("Cannot export all rows. Data loader must be an instance of CollectionLoader.");
+        }
+
+        LoadContext loadContext = ((CollectionLoader) dataLoader).createLoadContext();
+        LoadContext.Query query = loadContext.getQuery();
+        if (query == null) {
+            throw new RuntimeException("Cannot export all rows. Query in LoadContext is null.");
+        }
+
+        MetaClass entityMetaClass = loadContext.getEntityMetaClass();
+        if (metadataTools.hasCompositePrimaryKey(entityMetaClass)) {
+            throw new RuntimeException("Cannot export all rows. Exporting of entities with composite key is not supported.");
+        }
+
+        //sort data by primary key. Next batch is loaded using the condition that compares the last primary key value
+        //from the previous batch.
+        String primaryKeyName = metadataTools.getPrimaryKeyName(entityMetaClass);
+        if (primaryKeyName == null) {
+            throw new RuntimeException("Cannot find a primary key for a meta class " + entityMetaClass.getName());
+        }
+        query.setSort(Sort.by(primaryKeyName));
+
+        Condition condition = loadContext.getQuery().getCondition();
+
+        String lastLoadedPkConditionParameterName = "lastLoadedPkValue";
+        if (condition instanceof LogicalCondition) {
+            PropertyCondition lastPkCondition = PropertyCondition.createWithParameterName(primaryKeyName, PropertyCondition.Operation.GREATER, lastLoadedPkConditionParameterName);
+            ((LogicalCondition) condition).add(lastPkCondition);
+        } else {
+            throw new RuntimeException("Cannot add a primary key condition to a query");
+        }
+
+        int loadBatchSize = exportActionProperties.getExportAllBatchSize();
+        TransactionTemplate transactionTemplate = new TransactionTemplate(platformTransactionManager);
+        transactionTemplate.executeWithoutResult(transactionStatus -> {
+            long count = dataManager.getCount(loadContext);
+            int rowNumber = 0;
+            boolean initialLoading = true;
+            Object lastLoadedPkValue = null;
+            for (int firstResult = 0; firstResult < count; firstResult += loadBatchSize) {
+                if (initialLoading) {
+                    initialLoading = false;
+                } else {
+                    query.setParameter(lastLoadedPkConditionParameterName, lastLoadedPkValue);
+                }
+                query.setMaxResults(loadBatchSize);
+
+                List entities = dataManager.loadList(loadContext);
+                for (Object entity : entities) {
+                    excelRowCreator.accept(new RowCreationContext(entity, ++rowNumber));
+                }
+                Object lastEntity = entities.get(entities.size() - 1);
+                lastLoadedPkValue = Id.of(lastEntity).getValue();
+            }
+        });
+    }
+
+    public static class RowCreationContext {
+        protected Object entity;
+        protected int rowNumber;
+
+        public RowCreationContext(Object entity, int rowNumber) {
+            this.entity = entity;
+            this.rowNumber = rowNumber;
+        }
+
+        public Object getEntity() {
+            return entity;
+        }
+
+        public int getRowNumber() {
+            return rowNumber;
+        }
+    }
+}

--- a/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/exporter/json/JsonExporter.java
+++ b/jmix-ui/ui-export/src/main/java/io/jmix/uiexport/exporter/json/JsonExporter.java
@@ -17,7 +17,6 @@
 package io.jmix.uiexport.exporter.json;
 
 import com.google.gson.*;
-import io.jmix.core.Messages;
 import io.jmix.core.Metadata;
 import io.jmix.core.metamodel.model.MetaPropertyPath;
 import io.jmix.ui.component.DataGrid;
@@ -128,11 +127,11 @@ public class JsonExporter extends AbstractTableExporter<JsonExporter> {
     }
 
     protected Collection<Object> getItems(Table<Object> table, ExportMode exportMode) {
-        return ExportMode.ALL == exportMode ? table.getItems().getItems() : table.getSelected();
+        return ExportMode.ALL_ROWS == exportMode ? table.getItems().getItems() : table.getSelected();
     }
 
     protected Collection<Object> getItems(DataGrid<Object> dataGrid, ExportMode exportMode) {
-        return ExportMode.ALL == exportMode ? dataGrid.getItems().getItems().collect(Collectors.toList()) : dataGrid.getSelected();
+        return ExportMode.ALL_ROWS == exportMode ? dataGrid.getItems().getItems().collect(Collectors.toList()) : dataGrid.getSelected();
     }
 
     @Override

--- a/jmix-ui/ui-export/src/main/resources/io/jmix/uiexport/messages.properties
+++ b/jmix-ui/ui-export/src/main/resources/io/jmix/uiexport/messages.properties
@@ -27,11 +27,13 @@ excelExporter.doubleFormat=#,##0.00##############
 
 jsonExporter.caption=JSON
 
-actions.exportSelectedTitle=Confirm export
-actions.exportSelectedCaption=Do you want to export only selected rows?
-actions.export.ALL_ROWS=All rows
-actions.export.SELECTED_ROWS=Selected rows
 actions.warningExport.title = Warning
 actions.warningExport.message = Exported table contains more than 65536 records. Because of XLS format limitation, \
   all records beyond 65536 will be ignored.
 
+io.jmix.uiexport.action/exportConfirmationDialog.caption=Confirmation
+io.jmix.uiexport.action/exportConfirmationDialog.message=Which rows would you like to export?
+
+io.jmix.uiexport.exporter/ExportMode.ALL_ROWS=All rows
+io.jmix.uiexport.exporter/ExportMode.CURRENT_PAGE=Current page
+io.jmix.uiexport.exporter/ExportMode.SELECTED_ROWS=Selected rows


### PR DESCRIPTION
A new exporting option has been added to the Excel Export action: "All rows". It exports all records from the database taking into account applied filter and initial data loader query from the screen.

Loading is performed using batches. The batch size may be configured using the following application property:

```
jmix.ui.exportaction.export-all-batch-size=2000
```

The default batch size is 1000.

Excel file now can be constructed using streaming POI API (SXSSF). It is turned on by default. To turn it off use the property:

```
jmix.ui.exportaction.excel.use-sxssf=false
```

Limitations:

* When a TreeTable or TreeDataGrid is exported no padding will be added to the column with hierarchy property.
* When a group table is exported, no grouping will be added to the excel file.
* Exporting of entities with composite primary key is not supported