### PR TITLE
Ability to not merge into DataContext entities loaded by certain data loaders

### DIFF
--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/element/StudioDataElements.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/element/StudioDataElements.java
@@ -69,7 +69,8 @@ public interface StudioDataElements {
                             defaultValue = "0"),
                     @StudioProperty(xmlAttribute = "maxResults", type = StudioPropertyType.INTEGER,
                             defaultValue = "0"),
-                    @StudioProperty(xmlAttribute = "readOnly", type = StudioPropertyType.BOOLEAN),
+                    @StudioProperty(xmlAttribute = "readOnly", type = StudioPropertyType.BOOLEAN,
+                            defaultValue = "false"),
                     @StudioProperty(xmlAttribute = "query", type = StudioPropertyType.JPA_QUERY)
             }
     )
@@ -91,7 +92,8 @@ public interface StudioDataElements {
                             defaultValue = "0"),
                     @StudioProperty(xmlAttribute = "cacheable", type = StudioPropertyType.BOOLEAN,
                             defaultValue = "false"),
-                    @StudioProperty(xmlAttribute = "readOnly", type = StudioPropertyType.BOOLEAN),
+                    @StudioProperty(xmlAttribute = "readOnly", type = StudioPropertyType.BOOLEAN,
+                            defaultValue = "false"),
                     @StudioProperty(xmlAttribute = "query", type = StudioPropertyType.JPA_QUERY)
             }
     )

--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/element/StudioDataElements.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/element/StudioDataElements.java
@@ -69,6 +69,7 @@ public interface StudioDataElements {
                             defaultValue = "0"),
                     @StudioProperty(xmlAttribute = "maxResults", type = StudioPropertyType.INTEGER,
                             defaultValue = "0"),
+                    @StudioProperty(xmlAttribute = "readOnly", type = StudioPropertyType.BOOLEAN),
                     @StudioProperty(xmlAttribute = "query", type = StudioPropertyType.JPA_QUERY)
             }
     )
@@ -90,6 +91,7 @@ public interface StudioDataElements {
                             defaultValue = "0"),
                     @StudioProperty(xmlAttribute = "cacheable", type = StudioPropertyType.BOOLEAN,
                             defaultValue = "false"),
+                    @StudioProperty(xmlAttribute = "readOnly", type = StudioPropertyType.BOOLEAN),
                     @StudioProperty(xmlAttribute = "query", type = StudioPropertyType.JPA_QUERY)
             }
     )

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/ViewDataXmlLoader.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/ViewDataXmlLoader.java
@@ -237,7 +237,10 @@ public class ViewDataXmlLoader {
         }
 
         InstanceLoader<Object> loader = factory.createInstanceLoader();
-        loader.setDataContext(viewData.getDataContext());
+
+        if (!Boolean.parseBoolean(element.attributeValue("readOnly"))) {
+            loader.setDataContext(viewData.getDataContextOrNull());
+        }
         loader.setContainer(container);
 
         loadAdditionalLoaderProperties(element, loader);
@@ -255,7 +258,10 @@ public class ViewDataXmlLoader {
         }
 
         CollectionLoader<Object> loader = createCollectionLoader(element);
-        loader.setDataContext(viewData.getDataContextOrNull());
+
+        if (!Boolean.parseBoolean(element.attributeValue("readOnly"))) {
+            loader.setDataContext(viewData.getDataContextOrNull());
+        }
         loader.setContainer(container);
 
         loadQuery(element, loader);

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/data.xsd
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/data.xsd
@@ -71,6 +71,7 @@
         </xs:sequence>
         <xs:attribute name="id" type="xs:string"/>
         <xs:attribute name="entityId" type="xs:string"/>
+        <xs:attribute name="readOnly" type="xs:boolean"/>
     </xs:complexType>
 
     <xs:complexType name="collectionLoaderType">
@@ -81,6 +82,7 @@
         <xs:attribute name="firstResult" type="xs:integer"/>
         <xs:attribute name="maxResults" type="xs:integer"/>
         <xs:attribute name="cacheable" type="xs:boolean"/>
+        <xs:attribute name="readOnly" type="xs:boolean"/>
     </xs:complexType>
 
 

--- a/jmix-flowui/flowui/src/test/groovy/data_components/ViewDataTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/ViewDataTest.groovy
@@ -90,10 +90,30 @@ class ViewDataTest extends DataContextSpec {
                     </loader>
                 </instance>
 
+                <instance id="userContReadOnly"
+                          class="test_support.entity.sec.User" fetchPlan="user.edit">
+                          
+                    <loader id="userLoaderReadOnly" readOnly="true">
+                        <query>
+                            select u from sec$User u where u.id = 1
+                        </query>
+                    </loader>
+                </instance>
+
                 <collection id="usersCont"
                             class="test_support.entity.sec.User" fetchPlan="user.browse">
             
                     <loader id="usersLoader">
+                        <query>
+                            select u from sec$User u
+                        </query>
+                    </loader>
+                </collection>
+                
+                <collection id="usersContReadOnly"
+                            class="test_support.entity.sec.User" fetchPlan="user.browse">
+            
+                    <loader id="usersLoaderReadOnly" readOnly="true">
                         <query>
                             select u from sec$User u
                         </query>
@@ -146,9 +166,11 @@ class ViewDataTest extends DataContextSpec {
         DataContext dataContext = viewData.dataContext
         InstanceContainer<User> userCont = viewData.getContainer('userCont')
         InstanceLoader<User> userLoader = viewData.getLoader('userLoader')
+        InstanceLoader<User> userLoaderReadOnly = viewData.getLoader('userLoaderReadOnly')
         CollectionContainer<User> usersCont = viewData.getContainer('usersCont')
         CollectionContainer<User> usersCont1 = viewData.getContainer('usersCont1')
         CollectionLoader<User> usersLoader = viewData.getLoader('usersLoader')
+        CollectionLoader<User> usersLoaderReadOnly = viewData.getLoader('usersLoaderReadOnly')
         KeyValueCollectionContainer userInfoCont = viewData.getContainer('userInfoCont')
         KeyValueCollectionLoader userInfoLoader = viewData.getLoader('userInfoLoader')
         KeyValueContainer userInfoInstanceCont = viewData.getContainer('userInfoInstanceCont')
@@ -164,6 +186,8 @@ class ViewDataTest extends DataContextSpec {
         userLoader.container == userCont
         userLoader.query == 'select u from sec$User u where u.id = 1'
 
+        userLoaderReadOnly.dataContext == null
+
         usersCont != null
         usersLoader != null
         usersCont instanceof HasLoader
@@ -174,6 +198,8 @@ class ViewDataTest extends DataContextSpec {
         usersLoader.firstResult == 0
         usersLoader.maxResults == Integer.MAX_VALUE
         !usersLoader.cacheable
+
+        usersLoaderReadOnly.dataContext == null
 
         viewData.getLoaderIds().find { String id -> viewData.getLoader(id) == usersCont1.loader } != null
 

--- a/jmix-templates/content/flowui/list-dto/descriptor.xml
+++ b/jmix-templates/content/flowui/list-dto/descriptor.xml
@@ -17,10 +17,10 @@ def tableXml = api.processSnippet('dto_table.xml',
       xmlns:c="http://jmix.io/schema/flowui/jpql-condition"
       title="${messageKeys['viewTitle']}"
       focusComponent="${tableId}">
-    <data readOnly="true">
+    <data>
         <collection id="${tableDc}"
                     class="${entity.fqn}">
-            <loader id="${tableDl}"/>
+            <loader id="${tableDl}" readOnly="true"/>
         </collection>
     </data>
     <facets>

--- a/jmix-templates/content/flowui/list/descriptor.xml
+++ b/jmix-templates/content/flowui/list/descriptor.xml
@@ -20,12 +20,12 @@ def tableXml = api.processSnippet('table.xml',
       xmlns:c="http://jmix.io/schema/flowui/jpql-condition"
       title="${messageKeys['viewTitle']}"
       focusComponent="${tableId}">
-    <data readOnly="true">
+    <data>
         <collection id="${tableDc}"
                     class="${entity.fqn}"<%if (!is_inline_listFetchPlan) {%>
         fetchPlan="${listFetchPlan.name}"<%}%>> <%if (is_inline_listFetchPlan) {%>
             ${inline_listFetchPlan}
-            <%}%><loader id="${tableDl}">
+            <%}%><loader id="${tableDl}" readOnly="true">
                 <query>
                     <![CDATA[select e from ${entity.name} e]]>
                 </query>

--- a/jmix-templates/content/project/application-kotlin/src/main/resources/${project_rootPath}/view/user/user-list-view.xml
+++ b/jmix-templates/content/project/application-kotlin/src/main/resources/${project_rootPath}/view/user/user-list-view.xml
@@ -2,11 +2,11 @@
 <view xmlns="http://jmix.io/schema/flowui/view"
       title="msg://UserListView.title"
       focusComponent="usersDataGrid">
-    <data readOnly="true">
+    <data>
         <collection id="usersDc"
                     class="${project_rootPackage}.entity.User">
             <fetchPlan extends="_base"/>
-            <loader id="usersDl">
+            <loader id="usersDl" readOnly="true">
                 <query>
                     <![CDATA[select e from ${normalizedPrefix_underscore}User e order by e.username]]>
                 </query>

--- a/jmix-templates/content/project/application/src/main/resources/${project_rootPath}/view/user/user-list-view.xml
+++ b/jmix-templates/content/project/application/src/main/resources/${project_rootPath}/view/user/user-list-view.xml
@@ -2,11 +2,11 @@
 <view xmlns="http://jmix.io/schema/flowui/view"
       title="msg://UserListView.title"
       focusComponent="usersDataGrid">
-    <data readOnly="true">
+    <data>
         <collection id="usersDc"
                     class="${project_rootPackage}.entity.User">
             <fetchPlan extends="_base"/>
-            <loader id="usersDl">
+            <loader id="usersDl" readOnly="true">
                 <query>
                     <![CDATA[select e from ${normalizedPrefix_underscore}User e order by e.username]]>
                 </query>

--- a/jmix-templates/content/snippet/flowui/optionsDsSource.xml
+++ b/jmix-templates/content/snippet/flowui/optionsDsSource.xml
@@ -4,7 +4,7 @@ def optionsDatasourceAttrs = api.evaluateScript('optionsDatasources.groovy', ['v
 <%if (optionsDatasourceAttrs) {
     optionsDatasourceAttrs.each {attr ->%>
         <collection id="${api.pluralForm(attr.name)}Dc" class="${attr.entityType.fqn}" fetchPlan="_base">
-            <loader id="${api.pluralForm(attr.name)}Dl">
+            <loader id="${api.pluralForm(attr.name)}Dl" readOnly="true">
                 <query>
                     <![CDATA[select e from ${attr.entityType.name} e]]>
                 </query>


### PR DESCRIPTION
See #2250 

The change is trivial - added `readOnly` attribute to data loaders XML. If it's set to true, the loader doesn't get a reference to DataContext and doesn't merge entities after load.

Consequences:
- We will generate `readOnly="true"` for collection loaders by default. In most cases collection containers contain read-only data (list views, option containers). Project and view templates are updated in this PR. We will create an issue for Studio to support this attribute in data container wizards.
- We don't need `<data readOnly="true">` and `NoopDataContext`, instead we'll use `readOnly="true"` for loaders. It is more clear and less error-prone. There will be one `DataContext` implementation in use, it saves everything that is merged into it. Perhaps we'll deprecate `NoopDataContext` in the future and remove `readOnly` attribute from `data` element.

See examples in https://github.com/jmix-projects/master-detail-views-prototype project.
