### PR TITLE
Skip enhancing of entities if entities weren't changed

### DIFF
--- a/jmix-gradle-plugin/src/main/groovy/io/jmix/gradle/JmixExtension.groovy
+++ b/jmix-gradle-plugin/src/main/groovy/io/jmix/gradle/JmixExtension.groovy
@@ -91,5 +91,13 @@ class JmixExtension {
          * </pre>
          */
         List<String> jpaConverters = []
+
+        /**
+         * The property indicates whether entity classes enhancing should be skipped in case there were no modifications
+         * in entities since the last build. If set to "true" the plugin will check whether entity classes have been
+         * changed since last build, and if they haven't been changed then enhancing step will be skipped. If set to
+         * false, then entities enhancing steps will be executed on each classes compilation.
+         */
+        boolean skipUnmodifiedEntitiesEnhancing = true
     }
 }


### PR DESCRIPTION
### Implementation Details

During entities enhancement, the Jmix Gradle plugin evaluates the checksum of enhanced entities classes and saves it to a file in the temporary directory. When next compilation is executed, the plugin checks that entity classes inside the project build directory are the same as the saved ones (have the same checksum). There will be difference if any entity class is changed or a new entity is created. In this case the build directory will contain a modified (non-enhanced) entity class. If such differences are found then entity enhancing step will be run.

To disable this behavior and always enhance all entities on each compilation the following config should be added to the build.gradle:

```
jmix {
    entitiesEnhancing {
        skipUnmodifiedEntitiesEnhancing = false
    }
}
```

By default, the entities enhancing skipping functionality is enabled.