### PR TITLE
AuthenticationPrincipalResolver mechanism introduced

### DIFF
--- a/jmix-authserver/authserver-starter/src/main/java/io/jmix/autoconfigure/authserver/AuthServerAutoConfiguration.java
+++ b/jmix-authserver/authserver-starter/src/main/java/io/jmix/autoconfigure/authserver/AuthServerAutoConfiguration.java
@@ -22,6 +22,7 @@ import io.jmix.authserver.authentication.OAuth2ResourceOwnerPasswordTokenEndpoin
 import io.jmix.authserver.filter.AsResourceServerEventSecurityFilter;
 import io.jmix.authserver.introspection.AuthorizationServiceOpaqueTokenIntrospector;
 import io.jmix.authserver.introspection.TokenIntrospectorRolesHelper;
+import io.jmix.authserver.principal.AuthServerAuthenticationPrincipalResolver;
 import io.jmix.authserver.roleassignment.InMemoryRegisteredClientRoleAssignmentRepository;
 import io.jmix.authserver.roleassignment.RegisteredClientRoleAssignment;
 import io.jmix.authserver.roleassignment.RegisteredClientRoleAssignmentPropertiesMapper;
@@ -154,6 +155,12 @@ public class AuthServerAutoConfiguration {
             Collection<RegisteredClientRoleAssignment> registeredClientRoleAssignments =
                     new RegisteredClientRoleAssignmentPropertiesMapper(authServerProperties).asRegisteredClientRoleAssignments();
             return new InMemoryRegisteredClientRoleAssignmentRepository(registeredClientRoleAssignments);
+        }
+
+        @Bean("authsr_AuthServerAuthenticationPrincipalResolver")
+        @Order(100)
+        AuthServerAuthenticationPrincipalResolver authServerAuthenticationPrincipalResolver() {
+            return new AuthServerAuthenticationPrincipalResolver();
         }
     }
 

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/principal/AuthServerAuthenticationPrincipalResolver.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/principal/AuthServerAuthenticationPrincipalResolver.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.authserver.principal;
+
+import io.jmix.authserver.introspection.UserDetailsOAuth2AuthenticatedPrincipal;
+import io.jmix.core.security.AuthenticationPrincipalResolver;
+import io.jmix.core.security.CurrentAuthentication;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthentication;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+
+/**
+ * A {@link AuthenticationPrincipalResolver} that makes the {@link CurrentAuthentication#getUser()} method return an
+ * instance of the actual user class (usually a JPA entity defined in the application) if authenticated using access
+ * token.
+ *
+ * @see CurrentAuthentication#getUser()
+ */
+public class AuthServerAuthenticationPrincipalResolver implements AuthenticationPrincipalResolver {
+
+    @Override
+    public boolean supports(Authentication authentication) {
+        if (authentication instanceof BearerTokenAuthentication bearerTokenAuthentication) {
+            return bearerTokenAuthentication.getPrincipal() instanceof UserDetailsOAuth2AuthenticatedPrincipal;
+        }
+        return false;
+    }
+
+    @Override
+    public Object resolveAuthenticationPrincipal(Authentication authentication) {
+        if (authentication instanceof BearerTokenAuthentication auth) {
+            if (auth.getPrincipal() instanceof UserDetailsOAuth2AuthenticatedPrincipal principal) {
+                Object nestedPrincipal = principal.getAttribute(Principal.class.getName());
+                if (nestedPrincipal instanceof UsernamePasswordAuthenticationToken token) {
+                    return token.getPrincipal();
+                }
+            }
+        }
+        return authentication.getPrincipal();
+    }
+}

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/principal/package-info.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/principal/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+package io.jmix.authserver.principal;
+
+import org.springframework.lang.NonNullApi;

--- a/jmix-core/core/src/main/java/io/jmix/core/security/AuthenticationPrincipalResolver.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/security/AuthenticationPrincipalResolver.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core.security;
+
+import org.springframework.security.core.Authentication;
+
+/**
+ * Strategy for resolving a principal from the authentication. Used by {@link CurrentAuthentication#getUser()}.
+ *
+ * @see CurrentAuthentication#getUser()
+ */
+public interface AuthenticationPrincipalResolver {
+
+    /**
+     * Checks if resolving strategy supports authentication from the current security context
+     */
+    boolean supports(Authentication authentication);
+
+    /**
+     * Resolves a principal from the authentication
+     */
+    Object resolveAuthenticationPrincipal(Authentication authentication);
+}


### PR DESCRIPTION
The issue: #2051 

`AuthenticationPrincipalResolver` mechanism has been introduced.

This is required to make the `CurrentAuthentication.getUser()` return an instance of actual user class when authenticating using the access token obtained with Authorization Server add-on.