### PR TITLE
Improve display of object save message (1886)

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/InstanceNameProvider.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/InstanceNameProvider.java
@@ -28,10 +28,19 @@ import java.util.Collection;
 public interface InstanceNameProvider {
 
     /**
-     * Get entity instance name defined by {@link InstanceName} annotation
+     * Checks if {@link InstanceName} annotation is present in an entity class,
+     * i.e. whether instance name can be obtained for entity instances.
      *
-     * @param instance   instance
+     * @param aClass an entity class to check
+     * @return {@code true} if {@link InstanceName} annotation is present, {@code false} otherwise
+     */
+    boolean isInstanceNameDefined(Class<?> aClass);
+
+    /**
+     * Gets entity instance name defined by {@link InstanceName} annotation.
+     * If {@link InstanceName} annotation is not defined, returns {@code entity.toString()}.
      *
+     * @param instance an entity instance to get instance name
      * @return instance name
      */
     String getInstanceName(Object instance);

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/InstanceNameProviderImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/InstanceNameProviderImpl.java
@@ -113,6 +113,12 @@ public class InstanceNameProviderImpl implements InstanceNameProvider {
     }
 
     @Override
+    public boolean isInstanceNameDefined(Class<?> aClass) {
+        MetaClass metaClass = metadata.getClass(aClass);
+        return instanceNameRecCache.getUnchecked(metaClass).isPresent();
+    }
+
+    @Override
     public String getInstanceName(Object instance) {
         checkNotNullArgument(instance, "instance is null");
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
@@ -156,11 +156,16 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
         MessageTools messageTools = getApplicationContext().getBean(MessageTools.class);
         InstanceNameProvider instanceNameProvider = getApplicationContext().getBean(InstanceNameProvider.class);
 
-        MetaClass metaClass = metadata.getClass(getEditedEntity());
+        T editedEntity = getEditedEntity();
+        MetaClass metaClass = metadata.getClass(editedEntity);
+        String entityCaption = messageTools.getEntityCaption(metaClass);
 
-        return messages.formatMessage("", "info.EntitySaved",
-                messageTools.getEntityCaption(metaClass),
-                instanceNameProvider.getInstanceName(getEditedEntity()));
+        if (instanceNameProvider.isInstanceNameDefined(editedEntity.getClass())) {
+            return messages.formatMessage("", "info.EntitySaved", entityCaption,
+                    instanceNameProvider.getInstanceName(editedEntity));
+        } else {
+            return messages.formatMessage("", "info.EntitySaved.short", entityCaption);
+        }
     }
 
     @Override

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/messages.properties
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/messages.properties
@@ -71,6 +71,7 @@ exceptionDialog.copyButton.description=Copy stack trace to the clipboard
 exceptionDialog.copingSuccessful=Copied to clipboard
 
 info.EntitySaved=%s %s saved successfully
+info.EntitySaved.short=%s saved successfully
 
 dialogWindow.closeButton.description = Close this dialog window
 

--- a/jmix-translations/content/io/jmix/flowui/messages.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages.properties
@@ -71,6 +71,7 @@ exceptionDialog.copyButton.description=Copy stack trace to the clipboard
 exceptionDialog.copingSuccessful=Copied to clipboard
 
 info.EntitySaved=%s %s saved successfully
+info.EntitySaved.short=%s saved successfully
 
 dialogWindow.closeButton.description = Close this dialog window
 

--- a/jmix-translations/content/io/jmix/flowui/messages_ckb.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages_ckb.properties
@@ -71,6 +71,7 @@ exceptionDialog.copyButton.description=شوێنپێی ستاک لەبەربگر�
 exceptionDialog.copingSuccessful=لەبەرگیرایەوە بۆ کلیپبۆرد
 
 info.EntitySaved=%s %s بە سەرکەوتوویی پاشەکەوتکرا
+info.EntitySaved.short=%s بە سەرکەوتوویی پاشەکەوتکرا
 
 dialogWindow.closeButton.description = ئەم پەنجەرە دیالۆگە دابخە
 

--- a/jmix-translations/content/io/jmix/flowui/messages_fr.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages_fr.properties
@@ -70,6 +70,7 @@ fileUploadField.uploadDialog.title = Téléchargement
 fileUploadField.uploadInternalError.notification.message = L'erreur se produit lors du téléchargement du fichier '%s'
 fileUploadField.uploadInternalError.notification.title = Échec du téléchargement
 info.EntitySaved = %s %s enregistré avec succès
+info.EntitySaved.short = %s enregistré avec succès
 io.jmix.flowui.app.filter.condition/conditionFilterField.placeholder = Chercher...
 io.jmix.flowui.app.pessimisticlocking/hasBeenUnlockedWithId = Le verrou %s avec ID : %s a été déverrouillé
 io.jmix.flowui.app.pessimisticlocking/hasBeenUnlockedWithoutId = Le verrou %s a été déverrouillé

--- a/jmix-translations/content/io/jmix/flowui/messages_it.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages_it.properties
@@ -71,6 +71,7 @@ exceptionDialog.copyButton.description=Copia stack trace negli appunti
 exceptionDialog.copingSuccessful=Copiato negli appunti
 
 info.EntitySaved=%s %s salvato con successo
+info.EntitySaved.short=%s salvato con successo
 
 dialogWindow.closeButton.description = Chiudi finestra di dialogo
 

--- a/jmix-translations/content/io/jmix/flowui/messages_nl.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages_nl.properties
@@ -61,6 +61,7 @@ exceptionDialog.copyButton.description=Kopieer stack trace naar het klembord
 exceptionDialog.copingSuccessful=Gekopieerd naar het klembord
 
 info.EntitySaved=%s %s succesvol opgeslagen
+info.EntitySaved.short=%s succesvol opgeslagen
 
 dialogWindow.closeButton.description = Sluit dit dialoogvenster
 

--- a/jmix-translations/content/io/jmix/flowui/messages_ru.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages_ru.properties
@@ -69,6 +69,7 @@ exceptionDialog.copyButton.description=Копировать
 exceptionDialog.copingSuccessful=Скопировано в буфер обмена
 
 info.EntitySaved=%s %s успешно сохранена
+info.EntitySaved.short=%s успешно сохранена
 
 dialogWindow.closeButton.description = Закрть диалог
 


### PR DESCRIPTION
Fixes: https://github.com/jmix-framework/jmix/issues/1886

## Solution

* `InstanceNameProvider` now contains a method to check if an entity class has `@IntanceName`. 
* Added a new message key: `info.EntitySaved.short`