### PR TITLE
add includeProperties options to filter

### DIFF
--- a/jmix-ui/ui/src/main/java/io/jmix/ui/UiComponentProperties.java
+++ b/jmix-ui/ui/src/main/java/io/jmix/ui/UiComponentProperties.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -137,6 +138,12 @@ public class UiComponentProperties {
      */
     boolean filterConfigurationUniqueNamesEnabled;
 
+
+    /**
+     * The list of properties that should be considered "system properties" when using the includeProperties attribute with a filter
+     */
+    List<String> filterIncludedSystemProperties;
+
     public UiComponentProperties(
             @DefaultValue("true") boolean htmlSanitizerEnabled,
             @DefaultValue("20") int uploadFieldMaxUploadSizeMb,
@@ -165,7 +172,8 @@ public class UiComponentProperties {
             @DefaultValue("2") int filterPropertiesHierarchyDepth,
             @DefaultValue("3") int filterColumnsCount,
             @DefaultValue("false") boolean filterShowConfigurationIdField,
-            @DefaultValue("true") boolean filterConfigurationUniqueNamesEnabled
+            @DefaultValue("true") boolean filterConfigurationUniqueNamesEnabled,
+            @DefaultValue("id,version,createTs,createdBy,createdBy,createdDate,updateTs,updatedBy,lastModifiedBy,lastModifiedDate,deleteTs,deletedBy,deletedBy,deletedDate") String filterIncludedSystemProperties
     ) {
         this.htmlSanitizerEnabled = htmlSanitizerEnabled;
         this.uploadFieldMaxUploadSizeMb = uploadFieldMaxUploadSizeMb;
@@ -195,6 +203,7 @@ public class UiComponentProperties {
         this.filterColumnsCount = filterColumnsCount;
         this.filterShowConfigurationIdField = filterShowConfigurationIdField;
         this.filterConfigurationUniqueNamesEnabled = filterConfigurationUniqueNamesEnabled;
+        this.filterIncludedSystemProperties = Arrays.asList(filterIncludedSystemProperties.replace(" ","").split(","));
     }
 
     public int getUploadFieldMaxUploadSizeMb() {
@@ -349,5 +358,12 @@ public class UiComponentProperties {
      */
     public boolean isFilterConfigurationUniqueNamesEnabled() {
         return filterConfigurationUniqueNamesEnabled;
+    }
+
+    /**
+     * @see #filterIncludedSystemProperties
+     */
+    public List<String> getFilterIncludedSystemProperties() {
+        return filterIncludedSystemProperties;
     }
 }

--- a/jmix-ui/ui/src/main/java/io/jmix/ui/UiProperties.java
+++ b/jmix-ui/ui/src/main/java/io/jmix/ui/UiProperties.java
@@ -22,6 +22,7 @@ import org.springframework.boot.context.properties.ConstructorBinding;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/jmix-ui/ui/src/main/java/io/jmix/ui/component/filter/FilterMetadataTools.java
+++ b/jmix-ui/ui/src/main/java/io/jmix/ui/component/filter/FilterMetadataTools.java
@@ -169,6 +169,7 @@ public class FilterMetadataTools {
         // parse the first string to determine if child attributes should be included.
         boolean addNonSystemChildren = false;
         boolean addSystemChildren = false;
+        boolean isClass = false;
         if (first.equals("*")) {
             addNonSystemChildren = true;
             addSystemChildren = true;
@@ -196,6 +197,7 @@ public class FilterMetadataTools {
         // get the next node to traverse by either finding an existing one, or creating a new node
         if (first.isEmpty()) {
             nextNode = parentNode;
+            isClass = true;
         } else {
             int indexOfFirst = nodeChildrenContainsElement(parentNode, first);
 
@@ -214,6 +216,7 @@ public class FilterMetadataTools {
             MetaProperty metaProperty = mpp.getMetaProperty();
 
             if (metaProperty.getRange().isClass()) {
+                isClass = true;
                 if (metadataTools.getCrossDataStoreReferenceIdProperty(metaProperty.getStore().getName(), metaProperty) == null)
                 {
                     childClass = metaProperty.getRange().asClass();
@@ -221,7 +224,9 @@ public class FilterMetadataTools {
             }
         }
 
-        recursivelyAddPropertyToIncludedPropertiesTree(filterMetaClass, nextNode, rest, childClass, query);
+        if(isClass) {
+            recursivelyAddPropertyToIncludedPropertiesTree(filterMetaClass, nextNode, rest, childClass, query);
+        }
     }
 
     private <T extends Object> int nodeChildrenContainsElement(Node<T> parentNode, T object) {

--- a/jmix-ui/ui/src/main/java/io/jmix/ui/component/filter/inspector/FilterPropertiesInspector.java
+++ b/jmix-ui/ui/src/main/java/io/jmix/ui/component/filter/inspector/FilterPropertiesInspector.java
@@ -28,6 +28,7 @@ public class FilterPropertiesInspector implements Predicate<MetaPropertyPath> {
     protected String includedPropertiesRegexp = ".*";
     protected String excludedPropertiesRegexp = "";
     protected List<String> excludedProperties = new ArrayList<>();
+    protected List<String> includedProperties = new ArrayList<>();
     protected boolean excludeRecursively;
 
     public FilterPropertiesInspector() {
@@ -47,6 +48,14 @@ public class FilterPropertiesInspector implements Predicate<MetaPropertyPath> {
 
     public void setExcludedPropertiesRegexp(String excludedPropertiesRegexp) {
         this.excludedPropertiesRegexp = excludedPropertiesRegexp;
+    }
+
+    public List<String> getIncludedProperties() {
+        return includedProperties;
+    }
+
+    public void setIncludedProperties(List<String> includedProperties) {
+        this.includedProperties = includedProperties;
     }
 
     public List<String> getExcludedProperties() {

--- a/jmix-ui/ui/src/main/java/io/jmix/ui/xml/layout/loader/FilterLoader.java
+++ b/jmix-ui/ui/src/main/java/io/jmix/ui/xml/layout/loader/FilterLoader.java
@@ -129,6 +129,11 @@ public class FilterLoader extends ActionsHolderLoader<Filter> {
                         Arrays.asList(excludePropertiesString.replace(" ", "").split(","));
                 propertiesInspector.setExcludedProperties(excludeProperties);
             });
+            loadString(propertiesElement, "includeProperties", includePropertiesString -> {
+                List<String> includeProperties =
+                        Arrays.asList(includePropertiesString.replace(" ", "").split(","));
+                propertiesInspector.setIncludedProperties(includeProperties);
+            });
             loadBoolean(propertiesElement, "excludeRecursively",
                     propertiesInspector::setExcludeRecursively);
 

--- a/jmix-ui/ui/src/main/resources/io/jmix/ui/screen/layout.xsd
+++ b/jmix-ui/ui/src/main/resources/io/jmix/ui/screen/layout.xsd
@@ -4234,6 +4234,7 @@
                     <xs:element name="properties" minOccurs="0">
                         <xs:complexType>
                             <xs:attribute name="include" type="xs:string" use="required"/>
+                            <xs:attribute name="includeProperties" type="xs:string"/>
                             <xs:attribute name="exclude" type="xs:string"/>
                             <xs:attribute name="excludeProperties" type="xs:string"/>
                             <xs:attribute name="excludeRecursively" type="xs:boolean"/>


### PR DESCRIPTION
Adds the ability to explicitly include properties into the Add Condition screen of the filter as described in [#419](https://github.com/jmix-framework/jmix/issues/419)