### PR TITLE
Support Items fetch callback (improvements)

### DIFF
--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/element/StudioElements.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/element/StudioElements.java
@@ -587,7 +587,8 @@ public interface StudioElements {
             properties = {
                     @StudioProperty(xmlAttribute = "searchStringFormat", type = StudioPropertyType.STRING),
                     @StudioProperty(xmlAttribute = "escapeValueForLike", type = StudioPropertyType.BOOLEAN,
-                            defaultValue = "false")
+                            defaultValue = "false"),
+                    @StudioProperty(xmlAttribute = "query", type = StudioPropertyType.JPA_QUERY)
             }
     )
     void valueItemsQuery();
@@ -607,6 +608,7 @@ public interface StudioElements {
                     @StudioProperty(xmlAttribute = "searchStringFormat", type = StudioPropertyType.STRING),
                     @StudioProperty(xmlAttribute = "escapeValueForLike", type = StudioPropertyType.BOOLEAN,
                             defaultValue = "false"),
+                    @StudioProperty(xmlAttribute = "query", type = StudioPropertyType.JPA_QUERY),
                     @StudioProperty(xmlAttribute = "fetchPlan", type = StudioPropertyType.FETCH_PLAN)
             }
     )
@@ -629,6 +631,7 @@ public interface StudioElements {
                     @StudioProperty(xmlAttribute = "searchStringFormat", type = StudioPropertyType.STRING),
                     @StudioProperty(xmlAttribute = "escapeValueForLike", type = StudioPropertyType.BOOLEAN,
                             defaultValue = "false"),
+                    @StudioProperty(xmlAttribute = "query", type = StudioPropertyType.JPA_QUERY),
                     @StudioProperty(xmlAttribute = "fetchPlan", type = StudioPropertyType.FETCH_PLAN)
             }
     )

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/support/DataLoaderSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/support/DataLoaderSupport.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.data.provider.Query;
 import io.jmix.core.*;
 import io.jmix.core.common.util.ParamsMap;
 import io.jmix.core.common.util.ReflectionHelper;
+import io.jmix.core.impl.FetchPlanLoader;
 import io.jmix.flowui.component.SupportsItemsFetchCallback;
 import io.jmix.flowui.data.SupportsItemsContainer;
 import io.jmix.flowui.data.SupportsItemsEnum;
@@ -61,6 +62,9 @@ public class DataLoaderSupport implements ApplicationContextAware {
     protected LoaderResolver loaderResolver;
     protected ClassManager classManager;
     protected LoaderSupport loaderSupport;
+    protected Metadata metadata;
+    protected FetchPlanLoader fetchPlanLoader;
+    protected FetchPlanRepository fetchPlanRepository;
 
     public DataLoaderSupport(Context context) {
         this.context = context;
@@ -84,6 +88,21 @@ public class DataLoaderSupport implements ApplicationContextAware {
     @Autowired
     public void setLoaderSupport(LoaderSupport loaderSupport) {
         this.loaderSupport = loaderSupport;
+    }
+
+    @Autowired
+    public void setMetadata(Metadata metadata) {
+        this.metadata = metadata;
+    }
+
+    @Autowired
+    public void setFetchPlanLoader(FetchPlanLoader fetchPlanLoader) {
+        this.fetchPlanLoader = fetchPlanLoader;
+    }
+
+    @Autowired
+    public void setFetchPlanRepository(FetchPlanRepository fetchPlanRepository) {
+        this.fetchPlanRepository = fetchPlanRepository;
     }
 
     public void loadData(SupportsValueSource<?> component, Element element) {
@@ -178,7 +197,7 @@ public class DataLoaderSupport implements ApplicationContextAware {
     @SuppressWarnings({"rawtypes", "unchecked"})
     protected void loadEntityItemsQueryInternal(SupportsItemsFetchCallback<?, String> component,
                                                 Element itemsElement, Class<?> entityClass) {
-        String queryString = itemsElement.getStringValue();
+        String queryString = loadQuery((Component) component, itemsElement);
         String searchStringFormat = loadSearchStringFormat(itemsElement);
         boolean escapeValue = loadEscapeValueForLike(itemsElement);
 
@@ -220,7 +239,7 @@ public class DataLoaderSupport implements ApplicationContextAware {
 
     protected void loadValueItemsQueryInternal(SupportsItemsFetchCallback<?, String> component,
                                                Element itemsElement) {
-        String queryString = itemsElement.getStringValue();
+        String queryString = loadQuery((Component) component, itemsElement);
         String searchStringFormat = loadSearchStringFormat(itemsElement);
         boolean escapeValue = loadEscapeValueForLike(itemsElement);
 
@@ -238,6 +257,17 @@ public class DataLoaderSupport implements ApplicationContextAware {
         });
     }
 
+    protected String loadQuery(Component component, Element itemsElement) {
+        Element queryElement = itemsElement.element("query");
+        if (queryElement == null) {
+            throw new GuiDevelopmentException(String.format("Nested 'query' element is missing " +
+                            "for '%s' element in component %s.",
+                    ITEMS_QUERY_ELEMENT, ((Component) component).getId()), getComponentContext());
+        }
+
+        return queryElement.getStringValue();
+    }
+
     @Nullable
     protected String loadSearchStringFormat(Element itemsElement) {
         return loaderSupport
@@ -253,12 +283,29 @@ public class DataLoaderSupport implements ApplicationContextAware {
 
     @Nullable
     protected FetchPlan loadFetchPlan(Element itemsElement, Class<?> entityClass) {
+        Element fetchPlanElement = itemsElement.element("fetchPlan");
+        if (fetchPlanElement != null) {
+            return loadInlineFetchPlan(fetchPlanElement, entityClass);
+        }
+
         return loaderSupport.loadString(itemsElement, "fetchPlan")
-                .map(fetchPlanName -> {
-                    FetchPlanRepository fetchPlanRepository = applicationContext.getBean(FetchPlanRepository.class);
-                    return fetchPlanRepository.getFetchPlan(entityClass, fetchPlanName);
-                })
+                .map(fetchPlanName ->
+                        fetchPlanRepository.getFetchPlan(entityClass, fetchPlanName))
                 .orElse(null);
+    }
+
+    protected FetchPlan loadInlineFetchPlan(Element fetchPlanElement, Class<?> entityClass) {
+        FetchPlanLoader.FetchPlanInfo fetchPlanInfo = fetchPlanLoader
+                .getFetchPlanInfo(fetchPlanElement, metadata.getClass(entityClass));
+
+        FetchPlanBuilder builder = fetchPlanLoader.getFetchPlanBuilder(fetchPlanInfo, name ->
+                fetchPlanRepository.getFetchPlan(fetchPlanInfo.getMetaClass(), name));
+
+        fetchPlanLoader.loadFetchPlanProperties(fetchPlanElement, builder,
+                fetchPlanInfo.isSystemProperties(), (metaClass, fetchPlanName) ->
+                        fetchPlanRepository.getFetchPlan(metaClass, fetchPlanName));
+
+        return builder.build();
     }
 
     protected String getSearchString(Query<?, String> query,
@@ -270,7 +317,7 @@ public class DataLoaderSupport implements ApplicationContextAware {
 
         if (!Strings.isNullOrEmpty(searchStringFormat)) {
             StringSubstitutor substitutor = applicationContext.getBean(StringSubstitutor.class);
-            searchString = substitutor.substitute(searchStringFormat, ParamsMap.of("searchString", searchString));
+            searchString = substitutor.substitute(searchStringFormat, ParamsMap.of("inputString", searchString));
         }
 
         return searchString;

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
@@ -2517,37 +2517,67 @@
     </xs:group>
 
     <xs:complexType name="baseComboBoxItemsQueryType">
-        <xs:simpleContent>
-            <xs:extension base="xs:string">
-                <xs:attribute name="searchStringFormat" type="xs:string"/>
-                <xs:attribute name="escapeValueForLike" type="xs:boolean"/>
-            </xs:extension>
-        </xs:simpleContent>
+        <xs:sequence>
+            <xs:element name="query"/>
+        </xs:sequence>
+        <xs:attribute name="searchStringFormat" type="xs:string"/>
+        <xs:attribute name="escapeValueForLike" type="xs:boolean"/>
     </xs:complexType>
 
     <xs:complexType name="comboBoxItemsQueryType">
-        <xs:simpleContent>
+        <xs:complexContent>
             <xs:extension base="baseComboBoxItemsQueryType"/>
-        </xs:simpleContent>
+        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="entityComboBoxItemsQueryType">
-        <xs:simpleContent>
+        <xs:complexContent>
             <xs:extension base="baseComboBoxItemsQueryType">
+                <xs:sequence>
+                    <xs:element name="fetchPlan" type="itemsQueryFetchPlanType" minOccurs="0"/>
+                </xs:sequence>
                 <xs:attribute name="class" type="xs:string" use="required"/>
                 <xs:attribute name="fetchPlan" type="xs:string"/>
             </xs:extension>
-        </xs:simpleContent>
+        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="multiSelectComboBoxItemsQueryType">
-        <xs:simpleContent>
+        <xs:complexContent>
             <xs:extension base="baseComboBoxItemsQueryType">
+                <xs:sequence>
+                    <xs:element name="fetchPlan" type="itemsQueryFetchPlanType" minOccurs="0"/>
+                </xs:sequence>
                 <xs:attribute name="class" type="xs:string"/>
                 <xs:attribute name="fetchPlan" type="xs:string"/>
             </xs:extension>
-        </xs:simpleContent>
+        </xs:complexContent>
     </xs:complexType>
+
+    <xs:complexType name="itemsQueryFetchPlanType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="itemsQueryFetchPlanPropertyType"/>
+        </xs:sequence>
+        <xs:attribute name="extends"/>
+    </xs:complexType>
+
+    <xs:complexType name="itemsQueryFetchPlanPropertyType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property" type="itemsQueryFetchPlanPropertyType"/>
+        </xs:sequence>
+        <xs:attribute name="name"/>
+        <xs:attribute name="fetchPlan"/>
+        <xs:attribute name="fetch" type="itemsQueryFetchPlanFetchMode"/>
+    </xs:complexType>
+
+    <xs:simpleType name="itemsQueryFetchPlanFetchMode">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="AUTO"/>
+            <xs:enumeration value="UNDEFINED"/>
+            <xs:enumeration value="JOIN"/>
+            <xs:enumeration value="BATCH"/>
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="gridAggregationType">
         <xs:choice minOccurs="0">


### PR DESCRIPTION
Improvements for https://github.com/jmix-framework/jmix/issues/1923

Changed:
* `searchStringFormat` attribute assumes `inputString` as a value placeholder instead of `searchString`

Added: 
* Nested `query` element, similar to data loaders
* Nested `fetchPlan` element that defines inline fetch plan, similar to data containers

Note: the `fetchPlan` attribute is still present and defines named fetch plan, same as for data containers