### PR TITLE
 Equals and hashcode aren't defined in io.jmix.data.Sequence

### DIFF
--- a/jmix-data/data/src/main/java/io/jmix/data/Sequence.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/Sequence.java
@@ -16,6 +16,8 @@
 
 package io.jmix.data;
 
+import java.util.Objects;
+
 /**
  * Represents sequence with name, store, start value and increment.
  * Default data store for sequence is MAIN data store.
@@ -64,5 +66,22 @@ public class Sequence {
 
     public long getIncrement() {
         return increment;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Sequence sequence = (Sequence) o;
+        return Objects.equals(name, sequence.name) && Objects.equals(dataStore, sequence.dataStore);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, dataStore);
     }
 }


### PR DESCRIPTION
Added a way (equals and hashcode) to compare two objects of Sequence type

Issue - [1497](https://github.com/jmix-framework/jmix/issues/1497)