### PR TITLE
DataManager.getReference() increments underlying sequence #1451

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/Metadata.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/Metadata.java
@@ -46,6 +46,14 @@ public interface Metadata extends Session {
     <T> T create(Class<T> entityClass);
 
     /**
+     * Instantiate an entity with provided id, taking into account extended entities.
+     * @param entityClass   entity class
+     * @param id            entity id
+     * @return              entity instance
+     */
+    <T> T create(Class<T> entityClass, Object id);
+
+    /**
      * Instantiate an entity, taking into account extended entities.
      * @param metaClass     entity MetaClass
      * @return              entity instance
@@ -53,9 +61,25 @@ public interface Metadata extends Session {
     Object create(MetaClass metaClass);
 
     /**
+     * Instantiate an entity with provided id, taking into account extended entities.
+     * @param metaClass     entity MetaClass
+     * @param id            entity id
+     * @return              entity instance
+     */
+    Object create(MetaClass metaClass, Object id);
+
+    /**
      * Instantiate an entity, taking into account extended entities.
      * @param entityName    entity name
      * @return              entity instance
      */
     Object create(String entityName);
+
+    /**
+     * Instantiate an entity with provided id, taking into account extended entities.
+     * @param entityName    entity name
+     * @param id            entity id
+     * @return              entity instance
+     */
+    Object create(String entityName, Object id);
 }

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/EmbeddedIdEntityInitializer.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/EmbeddedIdEntityInitializer.java
@@ -36,7 +36,9 @@ public class EmbeddedIdEntityInitializer implements EntityInitializer, Ordered {
     public void initEntity(Object entity) {
         MetaClass metaClass = metadata.getClass(entity);
         MetaProperty primaryKeyProperty = metadataTools.getPrimaryKeyProperty(metaClass);
-        if (primaryKeyProperty != null && metadataTools.isEmbedded(primaryKeyProperty)) {
+        if (primaryKeyProperty != null
+                && metadataTools.isEmbedded(primaryKeyProperty)
+                && EntityValues.getValue(entity, primaryKeyProperty.getName()) == null) {
             // create an instance of embedded ID
             Object key = metadata.create(primaryKeyProperty.getRange().asClass());
             EntityValues.setId(entity, key);

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/MetadataImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/MetadataImpl.java
@@ -18,6 +18,7 @@ package io.jmix.core.impl;
 
 import io.jmix.core.*;
 import io.jmix.core.common.util.Preconditions;
+import io.jmix.core.entity.EntityValues;
 import io.jmix.core.entity.HasInstanceMetaClass;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.Session;
@@ -63,9 +64,14 @@ public class MetadataImpl implements Metadata {
     }
 
     protected <T> T internalCreate(Class<T> entityClass) {
+        return internalCreate(entityClass, null);
+    }
+
+    protected <T> T internalCreate(Class<T> entityClass, @Nullable Object id) {
         Class<T> extClass = getSession().getClass(entityClass).getJavaClass();
         try {
             T obj = extClass.getDeclaredConstructor().newInstance();
+            EntityValues.setId(obj, id);
 
             if (entityInitializers != null) {
                 for (EntityInitializer initializer : entityInitializers) {
@@ -74,7 +80,8 @@ public class MetadataImpl implements Metadata {
             }
 
             return obj;
-        } catch (InstantiationException | InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+        } catch (InstantiationException | InvocationTargetException
+                 | IllegalAccessException | NoSuchMethodException e) {
             throw new RuntimeException("Unable to create entity instance", e);
         }
     }
@@ -85,14 +92,30 @@ public class MetadataImpl implements Metadata {
     }
 
     @Override
+    public <T> T create(Class<T> entityClass, Object id) {
+        return internalCreate(entityClass, id);
+    }
+
+    @Override
     public Object create(MetaClass metaClass) {
         return internalCreate(metaClass.getJavaClass());
+    }
+
+    @Override
+    public Object create(MetaClass metaClass, Object id) {
+        return internalCreate(metaClass.getJavaClass(), id);
     }
 
     @Override
     public Object create(String entityName) {
         MetaClass metaClass = getSession().getClass(entityName);
         return internalCreate(metaClass.getJavaClass());
+    }
+
+    @Override
+    public Object create(String entityName, Object id) {
+        MetaClass metaClass = getSession().getClass(entityName);
+        return internalCreate(metaClass.getJavaClass(), id);
     }
 
     @Nullable

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/UnconstrainedDataManagerImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/UnconstrainedDataManagerImpl.java
@@ -318,8 +318,7 @@ public class UnconstrainedDataManagerImpl implements UnconstrainedDataManager {
 
     @Override
     public <T> T getReference(Class<T> entityClass, Object id) {
-        T entity = metadata.create(entityClass);
-        EntityValues.setId(entity, id);
+        T entity = metadata.create(entityClass, id);
         entityStates.makePatch(entity);
         return entity;
     }


### PR DESCRIPTION
https://github.com/jmix-framework/jmix/issues/1451

- Override 'create' methods with externally provided entity id.
- Set provided id before apply entity initializers.
- Update `EmbeddedIdEntityInitializer`: create new embedded id instance only if id is not set.