### PR TITLE
fix NullPointerException: Master-detail view + DynamicAttribute

### DIFF
--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrFacetInfo.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrFacetInfo.java
@@ -25,6 +25,7 @@ import io.jmix.core.common.xmlparsing.Dom4jTools;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.dynattrflowui.facet.DynAttrFacet;
 import io.jmix.flowui.component.formlayout.JmixFormLayout;
+import io.jmix.flowui.component.grid.DataGrid;
 import io.jmix.flowui.view.ViewInfo;
 import io.jmix.flowui.view.ViewRegistry;
 import org.apache.commons.lang3.StringUtils;
@@ -223,8 +224,11 @@ public class DynAttrFacetInfo {
     private void findTargetElementNames(List<String> targetElementList, Element searchElement) {
         for (var child : searchElement.elements()) {
             if (child.getQName().getName().equals(JmixFormLayout.QUALIFIED_XML_NAME) ||
-                    child.getQName().getName().equals("dataGrid")) {
-                targetElementList.add(child.attributeValue("id"));
+                    child.getQName().getName().equals(DataGrid.QUALIFIED_XML_NAME)) {
+                String idAttribute = child.attributeValue("id");
+                if(StringUtils.isNotBlank(idAttribute)) {
+                    targetElementList.add(idAttribute);
+                }
             }
             if (!child.elements().isEmpty()) {
                 findTargetElementNames(targetElementList, child);

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrFacetInfo.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrFacetInfo.java
@@ -25,7 +25,6 @@ import io.jmix.core.common.xmlparsing.Dom4jTools;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.dynattrflowui.facet.DynAttrFacet;
 import io.jmix.flowui.component.formlayout.JmixFormLayout;
-import io.jmix.flowui.component.grid.DataGrid;
 import io.jmix.flowui.view.ViewInfo;
 import io.jmix.flowui.view.ViewRegistry;
 import org.apache.commons.lang3.StringUtils;
@@ -226,7 +225,7 @@ public class DynAttrFacetInfo {
             if (child.getQName().getName().equals(JmixFormLayout.QUALIFIED_XML_NAME) ||
                     child.getQName().getName().equals(DATAGRID_QUALIFIED_XML_NAME)) {
                 String idAttribute = child.attributeValue("id");
-                if(StringUtils.isNotBlank(idAttribute)) {
+                if (StringUtils.isNotBlank(idAttribute)) {
                     targetElementList.add(idAttribute);
                 }
             }

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrFacetInfo.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrFacetInfo.java
@@ -24,7 +24,6 @@ import io.jmix.core.Resources;
 import io.jmix.core.common.xmlparsing.Dom4jTools;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.dynattrflowui.facet.DynAttrFacet;
-import io.jmix.flowui.component.formlayout.JmixFormLayout;
 import io.jmix.flowui.view.ViewInfo;
 import io.jmix.flowui.view.ViewRegistry;
 import org.apache.commons.lang3.StringUtils;
@@ -44,7 +43,8 @@ import java.util.concurrent.ConcurrentHashMap;
 @Order(JmixOrder.LOWEST_PRECEDENCE)
 @Component("dynattr_DynAttrFacetInfo")
 public class DynAttrFacetInfo {
-    public static final String DATAGRID_QUALIFIED_XML_NAME = "dataGrid";
+    private static final String DATAGRID_QUALIFIED_XML_NAME = "dataGrid";
+    private static final String FORM_LAYOUT_QUALIFIED_XML_NAME = "formLayout";
     private static final Logger log = LoggerFactory.getLogger(DynAttrFacetInfo.class);
 
     protected final ViewRegistry viewRegistry;
@@ -222,7 +222,7 @@ public class DynAttrFacetInfo {
 
     private void findTargetElementNames(List<String> targetElementList, Element searchElement) {
         for (var child : searchElement.elements()) {
-            if (child.getQName().getName().equals(JmixFormLayout.QUALIFIED_XML_NAME) ||
+            if (child.getQName().getName().equals(FORM_LAYOUT_QUALIFIED_XML_NAME) ||
                     child.getQName().getName().equals(DATAGRID_QUALIFIED_XML_NAME)) {
                 String idAttribute = child.attributeValue("id");
                 if (StringUtils.isNotBlank(idAttribute)) {

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrFacetInfo.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrFacetInfo.java
@@ -45,7 +45,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @Order(JmixOrder.LOWEST_PRECEDENCE)
 @Component("dynattr_DynAttrFacetInfo")
 public class DynAttrFacetInfo {
-
+    public static final String DATAGRID_QUALIFIED_XML_NAME = "dataGrid";
     private static final Logger log = LoggerFactory.getLogger(DynAttrFacetInfo.class);
 
     protected final ViewRegistry viewRegistry;
@@ -224,7 +224,7 @@ public class DynAttrFacetInfo {
     private void findTargetElementNames(List<String> targetElementList, Element searchElement) {
         for (var child : searchElement.elements()) {
             if (child.getQName().getName().equals(JmixFormLayout.QUALIFIED_XML_NAME) ||
-                    child.getQName().getName().equals(DataGrid.QUALIFIED_XML_NAME)) {
+                    child.getQName().getName().equals(DATAGRID_QUALIFIED_XML_NAME)) {
                 String idAttribute = child.attributeValue("id");
                 if(StringUtils.isNotBlank(idAttribute)) {
                     targetElementList.add(idAttribute);

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrFacetInfo.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrFacetInfo.java
@@ -43,8 +43,8 @@ import java.util.concurrent.ConcurrentHashMap;
 @Order(JmixOrder.LOWEST_PRECEDENCE)
 @Component("dynattr_DynAttrFacetInfo")
 public class DynAttrFacetInfo {
-    private static final String DATAGRID_QUALIFIED_XML_NAME = "dataGrid";
-    private static final String FORM_LAYOUT_QUALIFIED_XML_NAME = "formLayout";
+    private static final String DATAGRID_XML_TAG = "dataGrid";
+    private static final String FORM_LAYOUT_XML_TAG = "formLayout";
     private static final Logger log = LoggerFactory.getLogger(DynAttrFacetInfo.class);
 
     protected final ViewRegistry viewRegistry;
@@ -222,8 +222,8 @@ public class DynAttrFacetInfo {
 
     private void findTargetElementNames(List<String> targetElementList, Element searchElement) {
         for (var child : searchElement.elements()) {
-            if (child.getQName().getName().equals(FORM_LAYOUT_QUALIFIED_XML_NAME) ||
-                    child.getQName().getName().equals(DATAGRID_QUALIFIED_XML_NAME)) {
+            if (child.getQName().getName().equals(FORM_LAYOUT_XML_TAG) ||
+                    child.getQName().getName().equals(DATAGRID_XML_TAG)) {
                 String idAttribute = child.attributeValue("id");
                 if (StringUtils.isNotBlank(idAttribute)) {
                     targetElementList.add(idAttribute);

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/FormEmbeddingStrategy.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/FormEmbeddingStrategy.java
@@ -60,7 +60,8 @@ public class FormEmbeddingStrategy extends BaseEmbeddingStrategy {
 
     @Override
     public boolean supportComponent(Component component) {
-        return component instanceof JmixFormLayout && ((JmixFormLayout) component).getValueSourceProvider() instanceof ContainerValueSourceProvider;
+        return component instanceof JmixFormLayout jmixFormLayout &&
+                jmixFormLayout.getValueSourceProvider() instanceof ContainerValueSourceProvider;
     }
 
     @Override

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/formlayout/JmixFormLayout.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/formlayout/JmixFormLayout.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 import static io.jmix.flowui.component.UiComponentUtils.sameId;
 
 public class JmixFormLayout extends FormLayout implements ComponentContainer, HasValueSourceProvider {
-    public static final String QUALIFIED_XML_NAME = "formLayout";
     protected ValueSourceProvider valueSourceProvider;
 
     @Override

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/DataGrid.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/DataGrid.java
@@ -59,7 +59,6 @@ import java.util.function.Consumer;
 
 public class DataGrid<E> extends JmixGrid<E> implements ListDataComponent<E>, MultiSelectLookupComponent<E>,
         EnhancedDataGrid<E>, SupportsEnterPress<DataGrid<E>>, ApplicationContextAware, InitializingBean {
-    public static final String QUALIFIED_XML_NAME = "dataGrid";
 
     protected ApplicationContext applicationContext;
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/DataGrid.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/DataGrid.java
@@ -59,6 +59,7 @@ import java.util.function.Consumer;
 
 public class DataGrid<E> extends JmixGrid<E> implements ListDataComponent<E>, MultiSelectLookupComponent<E>,
         EnhancedDataGrid<E>, SupportsEnterPress<DataGrid<E>>, ApplicationContextAware, InitializingBean {
+    public static final String QUALIFIED_XML_NAME = "dataGrid";
 
     protected ApplicationContext applicationContext;
 


### PR DESCRIPTION
Duplicated from issue comment(i created an issues):


There is not errors for master detail screen.
Bug was produced by service that finds elements with "null" id. 
So, we need to fix that method, ignore searching elements without IDs(formLayout and dataGrid).

Issue causes following issues:
* No root form layout id inside root form: https://github.com/jmix-framework/jmix/issues/2958
* No validation inside MasterDetailsView's form layout https://github.com/jmix-framework/jmix/issues/2959

We would not support detail's view behaviour for form inside it, but we can fix it for scaffolded views