### PR TITLE
Rename QueryParametersFacet to UrlQueryParametersFacet

### DIFF
--- a/jmix-audit/audit-flowui/src/main/resources/io/jmix/auditflowui/view/entitylog/entity-log-view.xml
+++ b/jmix-audit/audit-flowui/src/main/resources/io/jmix/auditflowui/view/entitylog/entity-log-view.xml
@@ -84,10 +84,10 @@
     </data>
     <facets>
         <dataLoadCoordinator auto="true"/>
-        <queryParameters>
+        <urlQueryParameters>
             <pagination component="paginationEntityLog"/>
             <pagination component="paginationLoggedEntity"/>
-        </queryParameters>
+        </urlQueryParameters>
     </facets>
     <layout>
         <tabs id="tabsheet" width="100%">

--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/facet/StudioFacets.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/facet/StudioFacets.java
@@ -43,10 +43,10 @@ public interface StudioFacets {
     void dataLoadCoordinator();
 
     @StudioFacet(
-            name = "QueryParameters",
-            classFqn = "io.jmix.flowui.facet.QueryParametersFacet",
+            name = "UrlQueryParameters",
+            classFqn = "io.jmix.flowui.facet.UrlQueryParametersFacet",
             category = "Facets",
-            xmlElement = "queryParameters",
+            xmlElement = "urlQueryParameters",
             icon = "io/jmix/flowui/kit/meta/icon/unknownComponent.svg",
             properties = {
                     @StudioProperty(xmlAttribute = "id", type = StudioPropertyType.COMPONENT_ID),

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/main/JmixListMenu.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/main/JmixListMenu.java
@@ -80,7 +80,7 @@ public class JmixListMenu extends ListMenu implements ApplicationContextAware, I
     protected RouterLink createMenuItemComponent(MenuItem menuItem) {
         RouterLink menuItemComponent = super.createMenuItemComponent(menuItem);
         if (menuItem instanceof ViewMenuItem) {
-            QueryParameters queryParameters = ((ViewMenuItem) menuItem).getQueryParameters();
+            QueryParameters queryParameters = ((ViewMenuItem) menuItem).getUrlQueryParameters();
             RouteParameters routeParameters = ((ViewMenuItem) menuItem).getRouteParameters();
 
             if (queryParameters != null) {
@@ -127,7 +127,7 @@ public class JmixListMenu extends ListMenu implements ApplicationContextAware, I
     public static class ViewMenuItem extends MenuItem {
 
         protected Class<? extends View<?>> controllerClass;
-        protected QueryParameters queryParameters;
+        protected QueryParameters urlQueryParameters;
         protected RouteParameters routeParameters;
 
         public ViewMenuItem(String id) {
@@ -178,15 +178,15 @@ public class JmixListMenu extends ListMenu implements ApplicationContextAware, I
         }
 
         @Nullable
-        public QueryParameters getQueryParameters() {
-            return queryParameters;
+        public QueryParameters getUrlQueryParameters() {
+            return urlQueryParameters;
         }
 
-        public ViewMenuItem withQueryParameters(List<MenuItemParameter> queryParameters) {
+        public ViewMenuItem withUrlQueryParameters(List<MenuItemParameter> queryParameters) {
             Map<String, String> parametersMap = queryParameters.stream()
                     .collect(Collectors.toMap(MenuItemParameter::getName, MenuItemParameter::getValue));
 
-            this.queryParameters = QueryParameters.simple(parametersMap);
+            this.urlQueryParameters = QueryParameters.simple(parametersMap);
             return this;
         }
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/UrlQueryParametersFacet.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/UrlQueryParametersFacet.java
@@ -25,9 +25,9 @@ import java.util.EventObject;
 import java.util.List;
 import java.util.function.Consumer;
 
-public interface QueryParametersFacet extends Facet, HasSubParts {
+public interface UrlQueryParametersFacet extends Facet, HasSubParts {
 
-    String NAME = "queryParameters";
+    String NAME = "urlQueryParameters";
 
     /**
      * Register a new query parameters binder.
@@ -67,12 +67,12 @@ public interface QueryParametersFacet extends Facet, HasSubParts {
         void updateState(QueryParameters queryParameters);
 
         /**
-         * Adds {@link QueryParametersChangeEvent} listener.
+         * Adds {@link UrlQueryParametersChangeEvent} listener.
          *
          * @param listener the listener to add, not {@code null}
          * @return a registration object that can be used for removing the listener.
          */
-        Registration addQueryParametersChangeListener(Consumer<QueryParametersChangeEvent> listener);
+        Registration addUrlQueryParametersChangeListener(Consumer<UrlQueryParametersChangeEvent> listener);
     }
 
     /**
@@ -80,11 +80,11 @@ public interface QueryParametersFacet extends Facet, HasSubParts {
      * its internal state has been changed and it should be reflected on
      * URL's query parameters.
      */
-    class QueryParametersChangeEvent extends EventObject {
+    class UrlQueryParametersChangeEvent extends EventObject {
 
         protected QueryParameters queryParameters;
 
-        public QueryParametersChangeEvent(Binder source, QueryParameters queryParameters) {
+        public UrlQueryParametersChangeEvent(Binder source, QueryParameters queryParameters) {
             super(source);
             this.queryParameters = queryParameters;
         }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/impl/UrlQueryParametersFacetImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/impl/UrlQueryParametersFacetImpl.java
@@ -20,7 +20,7 @@ import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.shared.Registration;
 import io.jmix.core.common.util.Preconditions;
 import io.jmix.flowui.component.UiComponentUtils;
-import io.jmix.flowui.facet.QueryParametersFacet;
+import io.jmix.flowui.facet.UrlQueryParametersFacet;
 import io.jmix.flowui.view.View;
 import io.jmix.flowui.view.ViewControllerUtils;
 import io.jmix.flowui.view.navigation.RouteSupport;
@@ -31,14 +31,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public class QueryParametersFacetImpl extends AbstractFacet implements QueryParametersFacet {
+public class UrlQueryParametersFacetImpl extends AbstractFacet implements UrlQueryParametersFacet {
 
     protected RouteSupport routeSupport;
 
     protected List<Binder> binders = new ArrayList<>();
     protected Registration queryParametersChangeRegistration;
 
-    public QueryParametersFacetImpl(RouteSupport routeSupport) {
+    public UrlQueryParametersFacetImpl(RouteSupport routeSupport) {
         this.routeSupport = routeSupport;
     }
 
@@ -71,11 +71,11 @@ public class QueryParametersFacetImpl extends AbstractFacet implements QueryPara
     public void registerBinder(Binder binder) {
         Preconditions.checkNotNullArgument(binder);
 
-        binder.addQueryParametersChangeListener(this::onComponentQueryParametersChanged);
+        binder.addUrlQueryParametersChangeListener(this::onComponentQueryParametersChanged);
         binders.add(binder);
     }
 
-    protected void onComponentQueryParametersChanged(QueryParametersChangeEvent event) {
+    protected void onComponentQueryParametersChanged(UrlQueryParametersChangeEvent event) {
         if (owner == null || UiComponentUtils.isComponentAttachedToDialog(owner)) {
             return;
         }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/AbstractUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/AbstractUrlQueryParametersBinder.java
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-package io.jmix.flowui.facet.queryparameters;
+package io.jmix.flowui.facet.urlqueryparameters;
 
 import com.vaadin.flow.shared.Registration;
-import io.jmix.flowui.facet.QueryParametersFacet;
-import io.jmix.flowui.facet.QueryParametersFacet.QueryParametersChangeEvent;
+import io.jmix.flowui.facet.UrlQueryParametersFacet;
+import io.jmix.flowui.facet.UrlQueryParametersFacet.UrlQueryParametersChangeEvent;
 import io.jmix.flowui.kit.event.EventBus;
 
 import jakarta.annotation.Nullable;
 import java.util.function.Consumer;
 
-public abstract class AbstractQueryParametersBinder implements QueryParametersFacet.Binder {
+public abstract class AbstractUrlQueryParametersBinder implements UrlQueryParametersFacet.Binder {
 
     protected String id;
 
@@ -42,11 +42,11 @@ public abstract class AbstractQueryParametersBinder implements QueryParametersFa
     }
 
     @Override
-    public Registration addQueryParametersChangeListener(Consumer<QueryParametersChangeEvent> listener) {
-        return getEventBus().addListener(QueryParametersChangeEvent.class, listener);
+    public Registration addUrlQueryParametersChangeListener(Consumer<UrlQueryParametersChangeEvent> listener) {
+        return getEventBus().addListener(UrlQueryParametersChangeEvent.class, listener);
     }
 
-    protected void fireQueryParametersChanged(QueryParametersChangeEvent event) {
+    protected void fireQueryParametersChanged(UrlQueryParametersChangeEvent event) {
         getEventBus().fireEvent(event);
     }
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/FilterUrlQueryParametersSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/FilterUrlQueryParametersSupport.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.jmix.flowui.facet.queryparameters;
+package io.jmix.flowui.facet.urlqueryparameters;
 
 import io.jmix.core.DataManager;
 import io.jmix.core.Id;
@@ -31,8 +31,8 @@ import org.springframework.stereotype.Component;
 import jakarta.annotation.Nullable;
 import java.util.Objects;
 
-@Component("flowui_FilterQueryParametersSupport")
-public class FilterQueryParametersSupport {
+@Component("flowui_FilterUrlQueryParametersSupport")
+public class FilterUrlQueryParametersSupport {
 
     public static final String SEPARATOR = "_";
 
@@ -40,9 +40,9 @@ public class FilterQueryParametersSupport {
     protected MetadataTools metadataTools;
     protected UrlParamSerializer urlParamSerializer;
 
-    public FilterQueryParametersSupport(DataManager dataManager,
-                                        MetadataTools metadataTools,
-                                        UrlParamSerializer urlParamSerializer) {
+    public FilterUrlQueryParametersSupport(DataManager dataManager,
+                                           MetadataTools metadataTools,
+                                           UrlParamSerializer urlParamSerializer) {
         this.dataManager = dataManager;
         this.metadataTools = metadataTools;
         this.urlParamSerializer = urlParamSerializer;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.jmix.flowui.facet.queryparameters;
+package io.jmix.flowui.facet.urlqueryparameters;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -35,7 +35,7 @@ import io.jmix.flowui.component.logicalfilter.LogicalFilterComponent;
 import io.jmix.flowui.component.logicalfilter.LogicalFilterComponent.FilterComponentsChangeEvent;
 import io.jmix.flowui.component.propertyfilter.PropertyFilter;
 import io.jmix.flowui.component.propertyfilter.SingleFilterSupport;
-import io.jmix.flowui.facet.QueryParametersFacet.QueryParametersChangeEvent;
+import io.jmix.flowui.facet.UrlQueryParametersFacet.UrlQueryParametersChangeEvent;
 import io.jmix.flowui.model.CollectionLoader;
 import io.jmix.flowui.model.DataLoader;
 import io.jmix.flowui.model.KeyValueCollectionLoader;
@@ -48,10 +48,10 @@ import java.util.EventObject;
 import java.util.List;
 import java.util.Map;
 
-import static io.jmix.flowui.facet.queryparameters.FilterQueryParametersSupport.SEPARATOR;
+import static io.jmix.flowui.facet.urlqueryparameters.FilterUrlQueryParametersSupport.SEPARATOR;
 import static java.util.Objects.requireNonNull;
 
-public class GenericFilterQueryParametersBinder extends AbstractQueryParametersBinder {
+public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParametersBinder {
 
     public static final String NAME = "genericFilter";
 
@@ -66,11 +66,11 @@ public class GenericFilterQueryParametersBinder extends AbstractQueryParametersB
     protected UrlParamSerializer urlParamSerializer;
     protected UiComponents uiComponents;
     protected SingleFilterSupport singleFilterSupport;
-    protected FilterQueryParametersSupport filterQueryParametersSupport;
+    protected FilterUrlQueryParametersSupport filterUrlQueryParametersSupport;
 
-    public GenericFilterQueryParametersBinder(GenericFilter filter,
-                                              UrlParamSerializer urlParamSerializer,
-                                              ApplicationContext applicationContext) {
+    public GenericFilterUrlQueryParametersBinder(GenericFilter filter,
+                                                 UrlParamSerializer urlParamSerializer,
+                                                 ApplicationContext applicationContext) {
         this.filter = filter;
         this.urlParamSerializer = urlParamSerializer;
         this.applicationContext = applicationContext;
@@ -81,7 +81,7 @@ public class GenericFilterQueryParametersBinder extends AbstractQueryParametersB
 
     protected void autowireDependencies() {
         uiComponents = applicationContext.getBean(UiComponents.class);
-        filterQueryParametersSupport = applicationContext.getBean(FilterQueryParametersSupport.class);
+        filterUrlQueryParametersSupport = applicationContext.getBean(FilterUrlQueryParametersSupport.class);
     }
 
     protected Registration filterComponentsChangeRegistration;
@@ -130,16 +130,16 @@ public class GenericFilterQueryParametersBinder extends AbstractQueryParametersB
 
         QueryParameters queryParameters =
                 new QueryParameters(ImmutableMap.of(getConditionParam(), params));
-        fireQueryParametersChanged(new QueryParametersChangeEvent(this, queryParameters));
+        fireQueryParametersChanged(new UrlQueryParametersChangeEvent(this, queryParameters));
     }
 
     protected String serializePropertyCondition(PropertyCondition condition) {
         String property = urlParamSerializer.serialize(
-                filterQueryParametersSupport.replaceSeparatorValue(condition.getProperty()));
+                filterUrlQueryParametersSupport.replaceSeparatorValue(condition.getProperty()));
         String operation = urlParamSerializer.serialize(
-                filterQueryParametersSupport.replaceSeparatorValue(condition.getOperation()));
+                filterUrlQueryParametersSupport.replaceSeparatorValue(condition.getOperation()));
         Object parameterValue = urlParamSerializer.serialize(
-                filterQueryParametersSupport.getSerializableValue(condition.getParameterValue()));
+                filterUrlQueryParametersSupport.getSerializableValue(condition.getParameterValue()));
 
         return PROPERTY_CONDITION_PREFIX +
                 property + SEPARATOR +
@@ -194,7 +194,7 @@ public class GenericFilterQueryParametersBinder extends AbstractQueryParametersB
 
         String propertyString = conditionString.substring(0, separatorIndex);
         String property = urlParamSerializer.deserialize(String.class,
-                filterQueryParametersSupport.restoreSeparatorValue(propertyString));
+                filterUrlQueryParametersSupport.restoreSeparatorValue(propertyString));
 
         conditionString = conditionString.substring(separatorIndex + 1);
         separatorIndex = conditionString.indexOf(SEPARATOR);
@@ -205,7 +205,7 @@ public class GenericFilterQueryParametersBinder extends AbstractQueryParametersB
         String operationString = conditionString.substring(0, separatorIndex);
         PropertyFilter.Operation operation = urlParamSerializer
                 .deserialize(PropertyFilter.Operation.class,
-                        filterQueryParametersSupport.restoreSeparatorValue(operationString));
+                        filterUrlQueryParametersSupport.restoreSeparatorValue(operationString));
 
         PropertyFilter propertyFilter = uiComponents.create(PropertyFilter.class);
         propertyFilter.setProperty(property);
@@ -220,7 +220,7 @@ public class GenericFilterQueryParametersBinder extends AbstractQueryParametersB
 
         String valueString = conditionString.substring(separatorIndex + 1);
         if (!Strings.isNullOrEmpty(valueString)) {
-            Object parsedValue = filterQueryParametersSupport
+            Object parsedValue = filterUrlQueryParametersSupport
                     .parseValue(dataLoader.getContainer().getEntityMetaClass(),
                             property, operation.getType(), valueString);
             propertyFilter.setValue(parsedValue);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/PaginationUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/PaginationUrlQueryParametersBinder.java
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-package io.jmix.flowui.facet.queryparameters;
+package io.jmix.flowui.facet.urlqueryparameters;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.vaadin.flow.router.QueryParameters;
 import io.jmix.flowui.component.PaginationComponent;
 import io.jmix.flowui.data.pagination.PaginationDataLoader;
-import io.jmix.flowui.facet.QueryParametersFacet.QueryParametersChangeEvent;
+import io.jmix.flowui.facet.UrlQueryParametersFacet.UrlQueryParametersChangeEvent;
 import io.jmix.flowui.view.navigation.UrlParamSerializer;
 
 import jakarta.annotation.Nullable;
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-public class PaginationQueryParametersBinder extends AbstractQueryParametersBinder {
+public class PaginationUrlQueryParametersBinder extends AbstractUrlQueryParametersBinder {
 
     public static final String NAME = "pagination";
 
@@ -43,8 +43,8 @@ public class PaginationQueryParametersBinder extends AbstractQueryParametersBind
 
     protected UrlParamSerializer urlParamSerializer;
 
-    public PaginationQueryParametersBinder(PaginationComponent<?> pagination,
-                                           UrlParamSerializer urlParamSerializer) {
+    public PaginationUrlQueryParametersBinder(PaginationComponent<?> pagination,
+                                              UrlParamSerializer urlParamSerializer) {
         this.pagination = pagination;
         this.urlParamSerializer = urlParamSerializer;
 
@@ -62,7 +62,7 @@ public class PaginationQueryParametersBinder extends AbstractQueryParametersBind
                     getMaxResultsParam(), urlParamSerializer.serialize(paginationLoader.getMaxResults())
             ));
 
-            fireQueryParametersChanged(new QueryParametersChangeEvent(this, queryParameters));
+            fireQueryParametersChanged(new UrlQueryParametersChangeEvent(this, queryParameters));
         });
     }
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/PropertyFilterUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/PropertyFilterUrlQueryParametersBinder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.jmix.flowui.facet.queryparameters;
+package io.jmix.flowui.facet.urlqueryparameters;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
@@ -23,7 +23,7 @@ import com.vaadin.flow.router.QueryParameters;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.flowui.component.propertyfilter.PropertyFilter;
 import io.jmix.flowui.component.propertyfilter.PropertyFilter.Operation;
-import io.jmix.flowui.facet.QueryParametersFacet.QueryParametersChangeEvent;
+import io.jmix.flowui.facet.UrlQueryParametersFacet.UrlQueryParametersChangeEvent;
 import io.jmix.flowui.view.navigation.UrlParamSerializer;
 import org.springframework.context.ApplicationContext;
 
@@ -32,9 +32,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
-import static io.jmix.flowui.facet.queryparameters.FilterQueryParametersSupport.SEPARATOR;
+import static io.jmix.flowui.facet.urlqueryparameters.FilterUrlQueryParametersSupport.SEPARATOR;
 
-public class PropertyFilterQueryParametersBinder extends AbstractQueryParametersBinder {
+public class PropertyFilterUrlQueryParametersBinder extends AbstractUrlQueryParametersBinder {
 
     public static final String NAME = "propertyFilter";
 
@@ -44,11 +44,11 @@ public class PropertyFilterQueryParametersBinder extends AbstractQueryParameters
 
     protected ApplicationContext applicationContext;
     protected UrlParamSerializer urlParamSerializer;
-    protected FilterQueryParametersSupport filterQueryParametersSupport;
+    protected FilterUrlQueryParametersSupport filterUrlQueryParametersSupport;
 
-    public PropertyFilterQueryParametersBinder(PropertyFilter<?> filter,
-                                               UrlParamSerializer urlParamSerializer,
-                                               ApplicationContext applicationContext) {
+    public PropertyFilterUrlQueryParametersBinder(PropertyFilter<?> filter,
+                                                  UrlParamSerializer urlParamSerializer,
+                                                  ApplicationContext applicationContext) {
         this.filter = filter;
         this.urlParamSerializer = urlParamSerializer;
         this.applicationContext = applicationContext;
@@ -58,7 +58,7 @@ public class PropertyFilterQueryParametersBinder extends AbstractQueryParameters
     }
 
     protected void autowireDependencies() {
-        filterQueryParametersSupport = applicationContext.getBean(FilterQueryParametersSupport.class);
+        filterUrlQueryParametersSupport = applicationContext.getBean(FilterUrlQueryParametersSupport.class);
     }
 
     protected void initComponent(PropertyFilter<?> filter) {
@@ -77,16 +77,16 @@ public class PropertyFilterQueryParametersBinder extends AbstractQueryParameters
 
     protected void updateQueryParameters() {
         String serializedOperation = urlParamSerializer
-                .serialize(filterQueryParametersSupport.replaceSeparatorValue(
+                .serialize(filterUrlQueryParametersSupport.replaceSeparatorValue(
                         filter.getOperation().name().toLowerCase()));
         String serializedValue = urlParamSerializer
-                .serialize(filterQueryParametersSupport.getSerializableValue(filter.getValue()));
+                .serialize(filterUrlQueryParametersSupport.getSerializableValue(filter.getValue()));
 
         String paramValue = serializedOperation + SEPARATOR + serializedValue;
         QueryParameters queryParameters = QueryParameters
                 .simple(ImmutableMap.of(getParameter(), paramValue));
 
-        fireQueryParametersChanged(new QueryParametersChangeEvent(this, queryParameters));
+        fireQueryParametersChanged(new UrlQueryParametersChangeEvent(this, queryParameters));
     }
 
     @Override
@@ -102,7 +102,7 @@ public class PropertyFilterQueryParametersBinder extends AbstractQueryParameters
 
             String operationString = serializedSettings.substring(0, separatorIndex);
             Operation operation = urlParamSerializer.deserialize(Operation.class,
-                    filterQueryParametersSupport.restoreSeparatorValue(operationString));
+                    filterUrlQueryParametersSupport.restoreSeparatorValue(operationString));
 
             if (filter.isOperationEditable()) {
                 filter.setOperation(operation);
@@ -114,7 +114,7 @@ public class PropertyFilterQueryParametersBinder extends AbstractQueryParameters
             String valueString = serializedSettings.substring(separatorIndex + 1);
             if (!Strings.isNullOrEmpty(valueString)) {
                 MetaClass entityMetaClass = filter.getDataLoader().getContainer().getEntityMetaClass();
-                Object parsedValue = filterQueryParametersSupport.parseValue(entityMetaClass,
+                Object parsedValue = filterUrlQueryParametersSupport.parseValue(entityMetaClass,
                         Objects.requireNonNull(filter.getProperty()), operation.getType(), valueString);
                 //noinspection unchecked,rawtypes
                 ((PropertyFilter) filter).setValue(parsedValue);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/package-info.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/package-info.java
@@ -16,7 +16,7 @@
 
 @Internal
 @NonNullApi
-package io.jmix.flowui.facet.queryparameters;
+package io.jmix.flowui.facet.urlqueryparameters;
 
 import io.jmix.core.annotation.Internal;
 import org.springframework.lang.NonNullApi;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/menu/ListMenuBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/menu/ListMenuBuilder.java
@@ -153,7 +153,7 @@ public class ListMenuBuilder {
                 .withTitle(menuConfig.getItemTitle(menuItem))
                 .withDescription(getDescription(menuItem))
                 .withClassNames(Arrays.stream(getClassNames(menuItem)).collect(Collectors.toList()))
-                .withQueryParameters(menuItem.getQueryParameters())
+                .withUrlQueryParameters(menuItem.getUrlQueryParameters())
                 .withRouteParameters(menuItem.getRouteParameters())
                 .withShortcutCombination(menuItem.getShortcutCombination());
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/menu/MenuConfig.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/menu/MenuConfig.java
@@ -275,7 +275,7 @@ public class MenuConfig {
         loadDescription(element, menuItem);
 
         menuItem.setProperties(loadMenuItemProperties(element));
-        menuItem.setQueryParameters(loadMenuItemParameters(element, "queryParameters"));
+        menuItem.setUrlQueryParameters(loadMenuItemParameters(element, "urlQueryParameters"));
         menuItem.setRouteParameters(loadMenuItemParameters(element, "routeParameters"));
 
         return menuItem;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/menu/MenuItem.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/menu/MenuItem.java
@@ -51,7 +51,7 @@ public class MenuItem {
     private boolean isMenu = false;
 
     protected List<MenuItemProperty> properties;
-    protected List<MenuItemParameter> queryParameters;
+    protected List<MenuItemParameter> urlQueryParameters;
     protected List<MenuItemParameter> routeParameters;
 
     public MenuItem(@Nullable MenuItem parent, String id) {
@@ -215,15 +215,15 @@ public class MenuItem {
         this.properties = properties;
     }
 
-    public List<MenuItemParameter> getQueryParameters() {
-        if (queryParameters == null) {
+    public List<MenuItemParameter> getUrlQueryParameters() {
+        if (urlQueryParameters == null) {
             return Collections.emptyList();
         }
-        return queryParameters;
+        return urlQueryParameters;
     }
 
-    public void setQueryParameters(List<MenuItemParameter> queryParameters) {
-        this.queryParameters = queryParameters;
+    public void setUrlQueryParameters(List<MenuItemParameter> urlQueryParameters) {
+        this.urlQueryParameters = urlQueryParameters;
     }
 
     public List<MenuItemParameter> getRouteParameters() {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/facet/UrlQueryParametersFacetProvider.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/facet/UrlQueryParametersFacetProvider.java
@@ -23,11 +23,11 @@ import io.jmix.flowui.component.UiComponentUtils;
 import io.jmix.flowui.component.genericfilter.GenericFilter;
 import io.jmix.flowui.component.propertyfilter.PropertyFilter;
 import io.jmix.flowui.exception.GuiDevelopmentException;
-import io.jmix.flowui.facet.QueryParametersFacet;
-import io.jmix.flowui.facet.impl.QueryParametersFacetImpl;
-import io.jmix.flowui.facet.queryparameters.GenericFilterQueryParametersBinder;
-import io.jmix.flowui.facet.queryparameters.PaginationQueryParametersBinder;
-import io.jmix.flowui.facet.queryparameters.PropertyFilterQueryParametersBinder;
+import io.jmix.flowui.facet.UrlQueryParametersFacet;
+import io.jmix.flowui.facet.impl.UrlQueryParametersFacetImpl;
+import io.jmix.flowui.facet.urlqueryparameters.GenericFilterUrlQueryParametersBinder;
+import io.jmix.flowui.facet.urlqueryparameters.PaginationUrlQueryParametersBinder;
+import io.jmix.flowui.facet.urlqueryparameters.PropertyFilterUrlQueryParametersBinder;
 import io.jmix.flowui.view.View;
 import io.jmix.flowui.view.navigation.RouteSupport;
 import io.jmix.flowui.view.navigation.UrlParamSerializer;
@@ -41,17 +41,17 @@ import org.springframework.context.ApplicationContextAware;
 
 import jakarta.annotation.Nullable;
 
-@org.springframework.stereotype.Component("flowui_QueryParametersFacetProvider")
-public class QueryParametersFacetProvider implements FacetProvider<QueryParametersFacet>, ApplicationContextAware {
+@org.springframework.stereotype.Component("flowui_UrlQueryParametersFacetProvider")
+public class UrlQueryParametersFacetProvider implements FacetProvider<UrlQueryParametersFacet>, ApplicationContextAware {
 
     protected LoaderSupport loaderSupport;
     protected RouteSupport routeSupport;
     protected UrlParamSerializer urlParamSerializer;
     protected ApplicationContext applicationContext;
 
-    public QueryParametersFacetProvider(LoaderSupport loaderSupport,
-                                        RouteSupport routeSupport,
-                                        UrlParamSerializer urlParamSerializer) {
+    public UrlQueryParametersFacetProvider(LoaderSupport loaderSupport,
+                                           RouteSupport routeSupport,
+                                           UrlParamSerializer urlParamSerializer) {
         this.loaderSupport = loaderSupport;
         this.routeSupport = routeSupport;
         this.urlParamSerializer = urlParamSerializer;
@@ -63,22 +63,22 @@ public class QueryParametersFacetProvider implements FacetProvider<QueryParamete
     }
 
     @Override
-    public Class<QueryParametersFacet> getFacetClass() {
-        return QueryParametersFacet.class;
+    public Class<UrlQueryParametersFacet> getFacetClass() {
+        return UrlQueryParametersFacet.class;
     }
 
     @Override
-    public QueryParametersFacet create() {
-        return new QueryParametersFacetImpl(routeSupport);
+    public UrlQueryParametersFacet create() {
+        return new UrlQueryParametersFacetImpl(routeSupport);
     }
 
     @Override
     public String getFacetTag() {
-        return QueryParametersFacet.NAME;
+        return UrlQueryParametersFacet.NAME;
     }
 
     @Override
-    public void loadFromXml(QueryParametersFacet facet, Element element, ComponentContext context) {
+    public void loadFromXml(UrlQueryParametersFacet facet, Element element, ComponentContext context) {
         facet.setOwner(context.getView());
 
         loaderSupport.loadString(element, "id", facet::setId);
@@ -88,16 +88,16 @@ public class QueryParametersFacetProvider implements FacetProvider<QueryParamete
         }
     }
 
-    protected void loadBinder(QueryParametersFacet facet, Element element, ComponentContext context) {
+    protected void loadBinder(UrlQueryParametersFacet facet, Element element, ComponentContext context) {
         // TODO: gg, rework, some registration is needed
         switch (element.getName()) {
-            case PaginationQueryParametersBinder.NAME:
+            case PaginationUrlQueryParametersBinder.NAME:
                 loadPaginationQueryParametersBinder(facet, element, context);
                 break;
-            case GenericFilterQueryParametersBinder.NAME:
+            case GenericFilterUrlQueryParametersBinder.NAME:
                 loadGenericFilterQueryParametersBinder(facet, element, context);
                 break;
-            case PropertyFilterQueryParametersBinder.NAME:
+            case PropertyFilterUrlQueryParametersBinder.NAME:
                 loadPropertyFilterQueryParametersBinder(facet, element, context);
                 break;
             default:
@@ -107,7 +107,7 @@ public class QueryParametersFacetProvider implements FacetProvider<QueryParamete
         }
     }
 
-    protected void loadPropertyFilterQueryParametersBinder(QueryParametersFacet facet,
+    protected void loadPropertyFilterQueryParametersBinder(UrlQueryParametersFacet facet,
                                                            Element element, ComponentContext context) {
         String componentId = loadRequiredAttribute(element, "component", context);
         String binderId = loadAttribute(element, "id");
@@ -118,7 +118,7 @@ public class QueryParametersFacetProvider implements FacetProvider<QueryParamete
         ));
     }
 
-    protected void loadGenericFilterQueryParametersBinder(QueryParametersFacet facet,
+    protected void loadGenericFilterQueryParametersBinder(UrlQueryParametersFacet facet,
                                                           Element element, ComponentContext context) {
         String componentId = loadRequiredAttribute(element, "component", context);
         String binderId = loadAttribute(element, "id");
@@ -129,7 +129,7 @@ public class QueryParametersFacetProvider implements FacetProvider<QueryParamete
         ));
     }
 
-    protected void loadPaginationQueryParametersBinder(QueryParametersFacet facet,
+    protected void loadPaginationQueryParametersBinder(UrlQueryParametersFacet facet,
                                                        Element element, ComponentContext context) {
         String componentId = loadRequiredAttribute(element, "component", context);
         String binderId = loadAttribute(element, "id");
@@ -155,14 +155,14 @@ public class QueryParametersFacetProvider implements FacetProvider<QueryParamete
 
     public static class PaginationQueryParametersBinderInitTask implements ComponentLoader.InitTask {
 
-        protected final QueryParametersFacet facet;
+        protected final UrlQueryParametersFacet facet;
         protected final String binderId;
         protected final String componentId;
         protected final String firstResultParam;
         protected final String maxResultsParam;
         protected final UrlParamSerializer urlParamSerializer;
 
-        public PaginationQueryParametersBinderInitTask(QueryParametersFacet facet,
+        public PaginationQueryParametersBinderInitTask(UrlQueryParametersFacet facet,
                                                        String componentId,
                                                        @Nullable String binderId,
                                                        @Nullable String firstResultParam,
@@ -178,15 +178,15 @@ public class QueryParametersFacetProvider implements FacetProvider<QueryParamete
 
         @Override
         public void execute(ComponentContext context, View<?> view) {
-            Preconditions.checkState(facet.getOwner() != null, "%s owner is not set", QueryParametersFacet.NAME);
+            Preconditions.checkState(facet.getOwner() != null, "%s owner is not set", UrlQueryParametersFacet.NAME);
 
             Component component = UiComponentUtils.getComponent(facet.getOwner(), componentId);
             if (!(component instanceof PaginationComponent)) {
                 throw new IllegalStateException(String.format("'%s' is not a pagination component", componentId));
             }
 
-            PaginationQueryParametersBinder binder =
-                    new PaginationQueryParametersBinder(((PaginationComponent<?>) component), urlParamSerializer);
+            PaginationUrlQueryParametersBinder binder =
+                    new PaginationUrlQueryParametersBinder(((PaginationComponent<?>) component), urlParamSerializer);
 
             binder.setId(binderId);
             binder.setFirstResultParam(firstResultParam);
@@ -198,14 +198,14 @@ public class QueryParametersFacetProvider implements FacetProvider<QueryParamete
 
     public static class PropertyFilterQueryParametersBinderInitTask implements ComponentLoader.InitTask {
 
-        protected final QueryParametersFacet facet;
+        protected final UrlQueryParametersFacet facet;
         protected final String binderId;
         protected final String componentId;
         protected final String parameter;
         protected final UrlParamSerializer urlParamSerializer;
         protected final ApplicationContext applicationContext;
 
-        public PropertyFilterQueryParametersBinderInitTask(QueryParametersFacet facet,
+        public PropertyFilterQueryParametersBinderInitTask(UrlQueryParametersFacet facet,
                                                            String componentId,
                                                            @Nullable String parameter,
                                                            @Nullable String binderId,
@@ -221,15 +221,15 @@ public class QueryParametersFacetProvider implements FacetProvider<QueryParamete
 
         @Override
         public void execute(ComponentContext context, View<?> view) {
-            Preconditions.checkState(facet.getOwner() != null, "%s owner is not set", QueryParametersFacet.NAME);
+            Preconditions.checkState(facet.getOwner() != null, "%s owner is not set", UrlQueryParametersFacet.NAME);
 
             Component component = UiComponentUtils.getComponent(facet.getOwner(), componentId);
             if (!(component instanceof PropertyFilter)) {
                 throw new IllegalStateException(String.format("'%s' is not a property filter component", componentId));
             }
 
-            PropertyFilterQueryParametersBinder binder =
-                    new PropertyFilterQueryParametersBinder(((PropertyFilter<?>) component),
+            PropertyFilterUrlQueryParametersBinder binder =
+                    new PropertyFilterUrlQueryParametersBinder(((PropertyFilter<?>) component),
                             urlParamSerializer, applicationContext);
 
             binder.setId(binderId);
@@ -241,14 +241,14 @@ public class QueryParametersFacetProvider implements FacetProvider<QueryParamete
 
     public static class GenericFilterQueryParametersBinderInitTask implements ComponentLoader.InitTask {
 
-        protected final QueryParametersFacet facet;
+        protected final UrlQueryParametersFacet facet;
         protected final String binderId;
         protected final String componentId;
         protected final String conditionParam;
         protected final UrlParamSerializer urlParamSerializer;
         protected final ApplicationContext applicationContext;
 
-        public GenericFilterQueryParametersBinderInitTask(QueryParametersFacet facet,
+        public GenericFilterQueryParametersBinderInitTask(UrlQueryParametersFacet facet,
                                                           String componentId,
                                                           @Nullable String binderId,
                                                           @Nullable String conditionParam,
@@ -264,15 +264,15 @@ public class QueryParametersFacetProvider implements FacetProvider<QueryParamete
 
         @Override
         public void execute(ComponentContext context, View<?> view) {
-            Preconditions.checkState(facet.getOwner() != null, "%s owner is not set", QueryParametersFacet.NAME);
+            Preconditions.checkState(facet.getOwner() != null, "%s owner is not set", UrlQueryParametersFacet.NAME);
 
             Component component = UiComponentUtils.getComponent(facet.getOwner(), componentId);
             if (!(component instanceof GenericFilter)) {
                 throw new IllegalStateException(String.format("'%s' is not a generic filter component", componentId));
             }
 
-            GenericFilterQueryParametersBinder binder =
-                    new GenericFilterQueryParametersBinder(((GenericFilter) component),
+            GenericFilterUrlQueryParametersBinder binder =
+                    new GenericFilterUrlQueryParametersBinder(((GenericFilter) component),
                             urlParamSerializer, applicationContext);
 
             binder.setId(binderId);

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/menu/menu.xsd
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/menu/menu.xsd
@@ -67,7 +67,7 @@
         <xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element name="properties" type="viewProperties" minOccurs="0"/>
-                <xs:element name="queryParameters" type="parameters" minOccurs="0"/>
+                <xs:element name="urlQueryParameters" type="parameters" minOccurs="0"/>
                 <xs:element name="routeParameters" type="parameters" minOccurs="0"/>
             </xs:choice>
         </xs:sequence>

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
@@ -3333,7 +3333,7 @@
         <xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
                 <xs:element name="dataLoadCoordinator" type="dataLoadCoordinatorType" minOccurs="0"/>
-                <xs:element name="queryParameters" type="queryParametersType" minOccurs="0"/>
+                <xs:element name="urlQueryParameters" type="urlQueryParametersType" minOccurs="0"/>
             </xs:choice>
         </xs:sequence>
     </xs:complexType>
@@ -3395,34 +3395,34 @@
         </xs:restriction>
     </xs:simpleType>
 
-    <!-- queryParameters -->
+    <!-- urlQueryParameters -->
 
-    <xs:complexType name="queryParametersType">
+    <xs:complexType name="urlQueryParametersType">
         <xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element name="pagination" type="paginationQueryParametersType" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="genericFilter" type="genericFilterQueryParametersType" minOccurs="0" maxOccurs="unbounded"/>
-                <xs:element name="propertyFilter" type="propertyFilterQueryParametersType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="pagination" type="paginationUrlQueryParametersType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="genericFilter" type="genericFilterUrlQueryParametersType" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element name="propertyFilter" type="propertyFilterUrlQueryParametersType" minOccurs="0" maxOccurs="unbounded"/>
             </xs:choice>
         </xs:sequence>
         <xs:attribute name="id" type="xs:string"/>
     </xs:complexType>
 
 
-    <xs:complexType name="paginationQueryParametersType">
+    <xs:complexType name="paginationUrlQueryParametersType">
         <xs:attribute name="id" type="xs:string"/>
         <xs:attribute name="component" type="xs:string" use="required"/>
         <xs:attribute name="firstResultParam" type="xs:string"/>
         <xs:attribute name="maxResultsParam" type="xs:string"/>
     </xs:complexType>
 
-    <xs:complexType name="genericFilterQueryParametersType">
+    <xs:complexType name="genericFilterUrlQueryParametersType">
         <xs:attribute name="id" type="xs:string"/>
         <xs:attribute name="component" type="xs:string" use="required"/>
         <xs:attribute name="conditionParam" type="xs:string"/>
     </xs:complexType>
 
-    <xs:complexType name="propertyFilterQueryParametersType">
+    <xs:complexType name="propertyFilterUrlQueryParametersType">
         <xs:attribute name="id" type="xs:string"/>
         <xs:attribute name="component" type="xs:string" use="required"/>
         <xs:attribute name="param" type="xs:string"/>

--- a/jmix-multitenancy/multitenancy-flowui/src/main/resources/io/jmix/multitenancyflowui/view/tenant/tenant-list-view.xml
+++ b/jmix-multitenancy/multitenancy-flowui/src/main/resources/io/jmix/multitenancyflowui/view/tenant/tenant-list-view.xml
@@ -37,9 +37,9 @@
     </actions>
     <facets>
         <dataLoadCoordinator auto="true"/>
-        <queryParameters>
+        <urlQueryParameters>
             <pagination component="pagination"/>
-        </queryParameters>
+        </urlQueryParameters>
     </facets>
     <layout expand="tenantsTable">
         <hbox id="buttonsPanel" classNames="buttons-panel">

--- a/jmix-templates/content/flowui/list/descriptor.xml
+++ b/jmix-templates/content/flowui/list/descriptor.xml
@@ -34,9 +34,9 @@ def tableXml = api.processSnippet('table.xml',
     </data>
     <facets>
         <dataLoadCoordinator auto="true"/>
-        <queryParameters>
+        <urlQueryParameters>
             <pagination component="pagination"/>
-        </queryParameters>
+        </urlQueryParameters>
     </facets>
     <actions>
         <action id="selectAction" type="lookup_select"/>

--- a/jmix-templates/content/project/flowui-application/src/main/resources/${project_rootPath}/view/user/user-list-view.xml
+++ b/jmix-templates/content/project/flowui-application/src/main/resources/${project_rootPath}/view/user/user-list-view.xml
@@ -19,9 +19,9 @@
     </actions>
     <facets>
         <dataLoadCoordinator auto="true"/>
-        <queryParameters>
+        <urlQueryParameters>
             <pagination component="pagination"/>
-        </queryParameters>
+        </urlQueryParameters>
     </facets>
     <layout>
         <hbox id="buttonsPanel" classNames="buttons-panel">


### PR DESCRIPTION
Fixes jmix-framework/jmix#1628

Changes:

* `QueryParametersFacet` and all related classes renamed to `UrlQueryParametersFacet`
```xml
<facets>
    <urlQueryParameters>
        <pagination component="pagination"/>
    </urlQueryParameters>
</facets>
```

* Menu item's `<queryParameters>` element and all related API renamed to `<urlQueryParameters>`
```xml
<menu id="application" title="msg://com.company.demo/menu.application.title" opened="true">
    <item view="User.list" title="msg://com.company.demo.view.user/UserListView.title">
        <urlQueryParameters>
            <parameter name="test" value="test"/>
        </urlQueryParameters>
    </item>
</menu>
```