### PR TITLE
Custom login form for authorization server 1098

### DIFF
--- a/jmix-authserver/authserver-starter/src/main/java/io/jmix/autoconfigure/authserver/AuthServerAutoConfiguration.java
+++ b/jmix-authserver/authserver-starter/src/main/java/io/jmix/autoconfigure/authserver/AuthServerAutoConfiguration.java
@@ -56,11 +56,18 @@ public class AuthServerAutoConfiguration {
     @Order(AuthorizationServerLoginPageConfiguration.ORDER)
     public static class AuthorizationServerLoginPageConfiguration implements WebMvcConfigurer {
 
+        private final AuthServerProperties authServerProperties;
+
+        public AuthorizationServerLoginPageConfiguration(AuthServerProperties authServerProperties) {
+            this.authServerProperties = authServerProperties;
+        }
+
         public static final int ORDER = 100;
 
         @Override
         public void addViewControllers(ViewControllerRegistry registry) {
-            registry.addViewController("/as-login").setViewName("as-login.html");
+            registry.addViewController(authServerProperties.getLoginPageUrl())
+                    .setViewName(authServerProperties.getLoginPageViewName());
         }
     }
 
@@ -86,7 +93,7 @@ public class AuthServerAutoConfiguration {
                     // authorization endpoint
                     .exceptionHandling((exceptions) -> exceptions
                             .authenticationEntryPoint(
-                                    new LoginUrlAuthenticationEntryPoint("/as-login"))
+                                    new LoginUrlAuthenticationEntryPoint(authServerProperties.getLoginPageUrl()))
                     );
 
             SecurityConfigurers.applySecurityConfigurersWithQualifier(http, SECURITY_CONFIGURER_QUALIFIER);
@@ -98,12 +105,12 @@ public class AuthServerAutoConfiguration {
         public SecurityFilterChain loginFormSecurityFilterChain(HttpSecurity http)
                 throws Exception {
             http
-                    .securityMatcher("/as-login")
+                    .securityMatcher(authServerProperties.getLoginPageUrl())
                     .authorizeHttpRequests(authorize -> {
                         authorize.anyRequest().permitAll();
                     })
                     .formLogin(form -> {
-                        form.loginPage("/as-login");
+                        form.loginPage(authServerProperties.getLoginPageUrl());
                     });
 
             SecurityConfigurers.applySecurityConfigurersWithQualifier(http, LOGIN_FORM_SECURITY_CONFIGURER_QUALIFIER);

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/AuthServerProperties.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/AuthServerProperties.java
@@ -35,11 +35,26 @@ public class AuthServerProperties {
      */
     Map<String, JmixClient> client;
 
+    /**
+     * URL to send users to if login is required
+     */
+    String loginPageUrl;
+
+    /**
+     * A Spring MVC view name for the login page
+     */
+    String loginPageViewName;
+
     public AuthServerProperties(
             @DefaultValue("true") boolean useDefaultConfiguration,
-            @DefaultValue Map<String, JmixClient> client) {
+            @DefaultValue Map<String, JmixClient> client,
+            @DefaultValue("/as-login") String loginPageUrl,
+            @DefaultValue("as-login.html") String loginPageViewName
+            ) {
         this.useDefaultConfiguration = useDefaultConfiguration;
         this.client = client;
+        this.loginPageUrl = loginPageUrl;
+        this.loginPageViewName = loginPageViewName;
     }
 
     public boolean isUseDefaultConfiguration() {
@@ -48,6 +63,14 @@ public class AuthServerProperties {
 
     public Map<String, JmixClient> getClient() {
         return client;
+    }
+
+    public String getLoginPageUrl() {
+        return loginPageUrl;
+    }
+
+    public String getLoginPageViewName() {
+        return loginPageViewName;
     }
 
     /**


### PR DESCRIPTION
Application properties for specifying the login form view name and login form URL have been introduced:

```
jmix.authserver.login-page-view-name=as-login.html
jmix.authserver.login-page-url=/as-login
```

In a application users may create a custom login page, e.g. `src/main/resources/templates/my-as-login.html` and define a property:

```
jmix.authserver.login-page-view-name=my-as-login.html
```