### PR TITLE
Allow using PropertyDatatype in composed annotations

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/annotation/PropertyDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/annotation/PropertyDatatype.java
@@ -8,7 +8,7 @@ import java.lang.annotation.Target;
 /**
  * Explicitly defined datatype that overrides a datatype inferred from the attribute Java type.
  */
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PropertyDatatype {
 


### PR DESCRIPTION
feat: ANNOTATION_TYPE target has been added for @PropertyDatatype