### PR TITLE
DataLoadCoordinator and session attribute parameters (2nd attempt)

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/QueryParamValueProvider.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/QueryParamValueProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.jmix.data;
+package io.jmix.core;
 
 import org.springframework.lang.Nullable;
 
@@ -24,8 +24,6 @@ import org.springframework.lang.Nullable;
  * For any given query parameter with an empty value, all existing {@code QueryParamValueProvider} beans are requested
  * until a provider supporting this parameter is found. You can use the {@code Order} annotation with
  * the {@code JmixOrder.HIGHEST_PRECEDENCE - 10} value to override providers of the framework.
- *
- * @see io.jmix.data.impl.SessionQueryParamValueProvider
  */
 public interface QueryParamValueProvider {
 

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/QueryParamValuesManager.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/QueryParamValuesManager.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package io.jmix.data.impl;
+package io.jmix.core.impl;
 
-import io.jmix.data.QueryParamValueProvider;
+import io.jmix.core.QueryParamValueProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -29,7 +29,7 @@ import java.util.List;
 @Component("data_QueryParamValuesManager")
 public class QueryParamValuesManager {
 
-    @Autowired
+    @Autowired(required = false)
     private List<QueryParamValueProvider> queryParamValueProviders;
 
     public boolean supports(String paramName) {

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/QueryParamValuesManager.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/QueryParamValuesManager.java
@@ -26,7 +26,7 @@ import java.util.List;
 /**
  * Encapsulates invocations of registered {@link QueryParamValueProvider}s.
  */
-@Component("data_QueryParamValuesManager")
+@Component("core_QueryParamValuesManager")
 public class QueryParamValuesManager {
 
     @Autowired(required = false)

--- a/jmix-data/data/src/main/java/io/jmix/data/impl/JpqlQueryBuilder.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/impl/JpqlQueryBuilder.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.jmix.core.*;
 import io.jmix.core.common.util.StringHelper;
+import io.jmix.core.impl.QueryParamValuesManager;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.core.querycondition.*;

--- a/jmix-data/data/src/main/java/io/jmix/data/impl/SessionQueryParamValueProvider.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/impl/SessionQueryParamValueProvider.java
@@ -18,7 +18,7 @@ package io.jmix.data.impl;
 
 import io.jmix.core.JmixOrder;
 import io.jmix.core.session.SessionData;
-import io.jmix.data.QueryParamValueProvider;
+import io.jmix.core.QueryParamValueProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.ObjectProvider;

--- a/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/JmixEclipseLinkQuery.java
+++ b/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/JmixEclipseLinkQuery.java
@@ -30,7 +30,7 @@ import io.jmix.data.*;
 import io.jmix.data.impl.EntityFetcher;
 import io.jmix.data.impl.QueryConstantHandler;
 import io.jmix.data.impl.QueryMacroHandler;
-import io.jmix.data.impl.QueryParamValuesManager;
+import io.jmix.core.impl.QueryParamValuesManager;
 import io.jmix.data.persistence.DbmsFeatures;
 import io.jmix.data.persistence.DbmsSpecifics;
 import io.jmix.eclipselink.impl.entitycache.QueryCacheManager;

--- a/jmix-data/eclipselink/src/test/java/test_support/TestQueryParamValueProvider.java
+++ b/jmix-data/eclipselink/src/test/java/test_support/TestQueryParamValueProvider.java
@@ -17,7 +17,7 @@
 package test_support;
 
 import io.jmix.core.JmixOrder;
-import io.jmix.data.QueryParamValueProvider;
+import io.jmix.core.QueryParamValueProvider;
 import org.springframework.lang.Nullable;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/impl/DataLoadCoordinatorImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/impl/DataLoadCoordinatorImpl.java
@@ -19,6 +19,7 @@ package io.jmix.flowui.facet.impl;
 import com.google.common.base.Strings;
 import com.vaadin.flow.component.Component;
 import io.jmix.core.DevelopmentException;
+import io.jmix.core.impl.QueryParamValuesManager;
 import io.jmix.core.querycondition.Condition;
 import io.jmix.core.querycondition.JpqlCondition;
 import io.jmix.core.querycondition.LogicalCondition;
@@ -54,9 +55,12 @@ public class DataLoadCoordinatorImpl extends AbstractFacet implements DataLoadCo
     protected List<Trigger> triggers = new ArrayList<>();
 
     protected ViewControllerReflectionInspector reflectionInspector;
+    private final QueryParamValuesManager queryParamValuesManager;
 
-    public DataLoadCoordinatorImpl(ViewControllerReflectionInspector reflectionInspector) {
+    public DataLoadCoordinatorImpl(ViewControllerReflectionInspector reflectionInspector,
+                                   QueryParamValuesManager queryParamValuesManager) {
         this.reflectionInspector = reflectionInspector;
+        this.queryParamValuesManager = queryParamValuesManager;
     }
 
     @Override
@@ -127,7 +131,11 @@ public class DataLoadCoordinatorImpl extends AbstractFacet implements DataLoadCo
     }
 
     protected void configureAutomatically(DataLoader loader, View<?> view) {
-        List<String> queryParameters = DataLoadersHelper.getQueryParameters(loader);
+        List<String> queryParameters = DataLoadersHelper.getQueryParameters(loader).stream()
+                .filter(paramName ->
+                        !queryParamValuesManager.supports(paramName))
+                .toList();
+
         List<String> allParameters = new ArrayList<>(queryParameters);
         allParameters.addAll(getConditionParameters(loader));
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/facet/DataLoadCoordinatorFacetProvider.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/facet/DataLoadCoordinatorFacetProvider.java
@@ -18,6 +18,7 @@ package io.jmix.flowui.xml.facet;
 
 import com.vaadin.flow.component.Component;
 import io.jmix.core.common.util.Preconditions;
+import io.jmix.core.impl.QueryParamValuesManager;
 import io.jmix.flowui.component.UiComponentUtils;
 import io.jmix.flowui.exception.GuiDevelopmentException;
 import io.jmix.flowui.facet.DataLoadCoordinator;
@@ -41,11 +42,14 @@ public class DataLoadCoordinatorFacetProvider implements FacetProvider<DataLoadC
 
     protected LoaderSupport loaderSupport;
     protected ViewControllerReflectionInspector reflectionInspector;
+    protected QueryParamValuesManager queryParamValuesManager;
 
     public DataLoadCoordinatorFacetProvider(LoaderSupport loaderSupport,
-                                            ViewControllerReflectionInspector reflectionInspector) {
+                                            ViewControllerReflectionInspector reflectionInspector,
+                                            QueryParamValuesManager queryParamValuesManager) {
         this.loaderSupport = loaderSupport;
         this.reflectionInspector = reflectionInspector;
+        this.queryParamValuesManager = queryParamValuesManager;
     }
 
     @Override
@@ -55,7 +59,7 @@ public class DataLoadCoordinatorFacetProvider implements FacetProvider<DataLoadC
 
     @Override
     public DataLoadCoordinator create() {
-        return new DataLoadCoordinatorImpl(reflectionInspector);
+        return new DataLoadCoordinatorImpl(reflectionInspector, queryParamValuesManager);
     }
 
     @Override

--- a/jmix-flowui/flowui/src/test/groovy/facet/data_load_coordinator/DataLoadCoordinatorFacetTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/facet/data_load_coordinator/DataLoadCoordinatorFacetTest.groovy
@@ -16,6 +16,7 @@
 
 package facet.data_load_coordinator
 
+import facet.data_load_coordinator.screen.DlcAutoProvidedParamTestScreen
 import facet.data_load_coordinator.screen.DlcAutoTestScreen
 import facet.data_load_coordinator.screen.DlcManualNoParamTestScreen
 import facet.data_load_coordinator.screen.DlcManualTestScreen
@@ -98,10 +99,11 @@ class DataLoadCoordinatorFacetTest extends FlowuiTestSpecification {
         screenClass << [DlcManualTestScreen, DlcManualNoParamTestScreen]
     }
 
+    @Unroll
     def "auto configuration"() {
         when: "show screen"
 
-        def screen = navigateToView(DlcAutoTestScreen)
+        def screen = navigateToView(screenClass)
         def screenFacets = ViewControllerUtils.getViewFacets(screen);
 
         then: "facet is created and injected"
@@ -150,5 +152,9 @@ class DataLoadCoordinatorFacetTest extends FlowuiTestSpecification {
         screen.events.size() == 1
         screen.events[0].loader == 'ownersDl'
         screen.events[0].loadContext.query.parameters['component_nameFilterField'] == '(?i)%o%'
+
+        where:
+
+        screenClass << [DlcAutoTestScreen, DlcAutoProvidedParamTestScreen]
     }
 }

--- a/jmix-flowui/flowui/src/test/java/facet/data_load_coordinator/screen/DlcAutoProvidedParamTestScreen.java
+++ b/jmix-flowui/flowui/src/test/java/facet/data_load_coordinator/screen/DlcAutoProvidedParamTestScreen.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package facet.data_load_coordinator.screen;
+
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+
+@Route(value = "facet/dlc/dlc-auto-provided")
+@ViewController
+@ViewDescriptor("dlc-auto-provided-param-screen.xml")
+public class DlcAutoProvidedParamTestScreen extends DlcBaseTestScreen {
+}

--- a/jmix-flowui/flowui/src/test/resources/facet/data_load_coordinator/screen/dlc-auto-provided-param-screen.xml
+++ b/jmix-flowui/flowui/src/test/resources/facet/data_load_coordinator/screen/dlc-auto-provided-param-screen.xml
@@ -1,0 +1,54 @@
+<!--
+  ~ Copyright (c) 2023 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view"
+      xmlns:c="http://jmix.io/schema/flowui/jpql-condition"
+      title="Owners">
+    <data readOnly="true">
+        <collection id="ownersDc"
+                    class="test_support.entity.petclinic.Owner">
+            <fetchPlan extends="_base"/>
+            <loader id="ownersDl">
+                <query>
+                    <![CDATA[select e from pc_Owner e where e.email = :session_ownerEmail]]>
+                    <condition>
+                        <and>
+                            <c:jpql>
+                                <c:where>e.category = :component_categoryFilterField</c:where>
+                            </c:jpql>
+                            <c:jpql>
+                                <c:where>e.name like :component_nameFilterField</c:where>
+                            </c:jpql>
+                        </and>
+                    </condition>
+                </query>
+            </loader>
+        </collection>
+        <collection id="petsDc" class="test_support.entity.petclinic.Pet">
+            <loader id="petsDl">
+                <query><![CDATA[select e from pc_Pet e where e.owner = :container_ownersDc
+                and e.name = :session_petName]]></query>
+            </loader>
+        </collection>
+    </data>
+    <facets>
+        <dataLoadCoordinator id="dlc" auto="true"/>
+    </facets>
+    <layout>
+        <entityPicker id="categoryFilterField" metaClass="pc_OwnerCategory"/>
+        <textField id="nameFilterField"/>
+    </layout>
+</view>

--- a/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/CurrentUserQueryParamValueProvider.java
+++ b/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/CurrentUserQueryParamValueProvider.java
@@ -18,7 +18,7 @@ package io.jmix.securitydata.impl;
 
 import io.jmix.core.JmixOrder;
 import io.jmix.core.usersubstitution.CurrentUserSubstitution;
-import io.jmix.data.QueryParamValueProvider;
+import io.jmix.core.QueryParamValueProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.core.userdetails.UserDetails;


### PR DESCRIPTION
Moved `QueryParamValueProvider` and `QueryParamValuesManager` to core. 
Now `QueryParamValuesManager` is used in `DataLoadCoordinatorImpl#configureAutomatically()` to filter out parameters that are provided by a `QueryParamValueProvider` .