### PR TITLE
[PR] Bean validation on persistence layer #1368

### DIFF
--- a/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/support/JmixEclipseLinkJpaVendorAdapter.java
+++ b/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/support/JmixEclipseLinkJpaVendorAdapter.java
@@ -19,6 +19,7 @@ import io.jmix.core.EnvironmentUtils;
 import io.jmix.core.MetadataTools;
 import io.jmix.eclipselink.impl.JmixPersistenceProvider;
 import jakarta.persistence.spi.PersistenceProvider;
+import jakarta.validation.ValidatorFactory;
 import org.eclipse.persistence.config.SessionCustomizer;
 import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.sessions.Session;
@@ -47,18 +48,22 @@ public class JmixEclipseLinkJpaVendorAdapter extends EclipseLinkJpaVendorAdapter
 
     protected final ObjectProvider<JmixEclipseLinkTransportManager> transportManagerProvider;
 
+    protected final ValidatorFactory validatorFactory;
+
     @Autowired
     public JmixEclipseLinkJpaVendorAdapter(Environment environment,
                                            JmixEclipseLinkJpaDialect jpaDialect,
                                            JmixEclipseLinkSessionEventListener sessionEventListener,
                                            ObjectProvider<JmixEclipseLinkTransportManager> transportManagerProvider,
                                            ListableBeanFactory beanFactory,
-                                           MetadataTools metadataTools) {
+                                           MetadataTools metadataTools,
+                                           ValidatorFactory validatorFactory) {
         this.environment = environment;
         this.jpaDialect = jpaDialect;
         this.persistenceProvider = new JmixPersistenceProvider(beanFactory, metadataTools);
         this.sessionEventListener = sessionEventListener;
         this.transportManagerProvider = transportManagerProvider;
+        this.validatorFactory = validatorFactory;
 
         setGenerateDdl(false);
         setShowSql(true);
@@ -79,6 +84,7 @@ public class JmixEclipseLinkJpaVendorAdapter extends EclipseLinkJpaVendorAdapter
         map.put("eclipselink.cache.shared.default", "false");
 
         map.put("jakarta.persistence.validation.mode", "NONE");
+        map.put("jakarta.persistence.validation.factory", validatorFactory);
 
         map.put("eclipselink.session.customizer", new JmixEclipseLinkSessionCustomizer());
         map.put("eclipselink.application-id", Integer.toString(System.identityHashCode(this)));

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/exception/ConstraintViolationExceptionHandler.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/exception/ConstraintViolationExceptionHandler.java
@@ -27,6 +27,10 @@ import org.springframework.stereotype.Component;
 
 import java.util.Set;
 
+/**
+ * Handles ConstraintViolationException that can be thrown by bean validation on persistence layer.
+ * Displays violation messages as screen notifications.
+ */
 @Component
 public class ConstraintViolationExceptionHandler extends AbstractUiExceptionHandler {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/exception/ConstraintViolationExceptionHandler.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/exception/ConstraintViolationExceptionHandler.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2022 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.exception;
+
+import io.jmix.core.MessageTools;
+import io.jmix.flowui.Notifications;
+import io.jmix.flowui.component.validation.ValidationErrors;
+import io.jmix.flowui.view.ViewValidation;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+public class ConstraintViolationExceptionHandler extends AbstractUiExceptionHandler {
+
+    @Autowired
+    protected Notifications notifications;
+    @Autowired
+    protected ViewValidation viewValidation;
+    @Autowired
+    protected MessageTools messageTools;
+
+    public ConstraintViolationExceptionHandler() {
+        super(ConstraintViolationException.class.getName());
+    }
+
+    @Override
+    protected void doHandle(String className, String message, Throwable throwable) {
+        ConstraintViolationException exception = (ConstraintViolationException) throwable;
+        Set<ConstraintViolation<?>> violations = exception.getConstraintViolations();
+        ValidationErrors validationErrors = new ValidationErrors();
+        violations.forEach(v -> {
+            String violationMessage = v.getMessage();
+            if (violationMessage.startsWith("{") && violationMessage.endsWith("}")) {
+                violationMessage = violationMessage.substring(1, violationMessage.length() - 1);
+                if (messageTools.isMessageKey(violationMessage)) {
+                    violationMessage = messageTools.loadString(violationMessage);
+                }
+            }
+            validationErrors.add(violationMessage);
+        });
+
+        viewValidation.showValidationErrors(validationErrors);
+    }
+}


### PR DESCRIPTION
- Automatical bean validation on persistence layer is enabled
- Can be disabled by setting `javax.persistence.validation.mode` app property to `NONE`
- Validator groups can be configured by the following application properties (full class name required as value): `jakarta.persistence.validation.group.pre-persist`, `jakarta.persistence.validation.group.pre-update`, `jakarta.persistence.validation.group.pre-remove`. `Default` group by default.
- JmixLocalValidatorFactoryBean with Jmix-specific message interpolator is used as validation factory for auto validation (the same as for the manual validation on UI\REST side)
