### PR TITLE
jmix.core.exclude-beans defined in project overrides values from Jmix modules (3129)

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/BeanExclusionProcessor.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/BeanExclusionProcessor.java
@@ -28,13 +28,19 @@ import org.springframework.core.env.Environment;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class BeanExclusionProcessor implements BeanDefinitionRegistryPostProcessor, EnvironmentAware {
 
     private static final Logger log = LoggerFactory.getLogger(BeanExclusionProcessor.class);
 
+    private final JmixModules modules;
     private List<String> beansToExclude = new ArrayList<>();
+
+    public BeanExclusionProcessor(JmixModules modules) {
+        this.modules = modules;
+    }
 
     @Override
     public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
@@ -52,9 +58,15 @@ public class BeanExclusionProcessor implements BeanDefinitionRegistryPostProcess
 
     @Override
     public void setEnvironment(Environment environment) {
-        String property = environment.getProperty("jmix.core.exclude-beans");
-        if (property != null) {
-            beansToExclude = Splitter.on(",").trimResults().omitEmptyStrings().splitToList(property);
-        }
+        List<String> propertyValues = modules.getPropertyValues("jmix.core.exclude-beans");
+
+        // put the list in default order - from the app down to the add-ons
+        Collections.reverse(propertyValues);
+
+        beansToExclude = propertyValues.stream()
+                .map(property ->
+                        Splitter.on(",").trimResults().omitEmptyStrings().splitToList(property))
+                .flatMap(List::stream)
+                .toList();
     }
 }

--- a/jmix-core/core/src/main/java/io/jmix/core/BeanExclusionProcessor.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/BeanExclusionProcessor.java
@@ -36,6 +36,7 @@ public class BeanExclusionProcessor implements BeanDefinitionRegistryPostProcess
     private static final Logger log = LoggerFactory.getLogger(BeanExclusionProcessor.class);
 
     private final JmixModules modules;
+
     private List<String> beansToExclude = new ArrayList<>();
 
     public BeanExclusionProcessor(JmixModules modules) {

--- a/jmix-core/core/src/main/java/io/jmix/core/CoreConfiguration.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/CoreConfiguration.java
@@ -53,8 +53,8 @@ public class CoreConfiguration {
     }
 
     @Bean("core_BeanExclusionProcessor")
-    public static BeanExclusionProcessor beanExclusionProcessor() {
-        return new BeanExclusionProcessor();
+    public static BeanExclusionProcessor beanExclusionProcessor(JmixModules modules) {
+        return new BeanExclusionProcessor(modules);
     }
 
     @Bean("core_Modules")


### PR DESCRIPTION
Fixes #3129