### PR TITLE
Generic Component XML Element (841)

### DIFF
--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/StudioPropertyType.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/StudioPropertyType.java
@@ -91,6 +91,11 @@ public enum StudioPropertyType {
     ENUM_CLASS,
 
     /**
+     * FQN of UI Component class.
+     */
+    COMPONENT_CLASS,
+
+    /**
      * Value from a strict list of property options.
      */
     ENUMERATION,

--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/component/StudioComponents.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/component/StudioComponents.java
@@ -16,6 +16,7 @@
 
 package io.jmix.flowui.kit.meta.component;
 
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Html;
 import com.vaadin.flow.component.applayout.DrawerToggle;
 import com.vaadin.flow.component.avatar.Avatar;
@@ -60,9 +61,30 @@ import io.jmix.flowui.kit.component.upload.JmixFileUploadField;
 import io.jmix.flowui.kit.component.valuepicker.MultiValuePicker;
 import io.jmix.flowui.kit.component.valuepicker.ValuePicker;
 import io.jmix.flowui.kit.meta.*;
+import io.jmix.flowui.kit.meta.component.preview.StudioGenericComponentPreview;
 
 @StudioUiKit
 public interface StudioComponents {
+
+    @StudioComponent(
+            name = "GenericComponent",
+            classFqn = "com.vaadin.flow.component.Component",
+            category = "Components",
+            xmlElement = "component",
+            properties = {
+                    @StudioProperty(xmlAttribute = "id", type = StudioPropertyType.COMPONENT_ID),
+                    @StudioProperty(xmlAttribute = "css", type = StudioPropertyType.STRING),
+                    @StudioProperty(xmlAttribute = "visible", type = StudioPropertyType.BOOLEAN,
+                            defaultValue = "true"),
+                    @StudioProperty(xmlAttribute = "colspan", type = StudioPropertyType.INTEGER),
+                    @StudioProperty(xmlAttribute = "alignSelf", type = StudioPropertyType.ENUMERATION,
+                            classFqn = "com.vaadin.flow.component.orderedlayout.FlexComponent$Alignment",
+                            defaultValue = "AUTO",
+                            options = {"START", "END", "CENTER", "STRETCH", "BASELINE", "AUTO"}),
+                    @StudioProperty(xmlAttribute = "component", type = StudioPropertyType.STRING),
+            }
+    )
+    StudioGenericComponentPreview genericComponent();
 
     @StudioComponent(
             name = "Avatar",

--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/component/preview/StudioGenericComponentPreview.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/component/preview/StudioGenericComponentPreview.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.kit.meta.component.preview;
+
+import com.vaadin.flow.component.html.Image;
+
+/**
+ * Stub component for Studio preview use only.
+ */
+public class StudioGenericComponentPreview extends Image {
+
+    public StudioGenericComponentPreview() {
+        initImage();
+    }
+
+    protected void initImage() {
+        setSrc("icons/studio-generic-component-preview.svg");
+    }
+}

--- a/jmix-flowui/flowui-kit/src/main/resources/META-INF/resources/icons/studio-generic-component-preview.svg
+++ b/jmix-flowui/flowui-kit/src/main/resources/META-INF/resources/icons/studio-generic-component-preview.svg
@@ -1,0 +1,19 @@
+<!--
+  - Copyright 2022 Haulmont.
+  -
+  - Licensed under the Apache License, Version 2.0 (the "License");
+  - you may not use this file except in compliance with the License.
+  - You may obtain a copy of the License at
+  -
+  -     http://www.apache.org/licenses/LICENSE-2.0
+  -
+  - Unless required by applicable law or agreed to in writing, software
+  - distributed under the License is distributed on an "AS IS" BASIS,
+  - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  - See the License for the specific language governing permissions and
+  - limitations under the License.
+  -->
+
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.5" y="2.5" width="13" height="11" rx="2.5" stroke="#9AA7B0"/>
+</svg>

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/BaseLoaderConfig.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/BaseLoaderConfig.java
@@ -18,6 +18,7 @@ package io.jmix.flowui.xml.layout;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.RangeInput;
+import io.jmix.flowui.xml.layout.loader.GenericComponentLoader;
 import io.jmix.flowui.xml.layout.loader.component.*;
 import io.jmix.flowui.xml.layout.loader.container.*;
 import io.jmix.flowui.xml.layout.loader.html.*;
@@ -34,6 +35,8 @@ public abstract class BaseLoaderConfig {
     }
 
     protected void initStandardLoaders() {
+        loaders.put("component", GenericComponentLoader.class);
+
         /* Abstract layouts */
         loaders.put("hbox", HorizontalLayoutLoader.class);
         loaders.put("vbox", VerticalLayoutLoader.class);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/ComponentPropertiesParsingManager.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/ComponentPropertiesParsingManager.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.xml.layout.loader;
+
+import com.google.common.base.Splitter;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.spring.annotation.SpringComponent;
+import io.jmix.core.ClassManager;
+import io.jmix.core.DevelopmentException;
+import io.jmix.core.common.util.Preconditions;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
+
+import java.lang.reflect.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@SpringComponent("flowui_ComponentPropertiesParsingManager")
+public class ComponentPropertiesParsingManager {
+
+    private static final Logger log = LoggerFactory.getLogger(ComponentPropertiesParsingManager.class);
+
+    protected final List<ComponentPropertyParser> parsers;
+    protected final ClassManager classManager;
+
+    public ComponentPropertiesParsingManager(List<ComponentPropertyParser> parsers,
+                                             ClassManager classManager) {
+        this.parsers = parsers;
+        this.classManager = classManager;
+    }
+
+    /**
+     * Parses a value from string representation and sets it to a component property.
+     *
+     * @param context a context object
+     */
+    public void parse(ComponentPropertyParsingContext context) {
+        Component component = context.component();
+        String propertyName = context.propertyName();
+
+        String setterName = "set" + StringUtils.capitalize(propertyName);
+        try {
+            Method method = Arrays.stream(component.getClass().getMethods())
+                    .filter(m -> m.getName().equals(setterName) && m.getParameterCount() == 1)
+                    .findAny()
+                    .orElseThrow(() -> new DevelopmentException("Unable to set component property '" +
+                            propertyName + "': cannot find setter method with single parameter"));
+
+            Class<?> parameterType = method.getParameterTypes()[0];
+            Type genericParameterType = method.getGenericParameterTypes()[0];
+
+            Object value = context.type() != null
+                    ? parseValueByType(context)
+                    : parseInternal(context.value(), parameterType, genericParameterType);
+
+            method.invoke(component, value);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            throw new DevelopmentException("Unable to set component property '" + propertyName + "': " + e);
+        }
+    }
+
+    protected Object parseValueByType(ComponentPropertyParsingContext context) {
+        for (ComponentPropertyParser parser : parsers) {
+            if (parser.supports(context)) {
+                return parser.parse(context);
+            }
+        }
+
+        throw new IllegalArgumentException(
+                String.format("Can't parse component property for the '%s' type", context.type()));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Nullable
+    protected Object parseInternal(String stringValue, Type propType, @Nullable Type genericParameterType) {
+        Object value = null;
+
+        if (String.class == propType) {
+            value = stringValue;
+
+        } else if (Class.class == propType) {
+            value = classManager.loadClass(stringValue);
+
+        } else if (Boolean.class == propType || Boolean.TYPE == propType) {
+            value = Boolean.valueOf(stringValue);
+
+        } else if (Byte.class == propType || Byte.TYPE == propType) {
+            value = parseNumber(stringValue, Byte.class);
+
+        } else if (Short.class == propType || Short.TYPE == propType) {
+            value = parseNumber(stringValue, Short.class);
+
+        } else if (Integer.class == propType || Integer.TYPE == propType) {
+            value = parseNumber(stringValue, Integer.class);
+
+        } else if (Long.class == propType || Long.TYPE == propType) {
+            value = parseNumber(stringValue, Long.class);
+
+        } else if (Float.class == propType || Float.TYPE == propType) {
+            value = parseNumber(stringValue, Float.class);
+
+        } else if (Double.class == propType || Double.TYPE == propType) {
+            value = parseNumber(stringValue, Double.class);
+
+        } else if (List.class == propType) {
+            value = parseList(stringValue, genericParameterType);
+
+        } else if (Set.class == propType) {
+            value = parseSet(stringValue, genericParameterType);
+
+        } else if (propType instanceof Class<?> aClass && aClass.isEnum()) {
+            value = Enum.valueOf((Class<Enum>) aClass, stringValue);
+
+        } else if (propType instanceof Class<?> aClass && aClass.isArray()) {
+            value = parseArray(stringValue, aClass.getComponentType());
+
+        }
+
+        if (value == null) {
+            log.warn("Unable to set value {} for property of type {}", stringValue, propType);
+        }
+
+        return value;
+    }
+
+    protected Object parseNumber(String stringValue, Class<? extends Number> numberType) {
+        if (!NumberUtils.isParsable(stringValue)) {
+            throw new DevelopmentException(String.format("Unable to parse '%s' as '%s'", stringValue, numberType));
+        }
+        return org.springframework.util.NumberUtils.parseNumber(stringValue, numberType);
+    }
+
+    @Nullable
+    protected Object parseList(String stringValue, @Nullable Type genericParameterType) {
+        Stream<?> stream = parseStream(stringValue, genericParameterType, null);
+        return stream != null ? stream.toList() : null;
+    }
+
+    @Nullable
+    protected Object parseSet(String stringValue, @Nullable Type genericParameterType) {
+        Stream<?> stream = parseStream(stringValue, genericParameterType, null);
+        return stream != null ? stream.collect(Collectors.toSet()) : null;
+    }
+
+    @Nullable
+    protected Object parseArray(String stringValue, Type arrayItemType) {
+        Preconditions.checkNotNullArgument(arrayItemType);
+
+        Stream<?> stream = parseStream(stringValue, null, arrayItemType);
+        return stream != null
+                ? stream.toArray(size -> ((Object[]) Array.newInstance(((Class<?>) arrayItemType), size)))
+                : null;
+    }
+
+    @Nullable
+    protected Stream<?> parseStream(String stringValue,
+                                    @Nullable Type genericParameterType,
+                                    @Nullable Type arrayItemType) {
+        Type itemType;
+        if (genericParameterType instanceof ParameterizedType parameterizedType) {
+            itemType = parameterizedType.getActualTypeArguments()[0];
+        } else if (arrayItemType != null) {
+            itemType = arrayItemType;
+        } else {
+            return null;
+        }
+
+        return split(stringValue).stream()
+                .map(s -> parseInternal(s, itemType, null));
+    }
+
+    protected List<String> split(String stringValue) {
+        return Splitter.onPattern("[\\s,]+")
+                .trimResults()
+                .omitEmptyStrings()
+                .splitToList(stringValue);
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/ComponentPropertyParser.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/ComponentPropertyParser.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.xml.layout.loader;
+
+/**
+ * A parser for converting string representation into actual value by {@link ComponentPropertiesParsingManager}
+ */
+public interface ComponentPropertyParser {
+
+    /**
+     * @param context a context object
+     * @return whether this parser can parse a value from string representation
+     */
+    boolean supports(ComponentPropertyParsingContext context);
+
+    /**
+     * Parses a value from string representation.
+     *
+     * @param context a context object
+     * @return parsed value
+     */
+    Object parse(ComponentPropertyParsingContext context);
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/ComponentPropertyParsingContext.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/ComponentPropertyParsingContext.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.xml.layout.loader;
+
+import com.vaadin.flow.component.Component;
+import io.jmix.flowui.xml.layout.ComponentLoader;
+import org.springframework.lang.Nullable;
+
+/**
+ * An object that stores information about the value to be set for a component property.
+ *
+ * @param component    a component to set value
+ * @param propertyName property name
+ * @param value        string value representation
+ * @param type         optional type that helps determine actual parser
+ * @param context      component loader context
+ */
+public record ComponentPropertyParsingContext(Component component,
+                                              String propertyName,
+                                              String value,
+                                              @Nullable String type,
+                                              ComponentLoader.Context context) {
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/GenericComponentLoader.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/GenericComponentLoader.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.xml.layout.loader;
+
+import com.vaadin.flow.component.Component;
+import io.jmix.core.ClassManager;
+import io.jmix.flowui.exception.GuiDevelopmentException;
+import org.dom4j.Element;
+
+public class GenericComponentLoader extends AbstractComponentLoader<Component> {
+
+    protected ComponentPropertiesParsingManager propertyParser;
+
+    @Override
+    protected Component createComponent() {
+        String componentClass = loadString(element, "component")
+                .orElseThrow(() -> new GuiDevelopmentException("Missing required 'component' attribute", context));
+
+        Class<?> aClass = applicationContext.getBean(ClassManager.class).loadClass(componentClass);
+        if (!Component.class.isAssignableFrom(aClass)) {
+            throw new GuiDevelopmentException("Component class '" + componentClass + "' is not a component", context);
+        }
+
+        return factory.create(aClass.asSubclass(Component.class));
+    }
+
+    @Override
+    public void loadComponent() {
+        loadProperties();
+    }
+
+    protected void loadProperties() {
+        Element propertiesElement = element.element("properties");
+        if (propertiesElement != null) {
+            for (Element propertyElement : propertiesElement.elements("property")) {
+                loadProperty(propertyElement);
+            }
+        }
+    }
+
+    protected void loadProperty(Element element) {
+        String propertyName = loadString(element, "name")
+                .orElseThrow(() -> new GuiDevelopmentException("Missing required 'name' attribute", context));
+        String stringValue = loadString(element, "value")
+                .orElseThrow(() -> new GuiDevelopmentException("Missing required 'value' attribute", context));
+        String type = loadString(element, "type").orElse(null);
+
+        getPropertyParser().parse(
+                new ComponentPropertyParsingContext(resultComponent, propertyName, stringValue, type, context));
+    }
+
+    protected ComponentPropertiesParsingManager getPropertyParser() {
+        if (propertyParser == null) {
+            propertyParser = applicationContext.getBean(ComponentPropertiesParsingManager.class);
+        }
+        return propertyParser;
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/impl/DataContainerComponentPropertyParser.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/impl/DataContainerComponentPropertyParser.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.xml.layout.loader.impl;
+
+import io.jmix.core.JmixOrder;
+import io.jmix.flowui.xml.layout.ComponentLoader;
+import io.jmix.flowui.xml.layout.loader.ComponentPropertyParser;
+import io.jmix.flowui.xml.layout.loader.ComponentPropertyParsingContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Order(JmixOrder.LOWEST_PRECEDENCE - 10)
+@Component("flowui_DataContainerComponentPropertyParser")
+public class DataContainerComponentPropertyParser implements ComponentPropertyParser {
+
+    public static final String TYPE = "CONTAINER_REF";
+
+    @Override
+    public boolean supports(ComponentPropertyParsingContext context) {
+        return TYPE.equals(context.type())
+                && context.context() instanceof ComponentLoader.ComponentContext;
+    }
+
+    @Override
+    public Object parse(ComponentPropertyParsingContext context) {
+        if (context.context() instanceof ComponentLoader.ComponentContext componentContext) {
+            return componentContext.getViewData().getContainer(context.value());
+        }
+
+        throw new IllegalArgumentException("Cannot find data container, component loader 'context' must implement " +
+                ComponentLoader.ComponentContext.class.getName());
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/impl/DataLoaderComponentPropertyParser.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/impl/DataLoaderComponentPropertyParser.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.xml.layout.loader.impl;
+
+import io.jmix.core.JmixOrder;
+import io.jmix.flowui.xml.layout.ComponentLoader;
+import io.jmix.flowui.xml.layout.loader.ComponentPropertyParser;
+import io.jmix.flowui.xml.layout.loader.ComponentPropertyParsingContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Order(JmixOrder.LOWEST_PRECEDENCE - 10)
+@Component("flowui_DataLoaderComponentPropertyParser")
+public class DataLoaderComponentPropertyParser implements ComponentPropertyParser {
+
+    public static final String TYPE = "LOADER_REF";
+
+    @Override
+    public boolean supports(ComponentPropertyParsingContext context) {
+        return TYPE.equals(context.type())
+                && context.context() instanceof ComponentLoader.ComponentContext;
+    }
+
+    @Override
+    public Object parse(ComponentPropertyParsingContext context) {
+        if (context.context() instanceof ComponentLoader.ComponentContext componentContext) {
+            return componentContext.getViewData().getLoader(context.value());
+        }
+
+        throw new IllegalArgumentException("Cannot find data container, component loader 'context' must implement " +
+                ComponentLoader.ComponentContext.class.getName());
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/impl/IconComponentPropertyParser.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/impl/IconComponentPropertyParser.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.xml.layout.loader.impl;
+
+import io.jmix.core.JmixOrder;
+import io.jmix.flowui.kit.component.ComponentUtils;
+import io.jmix.flowui.xml.layout.loader.ComponentPropertyParser;
+import io.jmix.flowui.xml.layout.loader.ComponentPropertyParsingContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Order(JmixOrder.LOWEST_PRECEDENCE - 10)
+@Component("flowui_IconComponentPropertyParser")
+public class IconComponentPropertyParser implements ComponentPropertyParser {
+
+    public static final String TYPE = "ICON";
+
+    @Override
+    public boolean supports(ComponentPropertyParsingContext context) {
+        return TYPE.equals(context.type());
+    }
+
+    @Override
+    public Object parse(ComponentPropertyParsingContext context) {
+        return ComponentUtils.parseIcon(context.value());
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/impl/package-info.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/impl/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+package io.jmix.flowui.xml.layout.loader.impl;
+
+import org.springframework.lang.NonNullApi;

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
@@ -4141,6 +4141,49 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
+
+    <!-- Generic Component -->
+    <xs:complexType name="genericComponent">
+        <xs:complexContent>
+            <xs:extension base="baseComponent">
+                <xs:sequence>
+                    <xs:element name="properties" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:choice maxOccurs="unbounded">
+                                    <xs:element name="property" type="genericComponentProperty"/>
+                                </xs:choice>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                </xs:sequence>
+
+                <xs:attribute name="component" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="genericComponentProperty">
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="value" type="xs:string" use="required"/>
+        <xs:attribute name="type" type="genericComponentPropertyValueType"/>
+    </xs:complexType>
+
+    <xs:simpleType name="genericComponentPropertyValueType">
+        <xs:union>
+            <xs:simpleType>
+                <xs:restriction base="xs:string"/>
+            </xs:simpleType>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="CONTAINER_REF"/>
+                    <xs:enumeration value="LOADER_REF"/>
+                    <xs:enumeration value="ICON"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:union>
+    </xs:simpleType>
+
     <!--    HTML-->
 
     <!-- Html -->
@@ -4725,6 +4768,7 @@
                 <xs:element name="menuFilterField" type="menuFilterFieldComponent"/>
                 <xs:element name="horizontalMenu" type="horizontalMenuComponent"/>
                 <xs:element name="richTextEditor" type="richTextEditorComponent"/>
+                <xs:element name="component" type="genericComponent"/>
             </xs:choice>
         </xs:sequence>
     </xs:group>

--- a/jmix-flowui/flowui/src/test/groovy/component/generic_component/GenericComponentTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/generic_component/GenericComponentTest.groovy
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.generic_component
+
+import com.vaadin.flow.component.Component
+import com.vaadin.flow.component.icon.VaadinIcon
+//import component.composite.component.TestDataGridPanel
+import component.generic_component.view.GenericComponentTestView
+import io.jmix.flowui.component.propertyfilter.PropertyFilter
+import io.jmix.flowui.data.grid.ContainerDataGridItems
+import io.jmix.flowui.kit.component.button.JmixButton
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.lang.Nullable
+import test_support.spec.FlowuiTestSpecification
+
+@SpringBootTest
+class GenericComponentTest extends FlowuiTestSpecification {
+
+    @Override
+    void setup() {
+        registerViewBasePackages("component.generic_component.view")
+    }
+
+    def "Open view with generic components"() {
+        def view = navigateToView(GenericComponentTestView)
+
+        /*when:
+        def dataGridPanel = view.dataGridPanel
+
+        then:
+        dataGridPanel instanceof TestDataGridPanel
+        dataGridPanel.items instanceof ContainerDataGridItems*/
+
+        when:
+        def button = view.button
+
+        then:
+        button instanceof JmixButton
+        button.text == "Button"
+        getIconAttribute(button.icon) == getIconAttribute(VaadinIcon.PLUS.create())
+
+        when:
+        def propertyFilter = view.propertyFilter
+
+        then:
+        propertyFilter instanceof PropertyFilter
+        propertyFilter.property == "name"
+        propertyFilter.operation == PropertyFilter.Operation.CONTAINS
+        propertyFilter.dataLoader == view.productsDl
+        propertyFilter.parameterName == "productName"
+        propertyFilter.label == "Property Filter"
+        propertyFilter.tabIndex == 2
+
+        when:
+        def testComponent = view.testComponent
+
+        then:
+        testComponent.stringsList == List.of("a", "b", "c")
+        testComponent.stringsSet == Set.of("a", "b", "c")
+        testComponent.stringsArray == new String[]{"a", "b", "c"}
+        testComponent.strings == new String[]{"a", "b", "c"}
+    }
+
+    @Nullable
+    private static String getIconAttribute(Component icon) {
+        return icon != null ? icon.element.getAttribute("icon") : null
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/component/generic_component/component/TestComponent.java
+++ b/jmix-flowui/flowui/src/test/java/component/generic_component/component/TestComponent.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.generic_component.component;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.Tag;
+
+import java.util.List;
+import java.util.Set;
+
+@Tag("test-component")
+public class TestComponent extends Component {
+
+    List<String> stringsList;
+    Set<String> stringsSet;
+    String[] stringsArray;
+    String[] strings;
+
+    public List<String> getStringsList() {
+        return stringsList;
+    }
+
+    public void setStringsList(List<String> strings) {
+        this.stringsList = strings;
+    }
+
+    public Set<String> getStringsSet() {
+        return stringsSet;
+    }
+
+    public void setStringsSet(Set<String> stringsSet) {
+        this.stringsSet = stringsSet;
+    }
+
+    public String[] getStringsArray() {
+        return stringsArray;
+    }
+
+    public void setStringsArray(String[] stringsArray) {
+        this.stringsArray = stringsArray;
+    }
+
+    public String[] getStrings() {
+        return strings;
+    }
+
+    public void setStrings(String... strings) {
+        this.strings = strings;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/component/generic_component/view/GenericComponentTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/generic_component/view/GenericComponentTestView.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.generic_component.view;
+
+import com.vaadin.flow.router.Route;
+//import component.composite.component.TestDataGridPanel;
+import component.generic_component.component.TestComponent;
+import io.jmix.flowui.component.propertyfilter.PropertyFilter;
+import io.jmix.flowui.kit.component.button.JmixButton;
+import io.jmix.flowui.model.CollectionLoader;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import test_support.entity.sales.Product;
+
+@Route("GenericComponentTestView")
+@ViewController("GenericComponentTestView")
+@ViewDescriptor("generic-component-test-view.xml")
+public class GenericComponentTestView extends StandardView {
+
+    @ViewComponent
+    public CollectionLoader<Product> productsDl;
+
+//    @ViewComponent
+//    public TestDataGridPanel dataGridPanel;
+
+    @ViewComponent
+    public JmixButton button;
+
+    @ViewComponent
+    public PropertyFilter<?> propertyFilter;
+
+    @ViewComponent
+    public TestComponent testComponent;
+}

--- a/jmix-flowui/flowui/src/test/resources/component/generic_component/view/generic-component-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/generic_component/view/generic-component-test-view.xml
@@ -1,0 +1,66 @@
+<!--
+  ~ Copyright 2024 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <collection id="productsDc"
+                    class="test_support.entity.sales.Product">
+            <fetchPlan extends="_base"/>
+            <loader id="productsDl" readOnly="true">
+                <query>
+                    <![CDATA[select e from test_Product e]]>
+                </query>
+            </loader>
+        </collection>
+    </data>
+    <facets>
+        <dataLoadCoordinator auto="true"/>
+    </facets>
+    <layout>
+        <!--<component id="dataGridPanel" component="component.composite.component.TestDataGridPanel">
+            <properties>
+                <property name="dataContainer" value="productsDc" type="CONTAINER_REF"/>
+            </properties>
+        </component>-->
+
+        <component id="button" component="com.vaadin.flow.component.button.Button">
+            <properties>
+                <property name="text" value="Button"/>
+                <property name="icon" value="PLUS" type="ICON"/>
+            </properties>
+        </component>
+
+        <component id="propertyFilter" component="io.jmix.flowui.component.propertyfilter.PropertyFilter">
+            <properties>
+                <property name="property" value="name"/>
+                <property name="operation" value="CONTAINS"/>
+                <property name="dataLoader" value="productsDl" type="LOADER_REF"/>
+                <property name="parameterName" value="productName"/>
+                <property name="label" value="Property Filter"/>
+                <property name="tabIndex" value="2"/>
+            </properties>
+        </component>
+
+        <component id="testComponent" component="component.generic_component.component.TestComponent">
+            <properties>
+                <property name="stringsList" value="a b ,c"/>
+                <property name="stringsSet" value="a b ,c"/>
+                <property name="stringsArray" value="a b ,c"/>
+                <property name="strings" value="a b ,c"/>
+            </properties>
+        </component>
+    </layout>
+</view>


### PR DESCRIPTION
Fixes: #841

## Generic Component XML  element 

Added `component` xml element that is used to create any UI component by FQN. In order to define component properties the nested `property` elements can be used (similar to actions). 

For example:

```
<component id="button" component="com.vaadin.flow.component.button.Button">
    <properties>
        <property name="text" value="Button"/>
        <property name="icon" value="PLUS" type="ICON"/>
    </properties>
</component>

<component id="propertyFilter" component="io.jmix.flowui.component.propertyfilter.PropertyFilter">
    <properties>
        <property name="property" value="name"/>
        <property name="operation" value="CONTAINS"/>
        <property name="dataLoader" value="productsDl" type="LOADER_REF"/>
        <property name="parameterName" value="productName"/>
        <property name="label" value="Property Filter"/>
        <property name="tabIndex" value="2"/>
    </properties>
</component>

<component id="dataGridPanel" component="component.composite.component.TestDataGridPanel">
    <properties>
        <property name="dataContainer" value="productsDc" type="CONTAINER_REF"/>
    </properties>
</component>
```

### Properties limitations and specifics

* The `name` attribute value is converted to setter method name, e.g. `text` -> `setText`. 
* The first method with this name and a single input parameter is used to set the value.
   * (limitation) if there are several methods with the same name, no guarantee that the one you need is used to set the value
* The found method input parameter type is used to convert string value of the `value` attribute into actual value.
* The `type` attribute is used to indicate that string value representation must be converted by one of pluggable `ComponentPropertyParser` beans.

### ComponentPropertyParser

As been mentioned above, if string value cannot be parsed using input parameter type, e.g. icon which is a `Component` or data container which is defined by its id, pluggable `ComponentPropertyParser` beans is used. 

Currently there are three implementations:
* `IconComponentPropertyParser` - converts string into a new `Icon` instance with the icon determined by the passed string. If a passed string contains `:` delimiter then a new `Icon` is created using **icon collection** and **icon name** values, otherwise the passed string is considered as `VaadinIcon` constant name.
* `DataContainerComponentPropertyParser` - returns **data container** with the given `id` from corresponding view's `ViewData` object.
* `DataLoaderComponentPropertyParser` - returns **data loader** with the given `id` from corresponding view's `ViewData` object.