### PR TITLE
Default test in add-on fails because of invalid Liquibase configuration 1533

### DIFF
--- a/jmix-templates/content/project/addon-kotlin/${module_name}/src/test/kotlin/${project_rootPath}/${project_id.capitalize()}TestConfiguration.kt
+++ b/jmix-templates/content/project/addon-kotlin/${module_name}/src/test/kotlin/${project_rootPath}/${project_id.capitalize()}TestConfiguration.kt
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.PropertySource
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType
 
@@ -14,12 +15,13 @@ import javax.sql.DataSource
 @SpringBootConfiguration
 @EnableAutoConfiguration
 @Import(${project_id.capitalize()}Configuration::class)
+@PropertySource("classpath:/${project_rootPath}/test-app.properties")
 @JmixModule(id = "${project_rootPackage}.test", dependsOn = [${project_id.capitalize()}Configuration::class])
-class ${project_id.capitalize()}TestConfiguration {
+open class ${project_id.capitalize()}TestConfiguration {
 
     @Bean
     @Primary
-    fun dataSource(): DataSource {
+    open fun dataSource(): DataSource {
         return EmbeddedDatabaseBuilder()
             .generateUniqueName(true)
             .setType(EmbeddedDatabaseType.HSQL)

--- a/jmix-templates/content/project/addon-kotlin/${module_name}/src/test/resources/${project_rootPath}/test-app.properties
+++ b/jmix-templates/content/project/addon-kotlin/${module_name}/src/test/resources/${project_rootPath}/test-app.properties
@@ -1,0 +1,1 @@
+main.liquibase.change-log=${project_rootPath}/liquibase/changelog.xml

--- a/jmix-templates/content/project/addon/${module_name}/src/test/java/${project_rootPath}/${project_id.capitalize()}TestConfiguration.java
+++ b/jmix-templates/content/project/addon/${module_name}/src/test/java/${project_rootPath}/${project_id.capitalize()}TestConfiguration.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.PropertySource;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
@@ -14,6 +15,7 @@ import javax.sql.DataSource;
 @SpringBootConfiguration
 @EnableAutoConfiguration
 @Import(${project_id.capitalize()}Configuration.class)
+@PropertySource("classpath:/${project_rootPath}/test-app.properties")
 @JmixModule(id = "${project_rootPackage}.test", dependsOn = ${project_id.capitalize()}Configuration.class)
 public class ${project_id.capitalize()}TestConfiguration {
 

--- a/jmix-templates/content/project/addon/${module_name}/src/test/resources/${project_rootPath}/test-app.properties
+++ b/jmix-templates/content/project/addon/${module_name}/src/test/resources/${project_rootPath}/test-app.properties
@@ -1,0 +1,1 @@
+main.liquibase.change-log=${project_rootPath}/liquibase/changelog.xml


### PR DESCRIPTION
The `test-app.properties` file with Liquibase config has been added to add-on templates for Java and Kotlin.