### PR TITLE
Fix that the name in the generated Code field does not start with a capital letter

### DIFF
--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
@@ -80,6 +80,7 @@ import io.jmix.flowui.sys.ViewSupport;
 import io.jmix.flowui.view.*;
 import io.jmix.flowui.view.builder.LookupWindowBuilder;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.CaseUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
@@ -888,14 +889,19 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
         if (Strings.isNullOrEmpty(attribute.getCode()) && !Strings.isNullOrEmpty(attribute.getName())) {
             String categoryName = StringUtils.EMPTY;
             if (attribute.getCategory() != null) {
-                categoryName = attribute.getCategory().getName();
+                categoryName = StringUtils.defaultString(attribute.getCategory().getName());
             }
-            // `org.springframework.util.StringUtils::hasText` simplifies expression `isNotEmpty && isNotBlank` into one `hasText`
-            String fullAttributeCode = org.springframework.util.StringUtils.hasText(categoryName) ?
-                    StringUtils.uncapitalize(categoryName) + StringUtils.capitalize(attribute.getName()) :
-                    StringUtils.uncapitalize(attribute.getName());
+            char[] delimiters = {' ', '.', '_', '-', '\t'};
 
-            codeField.setValue(StringUtils.deleteWhitespace(fullAttributeCode));
+            String categoryNameInCamelCaseUncapitalized = CaseUtils.toCamelCase(categoryName, false, delimiters);
+            String attributeNameInCamelCaseUncapitalized = CaseUtils.toCamelCase(attribute.getName(), false, delimiters);
+
+            // `org.springframework.util.StringUtils::hasText` simplifies expression `isNotEmpty && isNotBlank` into one `hasText`
+            String resultCodeName = org.springframework.util.StringUtils.hasText(categoryNameInCamelCaseUncapitalized) ?
+                    categoryNameInCamelCaseUncapitalized + StringUtils.capitalize(attributeNameInCamelCaseUncapitalized) :
+                    attributeNameInCamelCaseUncapitalized;
+
+            codeField.setValue(resultCodeName);
         }
     }
 

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
@@ -888,9 +888,14 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
         if (Strings.isNullOrEmpty(attribute.getCode()) && !Strings.isNullOrEmpty(attribute.getName())) {
             String categoryName = StringUtils.EMPTY;
             if (attribute.getCategory() != null) {
-                categoryName = StringUtils.defaultString(attribute.getCategory().getName());
+                categoryName = attribute.getCategory().getName();
             }
-            codeField.setValue(StringUtils.deleteWhitespace(categoryName + attribute.getName()));
+            // `org.springframework.util.StringUtils::hasText` simplifies expression `isNotEmpty && isNotBlank` into one `hasText`
+            String fullAttributeCode = org.springframework.util.StringUtils.hasText(categoryName) ?
+                    categoryName  + "_" + attribute.getName() :
+                    attribute.getName();
+
+            codeField.setValue(StringUtils.deleteWhitespace(fullAttributeCode));
         }
     }
 

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
@@ -892,8 +892,8 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
             }
             // `org.springframework.util.StringUtils::hasText` simplifies expression `isNotEmpty && isNotBlank` into one `hasText`
             String fullAttributeCode = org.springframework.util.StringUtils.hasText(categoryName) ?
-                    categoryName  + "_" + attribute.getName() :
-                    attribute.getName();
+                    StringUtils.uncapitalize(categoryName) + StringUtils.capitalize(attribute.getName()) :
+                    StringUtils.uncapitalize(attribute.getName());
 
             codeField.setValue(StringUtils.deleteWhitespace(fullAttributeCode));
         }

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
@@ -896,8 +896,7 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
             String categoryNameInCamelCaseUncapitalized = CaseUtils.toCamelCase(categoryName, false, delimiters);
             String attributeNameInCamelCaseUncapitalized = CaseUtils.toCamelCase(attribute.getName(), false, delimiters);
 
-            // `org.springframework.util.StringUtils::hasText` simplifies expression `isNotEmpty && isNotBlank` into one `hasText`
-            String resultCodeName = org.springframework.util.StringUtils.hasText(categoryNameInCamelCaseUncapitalized) ?
+            String resultCodeName = Strings.isNullOrEmpty(categoryNameInCamelCaseUncapitalized) ?
                     categoryNameInCamelCaseUncapitalized + StringUtils.capitalize(attributeNameInCamelCaseUncapitalized) :
                     attributeNameInCamelCaseUncapitalized;
 


### PR DESCRIPTION
I choose to concate category name and attribute name by **_** instead of trying to predict which case user chose for name:
samples:
1. How to concate when category name is FULLUPPERCASE or fULLCASEWITHUNDERCUT
2. Same as first but for attribute name

Besides, we can do not change names and just concate both with "_" and we will prevent any misunderstood cases

Advantages:
1. We will not take any responsibility of name changing
2. More understandable name-code (if names contains more then one word / contains same words => mass of camelcase)
3. Real word split and user always sees what category he uses (+SomeCategory_SomeName)

![image](https://github.com/jmix-framework/jmix/assets/43281522/e472379d-dab0-474a-be96-5a54300761e1)
![image](https://github.com/jmix-framework/jmix/assets/43281522/9aeee658-5986-445c-bac2-ad47bf3f9392)

