### PR TITLE
Improvment awsfs save stream

### DIFF
--- a/jmix-awsfs/awsfs/src/main/java/io/jmix/awsfs/AwsFileStorage.java
+++ b/jmix-awsfs/awsfs/src/main/java/io/jmix/awsfs/AwsFileStorage.java
@@ -194,6 +194,7 @@ public class AwsFileStorage implements FileStorage {
     @Override
     public FileRef saveStream(String fileName, InputStream inputStream, Map<String, Object> parameters) {
         String fileKey = createFileKey(fileName);
+        String bucket = this.bucket;
         int s3ChunkSizeBytes = this.chunkSize * 1024;
         try (BufferedInputStream bos = new BufferedInputStream(inputStream, s3ChunkSizeBytes)) {
             S3Client s3Client = s3ClientReference.get();

--- a/jmix-awsfs/awsfs/src/main/java/io/jmix/awsfs/AwsFileStorage.java
+++ b/jmix-awsfs/awsfs/src/main/java/io/jmix/awsfs/AwsFileStorage.java
@@ -249,6 +249,7 @@ public class AwsFileStorage implements FileStorage {
     }
 
     private RequestBody fromBytes(byte[] buffer, int length) {
+        length = Math.max(0, length);
         byte[] bytes = Arrays.copyOf(buffer, length);
         return RequestBody.fromContentProvider(() -> new ByteArrayInputStream(bytes), length, Mimetype.MIMETYPE_OCTET_STREAM);
     }

--- a/jmix-awsfs/awsfs/src/main/java/io/jmix/awsfs/AwsFileStorage.java
+++ b/jmix-awsfs/awsfs/src/main/java/io/jmix/awsfs/AwsFileStorage.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.internal.util.Mimetype;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.regions.Region;
@@ -58,9 +59,11 @@ import software.amazon.awssdk.services.s3.model.S3Object;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
@@ -251,6 +254,11 @@ public class AwsFileStorage implements FileStorage {
             String message = String.format("Could not save file %s.", fileName);
             throw new FileStorageException(FileStorageException.Type.IO_EXCEPTION, message);
         }
+    }
+
+    private RequestBody fromBytes(byte[] buffer, int length) {
+        byte[] bytes = Arrays.copyOf(buffer, length);
+        return RequestBody.fromContentProvider(() -> new ByteArrayInputStream(bytes), length, Mimetype.MIMETYPE_OCTET_STREAM);
     }
 
     @Override


### PR DESCRIPTION
- Reduce the number of requests to upload small files
- Replace BufferedInputStream.available() (#327)
- Reduce memory allocation for multipart upload
- Make upload bucket name thread safe when refresh s3 client 