### PR TITLE
Uniform handling of JPA and DTO entities in standard list/detail views

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/EntityStates.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/EntityStates.java
@@ -61,9 +61,9 @@ public class EntityStates {
      * Determines whether the instance is <em>New</em>, i.e. just created and not stored in database yet.
      *
      * @param entity entity instance
-     * @return - true if the instance is a new persistent entity, or if it is actually in Managed state
+     * @return - true if the instance is a new JPA entity, or if it is actually in Managed state
      * but newly-persisted in this transaction <br>
-     * - true if the instance is a new non-persistent entity never returned from DataManager <br>
+     * - true if the instance is not a JPA entity <br>
      * - false otherwise
      * @throws IllegalArgumentException if entity instance is null
      */
@@ -85,7 +85,7 @@ public class EntityStates {
      *
      * @param entity entity instance
      * @return - true if the instance is managed,<br>
-     * - false if it is New (and not yet persisted) or Detached, or if it is not a persistent entity
+     * - false if it is New (and not yet persisted) or Detached, or if it is not a JPA entity
      * @throws IllegalArgumentException if entity instance is null
      */
     public boolean isManaged(Object entity) {
@@ -107,7 +107,7 @@ public class EntityStates {
      *
      * @param entity entity instance
      * @return - true if the instance is detached,<br>
-     * - false if it is New or Managed, or if it is not a persistent entity
+     * - false if it is New or Managed, or if it is not a JPA entity
      * @throws IllegalArgumentException if entity instance is null
      */
     public boolean isDetached(Object entity) {
@@ -374,7 +374,19 @@ public class EntityStates {
     }
 
     /**
-     * Makes a newly constructed object detached. The detached object can be passed to {@code DataManager.commit()} or
+     * Manages the <em>New</em> state of the entity instance.
+     *
+     * @see #isNew(Object)
+     */
+    public void setNew(Object entity, boolean isNew) {
+        checkNotNullArgument(entity, "entity is null");
+        EntityPreconditions.checkEntityType(entity);
+
+        getUncheckedEntityEntry(entity).setNew(isNew);
+    }
+
+    /**
+     * Makes a newly constructed object detached. The detached object can be passed to {@code DataManager.save()} or
      * to {@code EntityManager.merge()} to save its state to the database.
      * <p>If an object with such ID does not exist in the database, a new object will be inserted.
      * <p>If the entity is {@code Versioned}, the version attribute should be equal to the latest version existing in

--- a/jmix-data/eclipselink/src/test/java/test_support/entity/dto/TestNullableIdDto.java
+++ b/jmix-data/eclipselink/src/test/java/test_support/entity/dto/TestNullableIdDto.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.dto;
+
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.core.metamodel.annotation.JmixProperty;
+
+@JmixEntity
+public class TestNullableIdDto {
+
+    @JmixId
+    protected Long id;
+
+    @JmixProperty
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jmix-data/eclipselink/src/test/java/test_support/entity/dto/TestUuidDto.java
+++ b/jmix-data/eclipselink/src/test/java/test_support/entity/dto/TestUuidDto.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.dto;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.core.metamodel.annotation.JmixProperty;
+
+import java.util.UUID;
+
+@JmixEntity
+public class TestUuidDto {
+
+    @JmixId
+    @JmixGeneratedValue
+    protected UUID id;
+
+    @JmixProperty
+    private String name;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/action/list/RemoveAction.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/action/list/RemoveAction.java
@@ -37,6 +37,8 @@ import io.jmix.flowui.util.RemoveOperation.AfterActionPerformedEvent;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import org.springframework.lang.Nullable;
+
+import java.util.Collection;
 import java.util.function.Consumer;
 
 @ActionType(RemoveAction.ID)
@@ -52,6 +54,7 @@ public class RemoveAction<E> extends SecuredListDataComponentAction<RemoveAction
     protected String confirmationHeader;
     protected Consumer<AfterActionPerformedEvent<E>> afterActionPerformedHandler;
     protected Consumer<ActionCancelledEvent<E>> actionCancelledHandler;
+    protected Consumer<Collection<E>> delegate;
 
     public RemoveAction() {
         this(ID);
@@ -146,6 +149,13 @@ public class RemoveAction<E> extends SecuredListDataComponentAction<RemoveAction
         this.actionCancelledHandler = actionCancelledHandler;
     }
 
+    /**
+     * Sets the delegate to be invoked instead of DataManager to remove the entities from a storage.
+     */
+    public void setDelegate(@Nullable Consumer<Collection<E>> delegate) {
+        this.delegate = delegate;
+    }
+
     @Override
     protected boolean isPermitted() {
         return checkRemovePermission() && super.isPermitted();
@@ -213,6 +223,10 @@ public class RemoveAction<E> extends SecuredListDataComponentAction<RemoveAction
 
         if (actionCancelledHandler != null) {
             builder = builder.onCancel(actionCancelledHandler);
+        }
+
+        if (delegate != null) {
+            builder = builder.withRemoveDelegate(delegate);
         }
 
         builder.remove();

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/CollectionLoaderImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/CollectionLoaderImpl.java
@@ -96,6 +96,9 @@ public class CollectionLoaderImpl<E> implements CollectionLoader<E> {
             list = dataManager.loadList(loadContext);
         } else {
             list = delegate.apply(loadContext);
+            if (list == null) {
+                return false;
+            }
         }
 
         if (dataContext != null) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/InstanceLoaderImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/InstanceLoaderImpl.java
@@ -77,10 +77,10 @@ public class InstanceLoaderImpl<E> implements InstanceLoader<E> {
 
         LoadContext<E> loadContext = createLoadContext();
 
-        if (delegate == null) {
-            if (!needLoad())
-                return;
+        if (!needLoad())
+            return;
 
+        if (delegate == null) {
             if (!sendPreLoadEvent(loadContext)) {
                 return;
             }
@@ -95,6 +95,9 @@ public class InstanceLoaderImpl<E> implements InstanceLoader<E> {
                 return;
             }
             entity = delegate.apply(createLoadContext());
+            if (entity == null) {
+                return;
+            }
         }
 
         if (dataContext != null) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/KeyValueCollectionLoaderImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/KeyValueCollectionLoaderImpl.java
@@ -84,6 +84,9 @@ public class KeyValueCollectionLoaderImpl implements KeyValueCollectionLoader {
             list = dataManager.loadValues(loadContext);
         } else {
             list = delegate.apply(loadContext);
+            if (list == null) {
+                return;
+            }
         }
 
         if (dataContext != null) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/KeyValueInstanceLoaderImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/KeyValueInstanceLoaderImpl.java
@@ -86,6 +86,9 @@ public class KeyValueInstanceLoaderImpl implements KeyValueInstanceLoader {
             }
         } else {
             result = delegate.apply(loadContext);
+            if (result == null) {
+                return;
+            }
         }
 
         container.setItem(result);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
@@ -26,14 +26,7 @@ import com.vaadin.flow.router.BeforeLeaveEvent;
 import com.vaadin.flow.router.BeforeLeaveEvent.ContinueNavigationAction;
 import com.vaadin.flow.router.Location;
 import com.vaadin.flow.shared.Registration;
-import io.jmix.core.AccessManager;
-import io.jmix.core.EntitySet;
-import io.jmix.core.EntityStates;
-import io.jmix.core.InstanceNameProvider;
-import io.jmix.core.MessageTools;
-import io.jmix.core.Messages;
-import io.jmix.core.Metadata;
-import io.jmix.core.MetadataTools;
+import io.jmix.core.*;
 import io.jmix.core.accesscontext.InMemoryCrudEntityContext;
 import io.jmix.core.annotation.Internal;
 import io.jmix.core.common.util.Preconditions;
@@ -43,16 +36,9 @@ import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.flowui.Notifications;
 import io.jmix.flowui.UiViewProperties;
 import io.jmix.flowui.accesscontext.UiEntityContext;
-import io.jmix.flowui.action.list.EditAction;
 import io.jmix.flowui.component.validation.ValidationErrors;
 import io.jmix.flowui.component.validation.group.UiCrossFieldChecks;
-import io.jmix.flowui.exception.GuiDevelopmentException;
-import io.jmix.flowui.model.DataContext;
-import io.jmix.flowui.model.DataLoader;
-import io.jmix.flowui.model.HasLoader;
-import io.jmix.flowui.model.InstanceContainer;
-import io.jmix.flowui.model.InstanceLoader;
-import io.jmix.flowui.model.ViewData;
+import io.jmix.flowui.model.*;
 import io.jmix.flowui.util.OperationResult;
 import io.jmix.flowui.util.UnknownOperationResult;
 import io.jmix.flowui.view.navigation.RouteSupport;
@@ -90,15 +76,17 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
 
     private boolean showValidationErrors = true;
     private boolean crossFieldValidationEnabled = true;
-    private boolean readOnly = false;
+    private boolean readOnly;
 
     // whether user has edited entity after view opening
-    private boolean modifiedAfterOpen = false;
+    private boolean modifiedAfterOpen;
 
     private Boolean showSaveNotification;
-    private boolean saveActionPerformed = false;
+    private boolean saveActionPerformed;
 
-    protected boolean reloadSaved = false;
+    private boolean reloadEdited = true;
+
+    protected boolean reloadSaved;
 
     /**
      * Create views using {@link io.jmix.flowui.ViewNavigators} or {@link io.jmix.flowui.DialogWindows}.
@@ -113,8 +101,10 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
     }
 
     private void onBeforeShow(BeforeShowEvent event) {
-        setupEntityToEdit();
-        setupLockHandler();
+        if (serializedEntityIdToEdit != null) {
+            setupEntityToEdit(serializedEntityIdToEdit);
+        }
+        getEditedEntityContainer().addItemChangeListener(this::itemChangeLockHandler);
     }
 
     private void onReady(ReadyEvent event) {
@@ -519,12 +509,6 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
         setupEntityToEdit(entity);
     }
 
-    protected void setupEntityToEdit() {
-        if (serializedEntityIdToEdit != null) {
-            setupEntityToEdit(serializedEntityIdToEdit);
-        }
-    }
-
     protected void setupEntityToEdit(String serializedEntityId) {
         //noinspection unchecked
         Class<T> entityClass = (Class<T>) DetailViewTypeExtractor.extractEntityClass(getClass())
@@ -551,25 +535,8 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
     }
 
     protected void initExistingEntity(String serializedEntityId) {
-        if (!entityCanBeLoaded()) {
-            throw new GuiDevelopmentException(String.format(
-                    "Entity '%s' cannot be loaded by id '%s' " +
-                            "due to it is non-JPA entity or load delegate is not set. To correctly handle editing non-" +
-                            "JPA entities open editor in DIALOG mode. Another way is using 'routeParametersProvider'" +
-                            " in %s and installing load delegate in editor or overriding 'initExistingEntity' method",
-                    getEditedEntityContainer().getEntityMetaClass().getJavaClass().getSimpleName(),
-                    serializedEntityId, EditAction.class.getSimpleName()
-            ), getId().orElse(null));
-        }
-
         Object entityId = getUrlParamSerializer().deserialize(getSerializedIdType(), serializedEntityId);
         getEditedEntityLoader().setEntityId(entityId);
-    }
-
-    @SuppressWarnings("ConstantValue")
-    protected boolean entityCanBeLoaded() {
-        return getMetadataTools().isJpaEntity(getEditedEntityContainer().getEntityMetaClass())
-                || getEditedEntityLoader().getLoadDelegate() != null;
     }
 
     private Class<?> getSerializedIdType() {
@@ -587,16 +554,15 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
         DataContext dataContext = getViewData().getDataContext();
 
         if (getEntityStates().isNew(entityToEdit) || doNotReloadEditedEntity()) {
-            // In case of DTO, this method is called after
-            // Modified Tracking is enabled, so we need to
-            // remember the original state and revert it after
-            // entity is set.
+            // If edited entity is set in AfterViewNavigationEvent handler, this method is called
+            // after setupModifiedTracking(), so we remember the original state and revert it after the entity is set.
             boolean modifiedAfterOpen = isModifiedAfterOpen();
 
             T mergedEntity = dataContext.merge(entityToEdit);
 
             DataContext parentDc = dataContext.getParent();
-            if (parentDc == null || !parentDc.contains(mergedEntity)) {
+            if (getEntityStates().isNew(entityToEdit) &&
+                    (parentDc == null || !parentDc.contains(mergedEntity))) {
                 fireEvent(new InitEntityEvent<>(this, mergedEntity));
             }
 
@@ -615,7 +581,7 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
             return getEntityStates().isLoadedWithFetchPlan(entityToEdit, container.getFetchPlan());
         }
 
-        return false;
+        return !isReloadEdited();
     }
 
     private boolean isEntityModifiedInParentContext() {
@@ -660,10 +626,6 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
         }
 
         return false;
-    }
-
-    private void setupLockHandler() {
-        getEditedEntityContainer().addItemChangeListener(this::itemChangeLockHandler);
     }
 
     private void itemChangeLockHandler(InstanceContainer.ItemChangeEvent<T> event) {
@@ -855,6 +817,23 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
      */
     protected Registration addValidationEventListener(ComponentEventListener<ValidationEvent> listener) {
         return getEventBus().addListener(ValidationEvent.class, listener);
+    }
+
+    /**
+     * @return true if the edited entity should be reloaded before setting to the data container.
+     */
+    protected boolean isReloadEdited() {
+        return reloadEdited;
+    }
+
+    /**
+     * Sets whether the edited entity should be reloaded before setting to the data container. True by default.
+     * <p>
+     * Set to false in the view constructor or {@code InitEvent} handler if the view is opened in dialog mode
+     * and the entity should not be loaded by ID from a data storage.
+     */
+    protected void setReloadEdited(boolean reloadEdited) {
+        this.reloadEdited = reloadEdited;
     }
 
     @Override

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
@@ -101,10 +101,8 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
     }
 
     private void onBeforeShow(BeforeShowEvent event) {
-        if (serializedEntityIdToEdit != null) {
-            setupEntityToEdit(serializedEntityIdToEdit);
-        }
-        getEditedEntityContainer().addItemChangeListener(this::itemChangeLockHandler);
+        setupEntityToEdit();
+        setupLockHandler();
     }
 
     private void onReady(ReadyEvent event) {
@@ -509,6 +507,20 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
         setupEntityToEdit(entity);
     }
 
+    /**
+     * Invoked on {@link BeforeShowEvent} both when the view is opened by navigation and in dialog window.
+     */
+    protected void setupEntityToEdit() {
+        if (serializedEntityIdToEdit != null) {
+            setupEntityToEdit(serializedEntityIdToEdit);
+        }
+    }
+
+    /**
+     * Invoked when the view is opened by navigation.
+     *
+     * @param serializedEntityId serialized id of the edited entity or {@link #NEW_ENTITY_ID} when creating new entity
+     */
     protected void setupEntityToEdit(String serializedEntityId) {
         //noinspection unchecked
         Class<T> entityClass = (Class<T>) DetailViewTypeExtractor.extractEntityClass(getClass())
@@ -550,6 +562,12 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
         return primaryKeyProperty.getJavaType();
     }
 
+    /**
+     * Invoked when the view is opened in dialog window or when the view is opened by navigation
+     * and {@link #setEntityToEdit(Object)} method is called in {@code AfterViewNavigationEvent} handler.
+     *
+     * @param entityToEdit entity instance to edit. Can be a new instance when the entity is being created, see {@link EntityStates#isNew(Object)}.
+     */
     protected void setupEntityToEdit(T entityToEdit) {
         DataContext dataContext = getViewData().getDataContext();
 
@@ -626,6 +644,10 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
         }
 
         return false;
+    }
+
+    private void setupLockHandler() {
+        getEditedEntityContainer().addItemChangeListener(this::itemChangeLockHandler);
     }
 
     private void itemChangeLockHandler(InstanceContainer.ItemChangeEvent<T> event) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/DetailViewNavigationProcessor.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/DetailViewNavigationProcessor.java
@@ -97,16 +97,6 @@ public class DetailViewNavigationProcessor extends AbstractNavigationProcessor<D
         }
     }
 
-    protected Object getEntityToEdit(DetailViewNavigator<?> navigator) {
-        return switch (navigator.getMode()) {
-            case CREATE -> metadata.create(navigator.getEntityClass());
-            case EDIT -> navigator.getEditedEntity().orElseThrow(() ->
-                    new IllegalStateException(String.format(
-                            "Detail View of %s cannot be open with mode EDIT, entity is not set",
-                            navigator.getEntityClass())));
-        };
-    }
-
     protected RouteParameters generateNewEntityRouteParameters(DetailViewNavigator<?> navigator) {
         return routeSupport.createRouteParameters("id", StandardDetailView.NEW_ENTITY_ID);
     }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/DetailViewNavigationProcessor.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/DetailViewNavigationProcessor.java
@@ -23,7 +23,6 @@ import io.jmix.core.MetadataTools;
 import io.jmix.core.annotation.Internal;
 import io.jmix.core.entity.EntityValues;
 import io.jmix.flowui.sys.ViewSupport;
-import io.jmix.flowui.view.DetailView;
 import io.jmix.flowui.view.DetailViewMode;
 import io.jmix.flowui.view.StandardDetailView;
 import io.jmix.flowui.view.View;
@@ -83,14 +82,10 @@ public class DetailViewNavigationProcessor extends AbstractNavigationProcessor<D
     @Override
     protected RouteParameters getRouteParameters(DetailViewNavigator<?> navigator) {
         return navigator.getRouteParameters().orElseGet(() -> {
-            if (metadataTools.isJpaEntity(navigator.getEntityClass())) {
-                return switch (navigator.getMode()) {
-                    case CREATE -> generateNewEntityRouteParameters(navigator);
-                    case EDIT -> generateEditEntityRouteParameters(navigator);
-                };
-            } else {
-                return RouteParameters.empty();
-            }
+            return switch (navigator.getMode()) {
+                case CREATE -> generateNewEntityRouteParameters(navigator);
+                case EDIT -> generateEditEntityRouteParameters(navigator);
+            };
         });
     }
 
@@ -99,16 +94,7 @@ public class DetailViewNavigationProcessor extends AbstractNavigationProcessor<D
         if (navigator instanceof SupportsAfterViewNavigationHandler<?>
                 && ((SupportsAfterViewNavigationHandler<?>) navigator).getAfterNavigationHandler().isPresent()) {
             super.fireAfterViewNavigation(navigator, view);
-        } else if (isNeedToSetEntityToEdit(navigator, view)) {
-            Object entityToEdit = getEntityToEdit(navigator);
-            ((DetailView) view).setEntityToEdit(entityToEdit);
         }
-    }
-
-    protected boolean isNeedToSetEntityToEdit(DetailViewNavigator<?> navigator, View<?> view) {
-        return !metadataTools.isJpaEntity(navigator.getEntityClass())
-                && view instanceof DetailView
-                && navigator.getRouteParameters().isEmpty();
     }
 
     protected Object getEntityToEdit(DetailViewNavigator<?> navigator) {

--- a/jmix-flowui/flowui/src/test/groovy/component/standarddetailview/StandardDetailViewTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standarddetailview/StandardDetailViewTest.groovy
@@ -17,6 +17,7 @@
 package component.standarddetailview
 
 import com.vaadin.flow.component.UI
+import com.vaadin.flow.router.RouteParameters
 import component.standarddetailview.view.BlankTestView
 import component.standarddetailview.view.OrderDetailTestView
 import component.standarddetailview.view.TestCopyingSystemStateDetailTestView
@@ -66,9 +67,12 @@ class StandardDetailViewTest extends FlowuiTestSpecification {
         entity.setName("test")
 
         navigators.detailView(TestCopyingSystemStateEntity)
-                .editEntity(entity)
                 .withViewClass(TestCopyingSystemStateDetailTestView)
                 .withBackwardNavigation(false)
+                .withRouteParameters(RouteParameters.empty())
+                .withAfterNavigationHandler {event ->
+                    event.view.setEntityToEdit(entity)
+                }
                 .navigate()
 
         then: """

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/TestNullableIdDto.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/TestNullableIdDto.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity;
+
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.core.metamodel.annotation.JmixProperty;
+
+@JmixEntity
+public class TestNullableIdDto {
+
+    @JmixId
+    protected Long id;
+
+    @JmixProperty
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/impl/JmxControlImpl.java
+++ b/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/impl/JmxControlImpl.java
@@ -16,6 +16,7 @@
 
 package io.jmix.jmxconsole.impl;
 
+import io.jmix.core.EntityStates;
 import io.jmix.core.Metadata;
 import io.jmix.jmxconsole.JmxControl;
 import io.jmix.jmxconsole.JmxControlException;
@@ -65,13 +66,15 @@ public class JmxControlImpl implements JmxControl {
     protected static final String ROLE_SETTER = "setter";
 
     private final Logger log = LoggerFactory.getLogger(JmxControlImpl.class);
+    private final EntityStates entityStates;
 
     protected ApplicationContext applicationContext;
     protected Metadata metadata;
 
-    public JmxControlImpl(ApplicationContext applicationContext, Metadata metadata) {
+    public JmxControlImpl(ApplicationContext applicationContext, Metadata metadata, EntityStates entityStates) {
         this.applicationContext = applicationContext;
         this.metadata = metadata;
+        this.entityStates = entityStates;
     }
 
     @Override
@@ -141,6 +144,7 @@ public class JmxControlImpl implements JmxControl {
         mbi.setDomain(name.getDomain());
         mbi.setPropertyList(name.getKeyPropertyListString());
 
+        entityStates.setNew(mbi, false);
         return mbi;
     }
 
@@ -229,6 +233,8 @@ public class JmxControlImpl implements JmxControl {
                 mba.setWriteable(false);
             }
         }
+
+        entityStates.setNew(mba, false);
         return mba;
     }
 

--- a/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/view/MBeanAttributeDetailView.java
+++ b/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/view/MBeanAttributeDetailView.java
@@ -45,6 +45,10 @@ public class MBeanAttributeDetailView extends StandardDetailView<ManagedBeanAttr
 
     protected AbstractField<?, ?> attributeField;
 
+    public MBeanAttributeDetailView() {
+        setReloadEdited(false);
+    }
+
     @Subscribe
     public void onBeforeShow(final BeforeShowEvent event) {
         ManagedBeanAttribute managedBeanAttribute = getEditedEntity();

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/model/RoleModelConverter.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/model/RoleModelConverter.java
@@ -16,6 +16,7 @@
 
 package io.jmix.securityflowui.model;
 
+import io.jmix.core.EntityStates;
 import io.jmix.core.Metadata;
 import io.jmix.security.model.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,8 +34,13 @@ import java.util.stream.Collectors;
 @Component("sec_RoleModelConverter")
 public class RoleModelConverter {
 
+    private final EntityStates entityStates;
     @Autowired
     protected Metadata metadata;
+
+    public RoleModelConverter(EntityStates entityStates) {
+        this.entityStates = entityStates;
+    }
 
     public ResourceRoleModel createResourceRoleModel(ResourceRole role) {
         ResourceRoleModel roleModel = metadata.create(ResourceRoleModel.class);
@@ -42,6 +48,8 @@ public class RoleModelConverter {
         initBaseParameters(roleModel, role);
         roleModel.setScopes(role.getScopes());
         roleModel.setResourcePolicies(createResourcePolicyModels(role.getResourcePolicies()));
+
+        entityStates.setNew(roleModel, false);
 
         return roleModel;
     }
@@ -53,6 +61,8 @@ public class RoleModelConverter {
         initBaseParameters(roleModel, role);
 
         roleModel.setRowLevelPolicies(createRowLevelPolicyModels(role.getRowLevelPolicies()));
+
+        entityStates.setNew(roleModel, false);
 
         return roleModel;
     }
@@ -76,6 +86,7 @@ public class RoleModelConverter {
                     model.setEffect(resourcePolicy.getEffect());
                     model.setPolicyGroup(resourcePolicy.getPolicyGroup());
                     model.setCustomProperties(resourcePolicy.getCustomProperties());
+                    entityStates.setNew(model, false);
                     return model;
                 })
                 .collect(Collectors.toList());
@@ -92,6 +103,7 @@ public class RoleModelConverter {
                     model.setWhereClause(rowLevelPolicy.getWhereClause());
                     model.setScript(rowLevelPolicy.getScript());
                     model.setCustomProperties(rowLevelPolicy.getCustomProperties());
+                    entityStates.setNew(model, false);
                     return model;
                 })
                 .collect(Collectors.toList());

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/EntityAttributeResourcePolicyModelDetailView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/EntityAttributeResourcePolicyModelDetailView.java
@@ -30,6 +30,7 @@ public class EntityAttributeResourcePolicyModelDetailView extends StandardDetail
 
     @Subscribe
     public void onInit(InitEvent event) {
+        setReloadEdited(false);
         ComponentUtils.setItemsMap(entityField, resourcePolicyEditorUtils.getEntityOptionsMap());
         entityField.addValueChangeListener(this::onEntityFieldValueChange);
         attributeField.addValueChangeListener(this::onAttributeFieldValueChange);

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/EntityResourcePolicyModelDetailView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/EntityResourcePolicyModelDetailView.java
@@ -23,6 +23,7 @@ public class EntityResourcePolicyModelDetailView extends StandardDetailView<Reso
 
     @Subscribe
     public void onInit(InitEvent event) {
+        setReloadEdited(false);
         ComponentUtils.setItemsMap(entityField, resourcePolicyEditorUtils.getEntityOptionsMap());
         resourcePolicyEditorUtils.setEnumItemsAsString(actionField, EntityPolicyAction.class);
     }

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/GraphQLResourcePolicyModelDetailView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/GraphQLResourcePolicyModelDetailView.java
@@ -8,4 +8,9 @@ import io.jmix.securityflowui.model.ResourcePolicyModel;
 @EditedEntityContainer("resourcePolicyModelDc")
 @DialogMode(width = "32em")
 public class GraphQLResourcePolicyModelDetailView extends StandardDetailView<ResourcePolicyModel> {
+
+    @Subscribe
+    public void onInit(InitEvent event) {
+        setReloadEdited(false);
+    }
 }

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/MenuResourcePolicyModelDetailView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/MenuResourcePolicyModelDetailView.java
@@ -24,6 +24,7 @@ public class MenuResourcePolicyModelDetailView extends StandardDetailView<Resour
 
     @Subscribe
     public void onInit(InitEvent event) {
+        setReloadEdited(false);
         ComponentUtils.setItemsMap(resourceField, resourcePolicyEditorUtils.getMenuItemOptionsMap());
     }
 

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/ResourcePolicyModelDetailView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/ResourcePolicyModelDetailView.java
@@ -8,4 +8,10 @@ import io.jmix.securityflowui.model.ResourcePolicyModel;
 @EditedEntityContainer("resourcePolicyModelDc")
 @DialogMode(width = "32em")
 public class ResourcePolicyModelDetailView extends StandardDetailView<ResourcePolicyModel> {
+
+    @Subscribe
+    public void onInit(InitEvent event) {
+        setReloadEdited(false);
+    }
+
 }

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/SpecificResourcePolicyModelDetailView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/SpecificResourcePolicyModelDetailView.java
@@ -25,6 +25,7 @@ public class SpecificResourcePolicyModelDetailView extends StandardDetailView<Re
 
     @Subscribe
     public void onInit(InitEvent event) {
+        setReloadEdited(false);
         List<String> specificPolicyNames = specificPolicyInfoRegistry.getSpecificPolicyInfos().stream()
                 .map(SpecificPolicyInfoRegistry.SpecificPolicyInfo::getName)
                 .sorted()

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/ViewResourcePolicyModelDetailView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcepolicy/ViewResourcePolicyModelDetailView.java
@@ -24,6 +24,7 @@ public class ViewResourcePolicyModelDetailView extends StandardDetailView<Resour
 
     @Subscribe
     public void onInit(InitEvent event) {
+        setReloadEdited(false);
         ComponentUtils.setItemsMap(resourceField, resourcePolicyEditorUtils.getViewsOptionsMap());
     }
 

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/rowlevelpolicy/RowLevelPolicyModelDetailView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/rowlevelpolicy/RowLevelPolicyModelDetailView.java
@@ -92,6 +92,7 @@ public class RowLevelPolicyModelDetailView extends StandardDetailView<RowLevelPo
 
     @Subscribe
     public void onInit(InitEvent event) {
+        setReloadEdited(false);
         ComponentUtils.setItemsMap(entityNameField, getEntityOptionsMap());
         docsLink.getStyle().set("margin-inline-start", "auto");
         detailActions.setAlignSelf(Alignment.CENTER, docsLink);

--- a/jmix-templates/content/flowui/detail-dto/controller.java
+++ b/jmix-templates/content/flowui/detail-dto/controller.java
@@ -21,14 +21,18 @@ public class ${detailControllerName} extends StandardDetailView<${entity.classNa
     @Install(to = "${dlId}", target = Target.DATA_LOADER)
     private ${entity.className} customerDlLoadDelegate(final LoadContext<${entity.className}> loadContext) {
         Object id = loadContext.getId();
-        // Here you can load the entity by id from an external storage
+        // Here you can load the entity by id from an external storage.
+        // Set the loaded entity to the not-new state using EntityStates.setNew(entity, false).
         return null;
     }
 
     @Install(target = Target.DATA_CONTEXT)
     private Set<Object> saveDelegate(final SaveContext saveContext) {
         ${entity.className} entity = getEditedEntity();
-        // Here you can save the entity to an external storage and return the saved instance
+        // Here you can save the entity to an external storage and return the saved instance.
+        // Set the returned entity to the not-new state using EntityStates.setNew(entity, false).
+        // If the new entity ID is assigned by the storage, set the ID to the original instance too 
+        // to let the framework match the saved instance with the original one.
         ${entity.className} saved = entity;
         return Set.of(saved);
     }

--- a/jmix-templates/content/flowui/detail-dto/controller.java
+++ b/jmix-templates/content/flowui/detail-dto/controller.java
@@ -3,20 +3,33 @@ package ${packageName};
 import ${entity.fqn};<%if (!api.jmixProjectModule.isApplication()) {%>
 import io.jmix.flowui.view.DefaultMainViewParent;<%} else {%>
 import ${module_basePackage}.view.main.MainView;
-<%}%>import com.vaadin.flow.router.BeforeEnterEvent;
-import com.vaadin.flow.router.Route;
+<%}%>import com.vaadin.flow.router.Route;
+import io.jmix.core.LoadContext;
+import io.jmix.core.SaveContext;
 import io.jmix.flowui.view.*;
+
+import java.util.Set;
 
 <%if (classComment) {%>
 ${classComment}
-<%}%>@Route(value = "${detailRoute}", layout = <%if (!api.jmixProjectModule.isApplication()) {%> DefaultMainViewParent.class <%} else {%>MainView.class<%}%>)
+<%}%>@Route(value = "${detailRoute}/:${detailRouteParam}", layout = <%if (!api.jmixProjectModule.isApplication()) {%> DefaultMainViewParent.class <%} else {%>MainView.class<%}%>)
 @ViewController("${detailId}")
 @ViewDescriptor("${detailDescriptorName}.xml")
 @EditedEntityContainer("${dcId}")
 public class ${detailControllerName} extends StandardDetailView<${entity.className}> {
 
-    @Override
-    protected void findEntityId(BeforeEnterEvent event) {
-        // Because DTO entity cannot be loaded by Id, we need to prevent Id parsing from route parameters
+    @Install(to = "${dlId}", target = Target.DATA_LOADER)
+    private ${entity.className} customerDlLoadDelegate(final LoadContext<${entity.className}> loadContext) {
+        Object id = loadContext.getId();
+        // Here you can load the entity by id from an external storage
+        return null;
+    }
+
+    @Install(target = Target.DATA_CONTEXT)
+    private Set<Object> saveDelegate(final SaveContext saveContext) {
+        ${entity.className} entity = getEditedEntity();
+        // Here you can save the entity to an external storage and return the saved instance
+        ${entity.className} saved = entity;
+        return Set.of(saved);
     }
 }

--- a/jmix-templates/content/flowui/detail-dto/controller.kt
+++ b/jmix-templates/content/flowui/detail-dto/controller.kt
@@ -20,13 +20,17 @@ class ${detailControllerName} : StandardDetailView<${entity.className}>() {
     @Install(to = "${dlId}", target = Target.DATA_LOADER)
     private fun ${dlId}LoadDelegate(loadContext: LoadContext<${entity.className}>): ${entity.className}? {
         val id = loadContext.id
-        // Here you can load the entity by id from an external storage
+        // Here you can load the entity by id from an external storage.
+        // Set the loaded entity to the not-new state using EntityStates.setNew(entity, false).
         return null
     }
 
     @Install(target = Target.DATA_CONTEXT)
     private fun saveDelegate(saveContext: SaveContext): MutableSet<Any> {
-        // Here you can save the entity to an external storage and return the saved instance
+        // Here you can save the entity to an external storage and return the saved instance.
+        // Set the returned entity to the not-new state using EntityStates.setNew(entity, false).
+        // If the new entity ID is assigned by the storage, set the ID to the original instance too 
+        // to let the framework match the saved instance with the original one.
         val savedEntity = editedEntity
         return mutableSetOf(savedEntity)
     }

--- a/jmix-templates/content/flowui/detail-dto/controller.kt
+++ b/jmix-templates/content/flowui/detail-dto/controller.kt
@@ -3,19 +3,31 @@ package ${packageName}
 import ${entity.fqn}<%if (!api.jmixProjectModule.isApplication()) {%>
 import io.jmix.flowui.view.DefaultMainViewParent<%} else {%>
 import ${module_basePackage}.view.main.MainView
-<%}%>import com.vaadin.flow.router.BeforeEnterEvent
-import com.vaadin.flow.router.Route
+<%}%>import com.vaadin.flow.router.Route
+import io.jmix.core.LoadContext
+import io.jmix.core.SaveContext
 import io.jmix.flowui.view.*
+import io.jmix.flowui.view.Target
 
 <%if (classComment) {%>
 ${classComment}
-<%}%>@Route(value = "${detailRoute}", layout = <%if (!api.jmixProjectModule.isApplication()) {%> DefaultMainViewParent::class <%} else {%>MainView::class<%}%>)
+<%}%>@Route(value = "${detailRoute}/:id", layout = <%if (!api.jmixProjectModule.isApplication()) {%> DefaultMainViewParent::class <%} else {%>MainView::class<%}%>)
 @ViewController("${detailId}")
 @ViewDescriptor("${detailDescriptorName}.xml")
 @EditedEntityContainer("${dcId}")
 class ${detailControllerName} : StandardDetailView<${entity.className}>() {
 
-    override fun findEntityId(event: BeforeEnterEvent) {
-        // Because DTO entity cannot be loaded by Id, we need to prevent Id parsing from route parameters
+    @Install(to = "${dlId}", target = Target.DATA_LOADER)
+    private fun ${dlId}LoadDelegate(loadContext: LoadContext<${entity.className}>): ${entity.className}? {
+        val id = loadContext.id
+        // Here you can load the entity by id from an external storage
+        return null
+    }
+
+    @Install(target = Target.DATA_CONTEXT)
+    private fun saveDelegate(saveContext: SaveContext): MutableSet<Any> {
+        // Here you can save the entity to an external storage and return the saved instance
+        val savedEntity = editedEntity
+        return mutableSetOf(savedEntity)
     }
 }

--- a/jmix-templates/content/flowui/detail-dto/settings.xml
+++ b/jmix-templates/content/flowui/detail-dto/settings.xml
@@ -83,9 +83,16 @@
               advanced="true"
               dynamic="true"
               required="true"
-              valueTemplate="${entity.uncapitalizedClassName}/detail">
+              valueTemplate="${api.pluralForm(entity.uncapitalizedClassName)}">
         <dependency code="entity"/>
     </property>
+
+    <property caption="View route parameter"
+              code="detailRouteParam"
+              propertyType="STRING"
+              advanced="true"
+              required="true"
+              defaultValue="id"/>
 
     <source fileExt="xml"
             name="descriptor"/>

--- a/jmix-templates/content/flowui/list-and-detail-dto/settings.xml
+++ b/jmix-templates/content/flowui/list-and-detail-dto/settings.xml
@@ -160,9 +160,16 @@
               advanced="true"
               dynamic="true"
               required="true"
-              valueTemplate="${entity.uncapitalizedClassName}/detail">
+              valueTemplate="${api.pluralForm(entity.uncapitalizedClassName)}">
         <dependency code="entity"/>
     </property>
+
+    <property caption="Detail view route parameter"
+              code="detailRouteParam"
+              propertyType="STRING"
+              advanced="true"
+              required="true"
+              defaultValue="id"/>
 
     <property caption="Parent menu item"
               code="menuItem"

--- a/jmix-templates/content/flowui/list-dto/controller.java
+++ b/jmix-templates/content/flowui/list-dto/controller.java
@@ -21,7 +21,8 @@ public class ${viewControllerName} extends StandardListView<${entity.className}>
 
     @Install(to = "${tableDl}", target = Target.DATA_LOADER)
     protected List<${entity.className}> ${tableDl}LoadDelegate(LoadContext<${entity.className}> loadContext) {
-        // Here you can load entities from an external storage
+        // Here you can load entities from an external storage.
+        // Set the loaded entities to the not-new state using EntityStates.setNew(entity, false).
         return List.of();
     }
 

--- a/jmix-templates/content/flowui/list-dto/controller.java
+++ b/jmix-templates/content/flowui/list-dto/controller.java
@@ -7,7 +7,7 @@ import ${module_basePackage}.view.main.MainView;
 import io.jmix.core.LoadContext;
 import io.jmix.flowui.view.*;
 
-import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
 
 <%if (classComment) {%>
@@ -21,7 +21,14 @@ public class ${viewControllerName} extends StandardListView<${entity.className}>
 
     @Install(to = "${tableDl}", target = Target.DATA_LOADER)
     protected List<${entity.className}> ${tableDl}LoadDelegate(LoadContext<${entity.className}> loadContext) {
-        // Here you can load entities from an external store
-        return Collections.emptyList();
+        // Here you can load entities from an external storage
+        return List.of();
+    }
+
+    @Install(to = "${tableId}.remove", subject = "delegate")
+    private void ${tableId}RemoveDelegate(final Collection<${entity.className}> collection) {
+        for (${entity.className} entity : collection) {
+            // Here you can remove entities from an external storage
+        }
     }
 }

--- a/jmix-templates/content/flowui/list-dto/controller.kt
+++ b/jmix-templates/content/flowui/list-dto/controller.kt
@@ -19,7 +19,13 @@ class ${viewControllerName} : StandardListView<${entity.className}>() {
 
     @Install(to = "${tableDl}", target = Target.DATA_LOADER)
     fun ${tableDl}LoadDelegate(loadContext: LoadContext<${entity.className}>): MutableList<${entity.className}> {
-        // Here you can load entities from an external store
+        // Here you can load entities from an external store.
+        // Set the loaded entities to the not-new state using EntityStates.setNew(entity, false).
         return mutableListOf()
+    }
+
+    @Install(to = "${tableId}.remove", subject = "delegate")
+    fun ${tableId}RemoveDelegate(entities: Collection<${entity.className}>) {
+        // Here you can remove entities from an external storage
     }
 }

--- a/jmix-templates/content/flowui/list-dto/descriptor.xml
+++ b/jmix-templates/content/flowui/list-dto/descriptor.xml
@@ -26,7 +26,6 @@ def tableXml = api.processSnippet('dto_table.xml',
         'multiselect': multiselect])
 %><?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <view xmlns="http://jmix.io/schema/flowui/view"
-      xmlns:c="http://jmix.io/schema/flowui/jpql-condition"
       title="${messageKeys['viewTitle']}"
       focusComponent="${tableId}">
     <data>


### PR DESCRIPTION
See #2788 for the problem description.

## Added methods

- `EntityStates.setNew(Object entity, boolean isNew)` - manages the "New" state of the entity instance.
- `RemoveAction.setDelegate()`, `RemoveOperation.RemoveBuilder.withRemoveDelegate()` - delegate to be invoked instead of DataManager to remove the entities from a storage
- `StandardDetailView.setReloadEdited(boolean)` - whether the edited entity should be reloaded before setting to the data container. True by default.

## Removed methods

- Protected `StandardDetailView.entityCanBeLoaded()`
- Protected `DetailViewNavigationProcessor.isNeedToSetEntityToEdit()`
- Protected `DetailViewNavigationProcessor.getEntityToEdit()`

## Behavior changes

The framework now doesn't make any difference between JPA and DTO entities when navigating to a detail view: it passes the entity ID in the route parameter. The detail view for DTO entity is supposed to get this ID and load the entity instance from some data storage using the load delegate. If the `new` constant is passed instead of ID, the view creates a new instance.

If the whole entity instance is passed instead of ID (e.g. when opening in dialog window), `EntityStates.isNew()` is used to distinguish between Edit and Create mode. Consequently, it's important to **set the entity in the not-new state after loading** it from a storage. For a DTO entity it can be done using the new `EntityStates.setNew()` method, for JPA entity it's done by the standard JPA data store implementation.

If the edited entity should not be reloaded from the data storage before setting to the data container, call `setReloadEdited(false)` in the detail view constructor or `InitEvent` handler. This is the case for DTO entities existing purely in memory and not mapped directly to external data, like Security or JMX Console model entities.

## Recommendations

### Opening DTO entity detail view

Previously, the framework automatically adjusted the process of opening detail views for DTO entities. In particular, when navigating, it didn't provide the entity ID in route parameters and instead passed the entity instance in `AfterViewNavigationEvent` handler.

If you have used this standard approach for navigation and want to keep it, you should replicate the old behavior in create/edit actions of the list view as in the following example for the `Phone` DTO entity:

```
@Autowired  
private ViewNavigators viewNavigators;
@ViewComponent  
private DataGrid<Phone> phonesDataGrid;

@Subscribe("phonesDataGrid.create")  
public void onPhonesDataGridCreate(final ActionPerformedEvent event) {  
    viewNavigators.detailView(phonesDataGrid)  
            .withViewClass(PhoneDetailView.class)  
            .withRouteParameters(RouteParameters.empty())  
            .withAfterNavigationHandler(afterViewNavigationEvent -> {  
                Phone phone = metadata.create(Phone.class);  
                afterViewNavigationEvent.getView().setEntityToEdit(phone);  
            })  
            .navigate();  
}  
  
@Subscribe("phonesDataGrid.edit")  
public void onPhonesDataGridEdit(final ActionPerformedEvent event) {  
    viewNavigators.detailView(phonesDataGrid)  
            .withViewClass(PhoneDetailView.class)  
            .withRouteParameters(RouteParameters.empty())  
            .withAfterNavigationHandler(afterViewNavigationEvent ->  
                    afterViewNavigationEvent.getView()  
                            .setEntityToEdit(Objects.requireNonNull(phonesDataGrid.getSingleSelectedItem())))  
            .navigate();  
}
```

As you can see, the action handler methods set the empty route parameters and pass the entity in `AfterViewNavigationEvent` handler.

Opening detail view in dialog window should work as before without changes in list view actions.

Both for the navigation and dialog mode, call `setReloadEdited(false)` in the detail view:
```
public PhoneDetailView() {  
    setReloadEdited(false);  
}
```

### Setting non-new state for loaded DTO entities

To make sure the framework correctly distinguish new instances from already existing in a storage, call `EntityStates.setNew(entity, false)` for entities loaded from external storage.


### Assigning ID to new DTO entities

If the new entity ID is assigned by the storage, set the ID to the original instance too to let the framework match the saved instance with the original one. For example:

```
public Task saveTask(Task task) {
    String url = task.getId() != null ? TASKS_BASE_URL + "/"  + task.getId() : TASKS_BASE_URL;
    ResponseEntity<Task> response = restTemplate.postForEntity(url, task, Task.class);
    Task savedTask = Objects.requireNonNull(response.getBody());
    if (task.getId() == null) {
        task.setId(savedTask.getId());
    }
    entityStates.setNew(savedTask, false);
    return savedTask;
}
```