### PR TITLE
Fields in genericFilter are not aligned if one label is longer jmix-framework/jmix#2745

### DIFF
--- a/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-lumo/component/vaadin-form-layout.css
+++ b/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-lumo/component/vaadin-form-layout.css
@@ -14,15 +14,12 @@
  * limitations under the License.
  */
 
-vaadin-form-item[theme~='jmix-group-filter-form-item']:not([label-position='top']) {
-  align-items: center;
-}
-
 vaadin-form-item[theme~='jmix-group-filter-form-item']:not([label-position='top'])::part(label) {
   margin: 0;
 }
 
 vaadin-form-item[theme~='label-align-end']:not([label-position='top'])::part(label) {
-  display: flex;
-  justify-content: end;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }

--- a/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-lumo/component/vaadin-form-layout.css
+++ b/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-lumo/component/vaadin-form-layout.css
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+vaadin-form-item[theme~='jmix-group-filter-form-item']:not([label-position='top']) {
+  align-items: center;
+}
+
 vaadin-form-item[theme~='jmix-group-filter-form-item']:not([label-position='top'])::part(label) {
   margin: 0;
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/filter/SingleFilterComponentBase.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/filter/SingleFilterComponentBase.java
@@ -236,6 +236,7 @@ public abstract class SingleFilterComponentBase<V> extends CustomField<V>
             super.setLabel(labelVisible ? labelText : null);
         } else {
             this.label.setText(labelVisible ? labelText : null);
+            this.label.setTitle(labelVisible && labelText != null ? labelText : "");
             this.label.setVisible(labelVisible);
         }
     }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/logicalfilter/GroupFilter.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/logicalfilter/GroupFilter.java
@@ -158,7 +158,10 @@ public class GroupFilter extends Composite<VerticalLayout>
 
             registerFilterComponentFormItem(filterComponent, formItem);
 
-            singleFilterComponent.setLabelDelegate(label::setText);
+            singleFilterComponent.setLabelDelegate(labelText -> {
+                label.setText(labelText);
+                label.setTitle(labelText != null ? labelText : "");
+            });
         } else if (filterComponent instanceof GroupFilter) {
             GroupFilter groupFilter = (GroupFilter) filterComponent;
             conditionsLayout.add(groupFilter, 3);


### PR DESCRIPTION
See: #2745

New approach is implemented: now, overflowing text will be hidden.

A title for the label component is also added.
![image](https://github.com/jmix-framework/jmix/assets/75516667/ce5bf075-d49e-4ffe-9e34-6b614770e319)
