### PR TITLE
Ability to define theme names for layouts jmix-framework/jmix#2293

### DIFF
--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/component/StudioLayouts.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/component/StudioLayouts.java
@@ -103,6 +103,8 @@ public interface StudioLayouts {
                             defaultValue = "false"),
                     @StudioProperty(xmlAttribute = "spacing", type = StudioPropertyType.BOOLEAN,
                             defaultValue = "true"),
+                    @StudioProperty(xmlAttribute = "themeNames", type = StudioPropertyType.VALUES_LIST,
+                            options = {"spacing-xs", "spacing-s", "spacing", "spacing-l", "spacing-xl"}),
                     @StudioProperty(xmlAttribute = "visible", type = StudioPropertyType.BOOLEAN,
                             defaultValue = "true"),
                     @StudioProperty(xmlAttribute = "width", type = StudioPropertyType.SIZE)
@@ -150,6 +152,8 @@ public interface StudioLayouts {
                             defaultValue = "true"),
                     @StudioProperty(xmlAttribute = "spacing", type = StudioPropertyType.BOOLEAN,
                             defaultValue = "true"),
+                    @StudioProperty(xmlAttribute = "themeNames", type = StudioPropertyType.VALUES_LIST,
+                            options = {"spacing-xs", "spacing-s", "spacing", "spacing-l", "spacing-xl"}),
                     @StudioProperty(xmlAttribute = "visible", type = StudioPropertyType.BOOLEAN,
                             defaultValue = "true"),
                     @StudioProperty(xmlAttribute = "width", type = StudioPropertyType.SIZE, defaultValue = "100%")

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/container/AbstractLayoutLoader.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/container/AbstractLayoutLoader.java
@@ -16,9 +16,14 @@
 
 package io.jmix.flowui.xml.layout.loader.container;
 
+import com.google.common.base.Strings;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.ThemableLayout;
+import org.dom4j.Element;
+
+import java.util.Arrays;
+import java.util.List;
 
 public abstract class AbstractLayoutLoader<T extends Component & ThemableLayout & FlexComponent>
         extends AbstractContainerLoader<T> {
@@ -34,7 +39,28 @@ public abstract class AbstractLayoutLoader<T extends Component & ThemableLayout 
         componentLoader().loadThemableAttributes(resultComponent, element);
         componentLoader().loadFlexibleAttributes(resultComponent, element);
         componentLoader().loadEnabled(resultComponent, element);
+        loadThemeNames(resultComponent, element);
 
         loadSubComponentsAndExpand(resultComponent, element);
+    }
+
+    protected void loadThemeNames(ThemableLayout resultComponent, Element element) {
+        loaderSupport.loadString(element, "themeNames")
+                .ifPresent(themesString -> {
+                    List<String> themeNames = split(themesString);
+
+                    if (!themeNames.isEmpty()) {
+                        // To unset the previous default spacing value
+                        resultComponent.setSpacing(false);
+
+                        resultComponent.getThemeList().addAll(themeNames);
+                    }
+                });
+    }
+
+    protected List<String> split(String names) {
+        return Arrays.stream(names.split("[\\s,]+"))
+                .filter(split -> !Strings.isNullOrEmpty(split))
+                .toList();
     }
 }

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
@@ -1793,6 +1793,23 @@
             </xs:simpleType>
         </xs:union>
     </xs:simpleType>
+    
+    <xs:simpleType name="spacingThemeNames">
+        <xs:union>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="spacing-xs"/>
+                    <xs:enumeration value="spacing-s"/>
+                    <xs:enumeration value="spacing"/>
+                    <xs:enumeration value="spacing-l"/>
+                    <xs:enumeration value="spacing-xl"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
 
     <xs:simpleType name="timePickerThemeNames">
         <xs:union>
@@ -4316,6 +4333,7 @@
                 <xs:attribute name="visible" type="xs:boolean"/>
                 <xs:attribute name="colspan" type="xs:integer"/>
                 <xs:attribute name="css" type="xs:string"/>
+                <xs:attribute name="themeNames" type="spacingThemeNames"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/jmix-flowui/flowui/src/test/groovy/component_xml_load/ContainerXmlLoadTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component_xml_load/ContainerXmlLoadTest.groovy
@@ -61,7 +61,7 @@ class ContainerXmlLoadTest extends FlowuiTestSpecification {
             minHeight == "40px"
             minWidth == "80px"
             padding
-            spacing
+            themeList.contains("spacing-xs")
             width == "100px"
             (getChildren().find { it instanceof TypedTextField<?> } as TypedTextField<?>).id.get() == "expanded"
             (getChildren().find { it instanceof JmixButton } as JmixButton).text == "${container}Child"

--- a/jmix-flowui/flowui/src/test/resources/component_xml_load/screen/container-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component_xml_load/screen/container-view.xml
@@ -44,6 +44,7 @@
               minWidth="80px"
               padding="true"
               spacing="true"
+              themeNames="spacing-xs"
               width="100px">
             <textField id="expanded"/>
             <button text="vboxChild"/>
@@ -65,6 +66,7 @@
               minWidth="80px"
               padding="true"
               spacing="true"
+              themeNames="spacing-xs"
               width="100px">
             <textField id="expanded"/>
             <button text="hboxChild"/>


### PR DESCRIPTION
See: #2293

The `loadThemeNames(ThemableLayout, Element)` method will be moved to the `AbstractComponentLoader` class if it is needed in other places besides `AbstractLayoutLoader`. 