### PR TITLE
Using DTO entities and non-persistent attributes in filter components

### DIFF
--- a/jmix-data/eclipselink/src/test/groovy/not_only_jpa/JpqlBuilderWithNonJpaPropertiesTest.groovy
+++ b/jmix-data/eclipselink/src/test/groovy/not_only_jpa/JpqlBuilderWithNonJpaPropertiesTest.groovy
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package not_only_jpa
+
+import io.jmix.core.querycondition.Condition
+import io.jmix.core.querycondition.LogicalCondition
+import io.jmix.core.querycondition.PropertyCondition
+import io.jmix.data.impl.JpqlQueryBuilder
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.annotation.Autowired
+import test_support.DataSpec
+import test_support.entity.sales.Customer
+
+class JpqlBuilderWithNonJpaPropertiesTest extends DataSpec {
+
+    @Autowired
+    BeanFactory beanFactory
+
+    def "test only non-jpa properties in conditions"(Condition condition) {
+        JpqlQueryBuilder queryBuilder
+
+        when:
+        queryBuilder = beanFactory.getBean(JpqlQueryBuilder)
+                .setEntityName('data_TestEntityWithNonPersistentRef')
+                .setQueryString('select e from data_TestEntityWithNonPersistentRef e')
+                .setCondition(condition)
+                .setQueryParameters([:])
+
+        then:
+        queryBuilder.getResultQueryString() == 'select e from data_TestEntityWithNonPersistentRef e'
+        queryBuilder.getResultParameters().size() == 0
+
+        where:
+        condition << [
+                LogicalCondition.and()
+                              .add(PropertyCondition.equal('customer', new Customer())),
+
+                LogicalCondition.and()
+                        .add(PropertyCondition.equal('customer.name', 'abc')),
+
+                LogicalCondition.and()
+                        .add(PropertyCondition.equal('customer.name', 'abc'))
+                        .add(PropertyCondition.equal('customer.id', UUID.randomUUID())),
+
+                LogicalCondition.and()
+                        .add(PropertyCondition.equal('customer.name', 'abc'))
+                        .add(LogicalCondition.or(
+                                PropertyCondition.equal('customer.id', UUID.randomUUID())
+                        ))
+        ]
+    }
+
+    def "test jpa and non-jpa properties in conditions"() {
+        JpqlQueryBuilder queryBuilder
+
+        when:
+        def condition = LogicalCondition.and()
+                .add(PropertyCondition.createWithParameterName('name', PropertyCondition.Operation.EQUAL, 'name'))
+                .add(PropertyCondition.equal('customer.name', 'abc'))
+                .add(LogicalCondition.or(
+                        PropertyCondition.equal('customer.id', UUID.randomUUID())
+                ))
+
+        queryBuilder = beanFactory.getBean(JpqlQueryBuilder)
+                .setEntityName('data_TestEntityWithNonPersistentRef')
+                .setQueryString('select e from data_TestEntityWithNonPersistentRef e')
+                .setCondition(condition)
+                .setQueryParameters(['name': 'abc'])
+
+        then:
+        queryBuilder.getResultQueryString() == 'select e from data_TestEntityWithNonPersistentRef e where (e.name = :name)'
+        queryBuilder.getResultParameters().size() == 1
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/UiComponentProperties.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/UiComponentProperties.java
@@ -78,6 +78,11 @@ public class UiComponentProperties {
     boolean filterShowConfigurationIdField;
 
     /**
+     * Whether non-JPA properties for filter should be visible in the {@link AddConditionView}.
+     */
+    boolean filterShowNonJpaProperties;
+
+    /**
      * Whether validation of filter configuration name uniqueness should be enabled
      */
     boolean filterConfigurationUniqueNamesEnabled;
@@ -105,6 +110,7 @@ public class UiComponentProperties {
             String filterApplyShortcut,
             @DefaultValue("2") int filterPropertiesHierarchyDepth,
             @DefaultValue("false") boolean filterShowConfigurationIdField,
+            @DefaultValue("true") boolean filterShowNonJpaProperties,
             @DefaultValue("true") boolean filterConfigurationUniqueNamesEnabled,
             @DefaultValue("true") boolean showErrorMessageBelowField) {
         this.gridCreateShortcut = gridCreateShortcut;
@@ -127,6 +133,7 @@ public class UiComponentProperties {
         this.filterApplyShortcut = filterApplyShortcut;
         this.filterPropertiesHierarchyDepth = filterPropertiesHierarchyDepth;
         this.filterShowConfigurationIdField = filterShowConfigurationIdField;
+        this.filterShowNonJpaProperties = filterShowNonJpaProperties;
         this.filterConfigurationUniqueNamesEnabled = filterConfigurationUniqueNamesEnabled;
 
         this.showErrorMessageBelowField = showErrorMessageBelowField;
@@ -219,6 +226,13 @@ public class UiComponentProperties {
      */
     public boolean isFilterShowConfigurationIdField() {
         return filterShowConfigurationIdField;
+    }
+
+    /**
+     * @see #filterShowNonJpaProperties
+     */
+    public boolean isFilterShowNonJpaProperties() {
+        return filterShowNonJpaProperties;
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/app/filter/condition/AddConditionView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/app/filter/condition/AddConditionView.java
@@ -138,7 +138,7 @@ public class AddConditionView extends StandardListView<FilterCondition> {
                         new UiGenericFilterModifyJpqlConditionContext();
                 accessManager.applyRegisteredConstraints(jpqlConditionsContext);
 
-                if (!jpqlConditionsContext.isPermitted()) {
+                if (!jpqlConditionsContext.isPermitted() || !filterMetaClass.getStore().getDescriptor().isJpa()) {
                     continue;
                 }
             }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/FilterMetadataTools.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/FilterMetadataTools.java
@@ -116,12 +116,8 @@ public class FilterMetadataTools {
 
         return context.canView()
                 && !metadataTools.isSystemLevel(propertyPath.getMetaProperty())
-                && ((metadataTools.isJpa(propertyPath)
-                || (propertyPath.getMetaClass() instanceof KeyValueMetaClass
-                && !isAggregateFunction(propertyPath, query)
-                && isKeyValueCrossDataStoreReferenceAllowed(propertyPath, query)))
-                || (isCrossDataStoreReference(propertyPath.getMetaProperty())
-                && !(propertyPath.getMetaClass() instanceof KeyValueMetaClass)))
+                && (!isAggregateFunction(propertyPath, query) && isKeyValueCrossDataStoreReferenceAllowed(propertyPath, query)
+                        || isCrossDataStoreReference(propertyPath.getMetaProperty()) && !(propertyPath.getMetaClass() instanceof KeyValueMetaClass))
                 && !(byte[].class.equals(propertyPath.getMetaProperty().getJavaType()));
     }
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/FilterMetadataTools.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/FilterMetadataTools.java
@@ -116,9 +116,26 @@ public class FilterMetadataTools {
 
         return context.canView()
                 && !metadataTools.isSystemLevel(propertyPath.getMetaProperty())
-                && (!isAggregateFunction(propertyPath, query) && isKeyValueCrossDataStoreReferenceAllowed(propertyPath, query)
-                        || isCrossDataStoreReference(propertyPath.getMetaProperty()) && !(propertyPath.getMetaClass() instanceof KeyValueMetaClass))
-                && !(byte[].class.equals(propertyPath.getMetaProperty().getJavaType()));
+                && !(byte[].class.equals(propertyPath.getMetaProperty().getJavaType()))
+                && isMetaPropertyPathAllowedJpaAware(propertyPath, query);
+    }
+
+    protected boolean isMetaPropertyPathAllowedJpaAware(MetaPropertyPath propertyPath, String query) {
+        return componentProperties.isFilterShowNonJpaProperties()
+                ? isKeyValueQueryAllowed(propertyPath, query) || isCrossDataStoreReferenceAllowed(propertyPath)
+                : (metadataTools.isJpa(propertyPath)
+                || (propertyPath.getMetaClass() instanceof KeyValueMetaClass && isKeyValueQueryAllowed(propertyPath, query)))
+                || isCrossDataStoreReferenceAllowed(propertyPath);
+    }
+
+    protected boolean isKeyValueQueryAllowed(MetaPropertyPath propertyPath, String query) {
+        return !isAggregateFunction(propertyPath, query)
+                && isKeyValueCrossDataStoreReferenceAllowed(propertyPath, query);
+    }
+
+    protected boolean isCrossDataStoreReferenceAllowed(MetaPropertyPath propertyPath) {
+        return isCrossDataStoreReference(propertyPath.getMetaProperty())
+                && !(propertyPath.getMetaClass() instanceof KeyValueMetaClass);
     }
 
     @SuppressWarnings("unused")


### PR DESCRIPTION
This implementation removes the restriction on JPA properties for the filter. Thus, entities and non-persistent properties are added to a set of meta property paths available for filtering.

E.g.: DTO Entity:
```java
@JmixEntity
public class TestEntity {
    
    @JmixGeneratedValue
    @JmixId
    private UUID id;

    @InstanceName
    private String name;

    public String getName() {
        return name;
    }

    public void setName(String name) {
        this.name = name;
    }

    public UUID getId() {
        return id;
    }

    public void setId(UUID id) {
        this.id = id;
    }
}
````

The properties become available in the `Add Condition` dialog:
![image](https://github.com/jmix-framework/jmix/assets/75516667/fb9e427f-d93a-4c22-92fb-10de030e7b24)

When you select any property, the **query** is modified in the data loader. This information is passed to the `LoadContext`, which can be processed in the `LoadDelegate`:
![image](https://github.com/jmix-framework/jmix/assets/75516667/2dd9fd70-718b-4aa2-827f-9babe7b6b720)

The you can use this information to process a set of non-persistent entities.
For example:
```java
    @Install(to = "testEntitiesDl", target = Target.DATA_LOADER)
    protected List<TestEntity> testEntitiesDlLoadDelegate(LoadContext<TestEntity> loadContext) {
        LoadContext.Query query = loadContext.getQuery();
        if (query == null) {
            return Collections.emptyList();
        }

        return entities.stream()
                .skip(query.getFirstResult())
                .limit(query.getMaxResults())
                .filter(testEntity -> isAcceptable(testEntity, query.getCondition()))
                .collect(Collectors.toList());
    }

    protected boolean isAcceptable(TestEntity entity, Condition condition) {
        // implement custom filter logic
        if (condition instanceof LogicalCondition logicalCondition
                && logicalCondition.getConditions().size() == 1
                && logicalCondition.getConditions().get(0) instanceof PropertyCondition propertyCondition
                && propertyCondition.getOperation().equals(PropertyCondition.Operation.CONTAINS)
                && "name".equals(propertyCondition.getProperty())
                && propertyCondition.getParameterValue() != null) {
            return entity.getName().contains(String.valueOf(propertyCondition.getParameterValue()));
        }

        return true;
    }
```

Ideally, we need to write a converter of `io.jmix.core.querycondition.Condition` into some kind of predicate.
This example uses a hardcoded check for the `name contains` operation.

> **Note:** sorting and pagination for DTO entities works out of the box

The test project attached: [dto-filter.zip](https://github.com/jmix-framework/jmix/files/15249866/dto-filter.zip)

