### PR TITLE
ApplicationListener defined in main view doesn't work after navigating to another view (3222)

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
@@ -36,6 +36,7 @@ import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.flowui.Notifications;
 import io.jmix.flowui.UiViewProperties;
 import io.jmix.flowui.accesscontext.UiEntityContext;
+import io.jmix.flowui.component.UiComponentUtils;
 import io.jmix.flowui.component.validation.ValidationErrors;
 import io.jmix.flowui.component.validation.group.UiCrossFieldChecks;
 import io.jmix.flowui.model.*;
@@ -96,6 +97,7 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
         addBeforeShowListener(this::onBeforeShow);
         addReadyListener(this::onReady);
         addBeforeCloseListener(this::onBeforeClose);
+        addAfterCloseListener(this::onAfterClose);
 
         setPreventBrowserTabClosing(true);
     }
@@ -111,6 +113,26 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
 
     private void onBeforeClose(BeforeCloseEvent event) {
         preventUnsavedChanges(event);
+    }
+
+    private void onAfterClose(AfterCloseEvent event) {
+        removeApplicationListeners();
+        removeViewAttributes();
+        unregisterBackNavigation();
+    }
+
+    @Override
+    protected void onDetachInternal() {
+        removeApplicationListeners();
+
+        // In case of Detail View, we remove ViewAttributes in detach event,
+        // only if it is attached to a dialog, because we want to preserve
+        // them if page is reloaded. For same reason, we don't unregister
+        // backward navigation here and do it if we leave a detail view
+        // by properly closing it.
+        if (UiComponentUtils.isComponentAttachedToDialog(this)) {
+            removeViewAttributes();
+        }
     }
 
     private void setupModifiedTracking() {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/View.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/View.java
@@ -20,8 +20,8 @@ import com.vaadin.flow.component.*;
 import com.vaadin.flow.router.*;
 import com.vaadin.flow.server.VaadinSession;
 import com.vaadin.flow.shared.Registration;
+import io.jmix.core.annotation.Internal;
 import io.jmix.flowui.UiViewProperties;
-import io.jmix.flowui.component.UiComponentUtils;
 import io.jmix.flowui.event.view.ViewClosedEvent;
 import io.jmix.flowui.event.view.ViewOpenedEvent;
 import io.jmix.flowui.model.ViewData;
@@ -75,13 +75,6 @@ public class View<T extends Component> extends Composite<T>
 
     public View() {
         closeDelegate = createDefaultViewDelegate();
-        addAfterCloseListener(this::onAfterClose);
-    }
-
-    private void onAfterClose(AfterCloseEvent event) {
-        removeApplicationListeners();
-        removeViewAttributes();
-        unregisterBackNavigation();
     }
 
     private Consumer<View<T>> createDefaultViewDelegate() {
@@ -177,28 +170,32 @@ public class View<T extends Component> extends Composite<T>
     protected void onDetach(DetachEvent detachEvent) {
         super.onDetach(detachEvent);
 
-        removeApplicationListeners();
-        if (UiComponentUtils.isComponentAttachedToDialog(this)) {
-            removeViewAttributes();
-        }
+        onDetachInternal();
 
         if (isPreventBrowserTabClosing()) {
             WebBrowserTools.allowBrowserTabClosing(this);
         }
     }
 
-    private void unregisterBackNavigation() {
+    @Internal
+    protected void onDetachInternal() {
+        removeApplicationListeners();
+        removeViewAttributes();
+        unregisterBackNavigation();
+    }
+
+    protected void unregisterBackNavigation() {
         getViewSupport().unregisterBackwardNavigation(this);
     }
 
-    private void removeApplicationListeners() {
+    protected void removeApplicationListeners() {
         VaadinSession session = VaadinSession.getCurrent();
         if (session != null) {
             session.getAttribute(UiEventsManager.class).removeApplicationListeners(this);
         }
     }
 
-    private void removeViewAttributes() {
+    protected void removeViewAttributes() {
         getViewAttributes().removeAllAttributes();
     }
 


### PR DESCRIPTION
* Fix for https://github.com/jmix-framework/jmix/issues/2992 is suitable for a detail view only as it's the main consumer of view attributes and backward navigation.
* Now, `View` has more generic solution, suitable in most cases for all views. `StandardDetailView` implements its own logic.
* Corresponding methods became `protected`, so it's possible to override them.