### PR TITLE
jmix.rest.anonymous-url-patterns doesn't work if multiple URLs separated by a comma with a space #1626

### DIFF
--- a/jmix-rest/rest/src/main/java/io/jmix/rest/security/impl/RestAuthorizedUrlsProvider.java
+++ b/jmix-rest/rest/src/main/java/io/jmix/rest/security/impl/RestAuthorizedUrlsProvider.java
@@ -16,18 +16,23 @@
 
 package io.jmix.rest.security.impl;
 
+import com.google.common.base.Splitter;
 import io.jmix.core.JmixModules;
 import io.jmix.core.security.AuthorizedUrlsProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Component("rest_RestAuthorizedUrlsProvider")
 public class RestAuthorizedUrlsProvider implements AuthorizedUrlsProvider {
+
+    protected static final Splitter urlPatternSplitter = Splitter.on(",")
+            .omitEmptyStrings()
+            .trimResults();
+
     @Autowired
     private JmixModules jmixModules;
 
@@ -35,7 +40,7 @@ public class RestAuthorizedUrlsProvider implements AuthorizedUrlsProvider {
     public Collection<String> getAuthenticatedUrlPatterns() {
         List<String> urlPatterns = jmixModules.getPropertyValues("jmix.rest.authenticated-url-patterns");
         return urlPatterns.stream()
-                .flatMap(s -> Arrays.stream(s.split(",")))
+                .flatMap(s -> urlPatternSplitter.splitToList(s).stream())
                 .collect(Collectors.toList());
     }
 
@@ -43,7 +48,7 @@ public class RestAuthorizedUrlsProvider implements AuthorizedUrlsProvider {
     public Collection<String> getAnonymousUrlPatterns() {
         List<String> urlPatterns = jmixModules.getPropertyValues("jmix.rest.anonymous-url-patterns");
         return urlPatterns.stream()
-                .flatMap(s -> Arrays.stream(s.split(",")))
+                .flatMap(s -> urlPatternSplitter.splitToList(s).stream())
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
See https://github.com/jmix-framework/jmix/issues/1626