### PR TITLE
The message about the wrong data type cannot be localised 3284

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/AdaptiveNumberDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/AdaptiveNumberDatatype.java
@@ -144,13 +144,13 @@ public class AdaptiveNumberDatatype extends NumberDatatype implements Datatype<N
     protected void checkIntegerRange(String value, Number result) throws ParseException {
         if ((result instanceof Long || result instanceof Double)
                 && (result.longValue() > Integer.MAX_VALUE || result.longValue() < Integer.MIN_VALUE))
-            throw new ParseException(String.format("Integer range exceeded: \"%s\"", value), 0);
+            throw new ParseException(String.format(messages.getMessage("integerOutOfRangeMessage"), value), 0);
     }
 
     protected void checkLongRange(String value, Number result) throws ParseException {
         if (result instanceof Double
                 && (result.doubleValue() > Long.MAX_VALUE || result.doubleValue() < Long.MIN_VALUE))
-        throw new ParseException(String.format("Long range exceeded: \"%s\"", value), 0);
+        throw new ParseException(String.format(messages.getMessage("longOutOfRangeMessage"), value), 0);
     }
 
     @Override

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/AdaptiveNumberDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/AdaptiveNumberDatatype.java
@@ -145,14 +145,14 @@ public class AdaptiveNumberDatatype extends NumberDatatype implements Datatype<N
         if ((result instanceof Long || result instanceof Double)
                 && (result.longValue() > Integer.MAX_VALUE || result.longValue() < Integer.MIN_VALUE))
             throw new ParseException(messages.formatMessage(
-                    "","datatype.integerOutOfRange.message", value), 0);
+                    "", "datatype.integerOutOfRange.message", value), 0);
     }
 
     protected void checkLongRange(String value, Number result) throws ParseException {
         if (result instanceof Double
                 && (result.doubleValue() > Long.MAX_VALUE || result.doubleValue() < Long.MIN_VALUE))
             throw new ParseException(messages.formatMessage(
-                    "","datatype.longOutOfRange.message", value), 0);
+                    "", "datatype.longOutOfRange.message", value), 0);
     }
 
     @Override

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/AdaptiveNumberDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/AdaptiveNumberDatatype.java
@@ -144,13 +144,15 @@ public class AdaptiveNumberDatatype extends NumberDatatype implements Datatype<N
     protected void checkIntegerRange(String value, Number result) throws ParseException {
         if ((result instanceof Long || result instanceof Double)
                 && (result.longValue() > Integer.MAX_VALUE || result.longValue() < Integer.MIN_VALUE))
-            throw new ParseException(String.format(messages.getMessage("integerOutOfRangeMessage"), value), 0);
+            throw new ParseException(messages.formatMessage(
+                    "","datatype.integerOutOfRange.message", value), 0);
     }
 
     protected void checkLongRange(String value, Number result) throws ParseException {
         if (result instanceof Double
                 && (result.doubleValue() > Long.MAX_VALUE || result.doubleValue() < Long.MIN_VALUE))
-        throw new ParseException(String.format(messages.getMessage("longOutOfRangeMessage"), value), 0);
+            throw new ParseException(messages.formatMessage(
+                    "","datatype.longOutOfRange.message", value), 0);
     }
 
     @Override

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/BooleanDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/BooleanDatatype.java
@@ -34,8 +34,12 @@ public class BooleanDatatype implements Datatype<Boolean> {
     @Autowired
     protected FormatStringsRegistry formatStringsRegistry;
 
-    @Autowired
     protected Messages messages;
+
+    @Autowired
+    public void setMessages(Messages messages) {
+        this.messages = messages;
+    }
 
     @Override
     public String format(@Nullable Object value) {
@@ -65,7 +69,8 @@ public class BooleanDatatype implements Datatype<Boolean> {
             if (falseString.equalsIgnoreCase(value)) {
                 return Boolean.FALSE;
             }
-            throw new ParseException(String.format(messages.getMessage("booleanParseErrorMessage"), value), 0);
+            throw new ParseException(messages.formatMessage(
+                    "","datatype.unparseableBoolean.message", value), 0);
         }
         return null;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/BooleanDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/BooleanDatatype.java
@@ -70,7 +70,7 @@ public class BooleanDatatype implements Datatype<Boolean> {
                 return Boolean.FALSE;
             }
             throw new ParseException(messages.formatMessage(
-                    "","datatype.unparseableBoolean.message", value), 0);
+                    "", "datatype.unparseableBoolean.message", value), 0);
         }
         return null;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/BooleanDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/BooleanDatatype.java
@@ -16,6 +16,7 @@
 
 package io.jmix.core.metamodel.datatype.impl;
 
+import io.jmix.core.Messages;
 import io.jmix.core.metamodel.annotation.DatatypeDef;
 import io.jmix.core.metamodel.datatype.Datatype;
 import io.jmix.core.metamodel.datatype.FormatStrings;
@@ -32,6 +33,9 @@ public class BooleanDatatype implements Datatype<Boolean> {
 
     @Autowired
     protected FormatStringsRegistry formatStringsRegistry;
+
+    @Autowired
+    protected Messages messages;
 
     @Override
     public String format(@Nullable Object value) {
@@ -61,7 +65,7 @@ public class BooleanDatatype implements Datatype<Boolean> {
             if (falseString.equalsIgnoreCase(value)) {
                 return Boolean.FALSE;
             }
-            throw new ParseException(String.format("Can't parse '%s'", value), 0);
+            throw new ParseException(String.format(messages.getMessage("booleanParseErrorMessage"), value), 0);
         }
         return null;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/CharacterDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/CharacterDatatype.java
@@ -29,8 +29,12 @@ import java.util.Locale;
 @DatatypeDef(id = "char", javaClass = Character.class, defaultForClass = true, value = "core_CharacterDatatype")
 public class CharacterDatatype implements Datatype<Character> {
 
-    @Autowired
     protected Messages messages;
+
+    @Autowired
+    public void setMessages(Messages messages) {
+        this.messages = messages;
+    }
 
     @Override
     public String format(@Nullable Object value) {
@@ -49,8 +53,8 @@ public class CharacterDatatype implements Datatype<Character> {
             return null;
 
         if (value.length() > 1)
-            throw new ParseException(String.format(
-                    messages.getMessage("characterParseErrorMessage"), value), 0);
+            throw new ParseException(messages.formatMessage(
+                    "","datatype.unparseableCharacter.message", value), 0);
 
         return value.charAt(0);
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/CharacterDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/CharacterDatatype.java
@@ -54,7 +54,7 @@ public class CharacterDatatype implements Datatype<Character> {
 
         if (value.length() > 1)
             throw new ParseException(messages.formatMessage(
-                    "","datatype.unparseableCharacter.message", value), 0);
+                    "", "datatype.unparseableCharacter.message", value), 0);
 
         return value.charAt(0);
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/CharacterDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/CharacterDatatype.java
@@ -16,16 +16,22 @@
 
 package io.jmix.core.metamodel.datatype.impl;
 
+import io.jmix.core.Messages;
 import io.jmix.core.metamodel.annotation.DatatypeDef;
 import io.jmix.core.metamodel.datatype.Datatype;
 import org.apache.commons.lang3.StringUtils;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.lang.Nullable;
 import java.text.ParseException;
 import java.util.Locale;
 
 @DatatypeDef(id = "char", javaClass = Character.class, defaultForClass = true, value = "core_CharacterDatatype")
 public class CharacterDatatype implements Datatype<Character> {
+
+    @Autowired
+    protected Messages messages;
+
     @Override
     public String format(@Nullable Object value) {
         return value == null ? "" : value.toString();
@@ -43,7 +49,8 @@ public class CharacterDatatype implements Datatype<Character> {
             return null;
 
         if (value.length() > 1)
-            throw new ParseException(String.format("String '%s' is too long", value), 0);
+            throw new ParseException(String.format(
+                    messages.getMessage("characterParseErrorMessage"), value), 0);
 
         return value.charAt(0);
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/DoubleDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/DoubleDatatype.java
@@ -104,7 +104,8 @@ public class DoubleDatatype extends NumberDatatype implements Datatype<Double> {
         }
 
         if (!isInDoubleRange(result)) {
-            throw new ParseException(String.format(messages.getMessage("doubleOutOfRangeMessage"), value), 0);
+            throw new ParseException(messages.formatMessage(
+                    "","datatype.doubleOutOfRange.message", value), 0);
         }
 
         return result;

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/DoubleDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/DoubleDatatype.java
@@ -105,7 +105,7 @@ public class DoubleDatatype extends NumberDatatype implements Datatype<Double> {
 
         if (!isInDoubleRange(result)) {
             throw new ParseException(messages.formatMessage(
-                    "","datatype.doubleOutOfRange.message", value), 0);
+                    "", "datatype.doubleOutOfRange.message", value), 0);
         }
 
         return result;

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/DoubleDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/DoubleDatatype.java
@@ -104,7 +104,7 @@ public class DoubleDatatype extends NumberDatatype implements Datatype<Double> {
         }
 
         if (!isInDoubleRange(result)) {
-            throw new ParseException(String.format("The value is out of Double datatype range: \"%s\"", value), 0);
+            throw new ParseException(String.format(messages.getMessage("doubleOutOfRangeMessage"), value), 0);
         }
 
         return result;

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/FloatDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/FloatDatatype.java
@@ -107,7 +107,7 @@ public class FloatDatatype extends NumberDatatype implements Datatype<Float> {
 
         if (!isInFloatRange(result)) {
             throw new ParseException(messages.formatMessage(
-                    "","datatype.floatOutOfRange.message", value), 0);
+                    "", "datatype.floatOutOfRange.message", value), 0);
         }
 
         return result;

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/FloatDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/FloatDatatype.java
@@ -106,8 +106,8 @@ public class FloatDatatype extends NumberDatatype implements Datatype<Float> {
         }
 
         if (!isInFloatRange(result)) {
-            throw new ParseException(String.format(
-                    messages.getMessage("floatOutOfRangeMessage"), value), 0);
+            throw new ParseException(messages.formatMessage(
+                    "","datatype.floatOutOfRange.message", value), 0);
         }
 
         return result;

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/FloatDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/FloatDatatype.java
@@ -106,7 +106,8 @@ public class FloatDatatype extends NumberDatatype implements Datatype<Float> {
         }
 
         if (!isInFloatRange(result)) {
-            throw new ParseException(String.format("The value is out of Float datatype range: \"%s\"", value), 0);
+            throw new ParseException(String.format(
+                    messages.getMessage("floatOutOfRangeMessage"), value), 0);
         }
 
         return result;

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/IntegerDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/IntegerDatatype.java
@@ -85,8 +85,8 @@ public class IntegerDatatype extends NumberDatatype implements Datatype<Integer>
 
         Number result = super.parse(value, format);
         if (!hasValidIntegerRange(result)) {
-            throw new ParseException(String.format(
-                    messages.getMessage("integerOutOfRangeMessage"), value), 0);
+            throw new ParseException(messages.formatMessage(
+                    "","datatype.integerOutOfRange.message", value), 0);
         }
         return result;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/IntegerDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/IntegerDatatype.java
@@ -86,7 +86,7 @@ public class IntegerDatatype extends NumberDatatype implements Datatype<Integer>
         Number result = super.parse(value, format);
         if (!hasValidIntegerRange(result)) {
             throw new ParseException(messages.formatMessage(
-                    "","datatype.integerOutOfRange.message", value), 0);
+                    "", "datatype.integerOutOfRange.message", value), 0);
         }
         return result;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/IntegerDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/IntegerDatatype.java
@@ -85,7 +85,8 @@ public class IntegerDatatype extends NumberDatatype implements Datatype<Integer>
 
         Number result = super.parse(value, format);
         if (!hasValidIntegerRange(result)) {
-            throw new ParseException(String.format("Integer range exceeded: \"%s\"", value), 0);
+            throw new ParseException(String.format(
+                    messages.getMessage("integerOutOfRangeMessage"), value), 0);
         }
         return result;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/LongDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/LongDatatype.java
@@ -91,7 +91,7 @@ public class LongDatatype extends NumberDatatype implements Datatype<Long> {
 
         Number result = super.parse(value, format);
         if (!hasValidLongRange(result)) {
-            throw new ParseException(String.format("Integer range exceeded: \"%s\"", value), 0);
+            throw new ParseException(String.format(messages.getMessage("integerOutOfRangeMessage"), value), 0);
         }
         return result;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/LongDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/LongDatatype.java
@@ -91,7 +91,8 @@ public class LongDatatype extends NumberDatatype implements Datatype<Long> {
 
         Number result = super.parse(value, format);
         if (!hasValidLongRange(result)) {
-            throw new ParseException(String.format(messages.getMessage("integerOutOfRangeMessage"), value), 0);
+            throw new ParseException(messages.formatMessage(
+                    "","datatype.longOutOfRange.message", value), 0);
         }
         return result;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/LongDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/LongDatatype.java
@@ -92,7 +92,7 @@ public class LongDatatype extends NumberDatatype implements Datatype<Long> {
         Number result = super.parse(value, format);
         if (!hasValidLongRange(result)) {
             throw new ParseException(messages.formatMessage(
-                    "","datatype.longOutOfRange.message", value), 0);
+                    "", "datatype.longOutOfRange.message", value), 0);
         }
         return result;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/NumberDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/NumberDatatype.java
@@ -16,14 +16,19 @@
 
 package io.jmix.core.metamodel.datatype.impl;
 
+import io.jmix.core.Messages;
 import io.jmix.core.common.util.ParamsMap;
 import io.jmix.core.metamodel.datatype.ParameterizedDatatype;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.text.*;
 import java.util.Map;
 
 public abstract class NumberDatatype implements ParameterizedDatatype {
+
+    @Autowired
+    protected Messages messages;
 
     protected String formatPattern;
     protected String decimalSeparator;
@@ -77,7 +82,7 @@ public abstract class NumberDatatype implements ParameterizedDatatype {
         Number res = format.parse(value.trim(), pos);
         if (pos.getIndex() != value.length()) {
             throw new ParseException(
-                    String.format("Unparseable number: \"%s\"", value),
+                    String.format(messages.getMessage("numberParseErrorMessage"), value),
                     pos.getErrorIndex()
             );
         }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/NumberDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/NumberDatatype.java
@@ -86,7 +86,7 @@ public abstract class NumberDatatype implements ParameterizedDatatype {
         Number res = format.parse(value.trim(), pos);
         if (pos.getIndex() != value.length()) {
             throw new ParseException(messages.formatMessage(
-                    "","datatype.unparseableNumber.message", value), pos.getErrorIndex());
+                    "", "datatype.unparseableNumber.message", value), pos.getErrorIndex());
         }
         return res;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/NumberDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/NumberDatatype.java
@@ -27,12 +27,16 @@ import java.util.Map;
 
 public abstract class NumberDatatype implements ParameterizedDatatype {
 
-    @Autowired
     protected Messages messages;
 
     protected String formatPattern;
     protected String decimalSeparator;
     protected String groupingSeparator;
+
+    @Autowired
+    public void setMessages(Messages messages) {
+        this.messages = messages;
+    }
 
     protected NumberDatatype(String formatPattern, String decimalSeparator, String groupingSeparator) {
         this.formatPattern = formatPattern;
@@ -81,10 +85,8 @@ public abstract class NumberDatatype implements ParameterizedDatatype {
         ParsePosition pos = new ParsePosition(0);
         Number res = format.parse(value.trim(), pos);
         if (pos.getIndex() != value.length()) {
-            throw new ParseException(
-                    String.format(messages.getMessage("numberParseErrorMessage"), value),
-                    pos.getErrorIndex()
-            );
+            throw new ParseException(messages.formatMessage(
+                    "","datatype.unparseableNumber.message", value), pos.getErrorIndex());
         }
         return res;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/ShortDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/ShortDatatype.java
@@ -92,8 +92,8 @@ public class ShortDatatype extends NumberDatatype implements Datatype<Short> {
 
         Number result = super.parse(value, format);
         if (!hasValidShortRange(result)) {
-            throw new ParseException(String.format(
-                    messages.getMessage("shortOutOfRangeMessage"), value), 0);
+            throw new ParseException(messages.formatMessage(
+                    "","datatype.shortOutOfRange.message", value), 0);
         }
         return result;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/ShortDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/ShortDatatype.java
@@ -92,7 +92,8 @@ public class ShortDatatype extends NumberDatatype implements Datatype<Short> {
 
         Number result = super.parse(value, format);
         if (!hasValidShortRange(result)) {
-            throw new ParseException(String.format("Short range exceeded: \"%s\"", value), 0);
+            throw new ParseException(String.format(
+                    messages.getMessage("shortOutOfRangeMessage"), value), 0);
         }
         return result;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/ShortDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/ShortDatatype.java
@@ -93,7 +93,7 @@ public class ShortDatatype extends NumberDatatype implements Datatype<Short> {
         Number result = super.parse(value, format);
         if (!hasValidShortRange(result)) {
             throw new ParseException(messages.formatMessage(
-                    "","datatype.shortOutOfRange.message", value), 0);
+                    "", "datatype.shortOutOfRange.message", value), 0);
         }
         return result;
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/UuidDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/UuidDatatype.java
@@ -15,10 +15,12 @@
  */
 package io.jmix.core.metamodel.datatype.impl;
 
+import io.jmix.core.Messages;
 import io.jmix.core.UuidProvider;
 import io.jmix.core.metamodel.annotation.DatatypeDef;
 import io.jmix.core.metamodel.datatype.Datatype;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.text.ParseException;
 import java.util.Locale;
@@ -26,6 +28,13 @@ import java.util.UUID;
 
 @DatatypeDef(id = "uuid", javaClass = UUID.class, defaultForClass = true, value = "core_UuidDatatype")
 public class UuidDatatype implements Datatype<UUID> {
+
+    protected Messages messages;
+
+    @Autowired
+    public void setMessages(Messages messages) {
+        this.messages = messages;
+    }
 
     @Override
     public String format(Object value) {
@@ -45,7 +54,8 @@ public class UuidDatatype implements Datatype<UUID> {
             try {
                 return UuidProvider.fromString(value.trim());
             } catch (Exception e) {
-                throw new ParseException("Error parsing UUID", 0);
+                throw new ParseException(messages.formatMessage(
+                        "","datatype.unparseableUuid.message", value.trim()), 0);
             }
         }
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/UuidDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/UuidDatatype.java
@@ -55,7 +55,7 @@ public class UuidDatatype implements Datatype<UUID> {
                 return UuidProvider.fromString(value.trim());
             } catch (Exception e) {
                 throw new ParseException(messages.formatMessage(
-                        "","datatype.unparseableUuid.message", value.trim()), 0);
+                        "", "datatype.unparseableUuid.message", value.trim()), 0);
             }
         }
     }

--- a/jmix-core/core/src/main/resources/io/jmix/core/messages.properties
+++ b/jmix-core/core/src/main/resources/io/jmix/core/messages.properties
@@ -28,6 +28,18 @@ integerFormat=#,##0
 doubleFormat=#,##0.###
 decimalFormat=#,##0.00
 
+#Parse error messages
+numberParseErrorMessage = "Unparseable number: \"%s\""
+booleanParseErrorMessage = "Can't parse '%s'"
+characterParseErrorMessage = "String '%s' is too long"
+
+#Out of range messages
+shortOutOfRangeMessage = "Short range exceeded: \"%s\""
+integerOutOfRangeMessage = "Integer range exceeded: \"%s\""
+longOutOfRangeMessage = "Long range exceeded: \"%s\""
+floatOutOfRangeMessage = "The value is out of Float datatype range: \"%s\""
+doubleOutOfRangeMessage = "The value is out of Double datatype range: \"%s\""
+
 # Number separators
 numberDecimalSeparator=.
 numberGroupingSeparator=,

--- a/jmix-core/core/src/main/resources/io/jmix/core/messages.properties
+++ b/jmix-core/core/src/main/resources/io/jmix/core/messages.properties
@@ -28,17 +28,16 @@ integerFormat=#,##0
 doubleFormat=#,##0.###
 decimalFormat=#,##0.00
 
-#Parse error messages
-numberParseErrorMessage = "Unparseable number: \"%s\""
-booleanParseErrorMessage = "Can't parse '%s'"
-characterParseErrorMessage = "String '%s' is too long"
-
-#Out of range messages
-shortOutOfRangeMessage = "Short range exceeded: \"%s\""
-integerOutOfRangeMessage = "Integer range exceeded: \"%s\""
-longOutOfRangeMessage = "Long range exceeded: \"%s\""
-floatOutOfRangeMessage = "The value is out of Float datatype range: \"%s\""
-doubleOutOfRangeMessage = "The value is out of Double datatype range: \"%s\""
+# Datatype parse error messages
+datatype.unparseableNumber.message = "Unparseable number: '%s'"
+datatype.unparseableBoolean.message = "Unparseable boolean '%s'"
+datatype.unparseableCharacter.message = "String '%s' is too long"
+datatype.unparseableUuid.message = "Unparseable UUID '%s'"
+datatype.shortOutOfRange.message = "Short range exceeded: '%s'"
+datatype.integerOutOfRange.message = "Integer range exceeded: '%s'"
+datatype.longOutOfRange.message = "Long range exceeded: '%s'"
+datatype.floatOutOfRange.message = "The value is out of Float datatype range: '%s'"
+datatype.doubleOutOfRange.message = "The value is out of Double datatype range: '%s'"
 
 # Number separators
 numberDecimalSeparator=.

--- a/jmix-core/core/src/main/resources/io/jmix/core/messages.properties
+++ b/jmix-core/core/src/main/resources/io/jmix/core/messages.properties
@@ -29,15 +29,15 @@ doubleFormat=#,##0.###
 decimalFormat=#,##0.00
 
 # Datatype parse error messages
-datatype.unparseableNumber.message = "Unparseable number: '%s'"
-datatype.unparseableBoolean.message = "Unparseable boolean '%s'"
-datatype.unparseableCharacter.message = "String '%s' is too long"
-datatype.unparseableUuid.message = "Unparseable UUID '%s'"
-datatype.shortOutOfRange.message = "Short range exceeded: '%s'"
-datatype.integerOutOfRange.message = "Integer range exceeded: '%s'"
-datatype.longOutOfRange.message = "Long range exceeded: '%s'"
-datatype.floatOutOfRange.message = "The value is out of Float datatype range: '%s'"
-datatype.doubleOutOfRange.message = "The value is out of Double datatype range: '%s'"
+datatype.unparseableNumber.message = Unparseable number: '%s'
+datatype.unparseableBoolean.message = Unparseable boolean '%s'
+datatype.unparseableCharacter.message = String '%s' is too long
+datatype.unparseableUuid.message = Unparseable UUID '%s'
+datatype.shortOutOfRange.message = Short range exceeded: '%s'
+datatype.integerOutOfRange.message = Integer range exceeded: '%s'
+datatype.longOutOfRange.message = Long range exceeded: '%s'
+datatype.floatOutOfRange.message = The value is out of Float datatype range: '%s'
+datatype.doubleOutOfRange.message = The value is out of Double datatype range: '%s'
 
 # Number separators
 numberDecimalSeparator=.

--- a/jmix-translations/content/io/jmix/core/messages.properties
+++ b/jmix-translations/content/io/jmix/core/messages.properties
@@ -28,6 +28,18 @@ integerFormat=#,##0
 doubleFormat=#,##0.###
 decimalFormat=#,##0.00
 
+#Parse error messages
+numberParseErrorMessage = "Unparseable number: \"%s\""
+booleanParseErrorMessage = "Can't parse '%s'"
+characterParseErrorMessage = "String '%s' is too long"
+
+#Out of range messages
+shortOutOfRangeMessage = "Short range exceeded: \"%s\""
+integerOutOfRangeMessage = "Integer range exceeded: \"%s\""
+longOutOfRangeMessage = "Long range exceeded: \"%s\""
+floatOutOfRangeMessage = "The value is out of Float datatype range: \"%s\""
+doubleOutOfRangeMessage = "The value is out of Double datatype range: \"%s\""
+
 # Number separators
 numberDecimalSeparator=.
 numberGroupingSeparator=,

--- a/jmix-translations/content/io/jmix/core/messages.properties
+++ b/jmix-translations/content/io/jmix/core/messages.properties
@@ -28,17 +28,16 @@ integerFormat=#,##0
 doubleFormat=#,##0.###
 decimalFormat=#,##0.00
 
-#Parse error messages
-numberParseErrorMessage = "Unparseable number: \"%s\""
-booleanParseErrorMessage = "Can't parse '%s'"
-characterParseErrorMessage = "String '%s' is too long"
-
-#Out of range messages
-shortOutOfRangeMessage = "Short range exceeded: \"%s\""
-integerOutOfRangeMessage = "Integer range exceeded: \"%s\""
-longOutOfRangeMessage = "Long range exceeded: \"%s\""
-floatOutOfRangeMessage = "The value is out of Float datatype range: \"%s\""
-doubleOutOfRangeMessage = "The value is out of Double datatype range: \"%s\""
+# Datatype parse error messages
+datatype.unparseableNumber.message = "Unparseable number: '%s'"
+datatype.unparseableBoolean.message = "Unparseable boolean '%s'"
+datatype.unparseableCharacter.message = "String '%s' is too long"
+datatype.unparseableUuid.message = "Unparseable UUID '%s'"
+datatype.shortOutOfRange.message = "Short range exceeded: '%s'"
+datatype.integerOutOfRange.message = "Integer range exceeded: '%s'"
+datatype.longOutOfRange.message = "Long range exceeded: '%s'"
+datatype.floatOutOfRange.message = "The value is out of Float datatype range: '%s'"
+datatype.doubleOutOfRange.message = "The value is out of Double datatype range: '%s'"
 
 # Number separators
 numberDecimalSeparator=.

--- a/jmix-translations/content/io/jmix/core/messages.properties
+++ b/jmix-translations/content/io/jmix/core/messages.properties
@@ -29,15 +29,15 @@ doubleFormat=#,##0.###
 decimalFormat=#,##0.00
 
 # Datatype parse error messages
-datatype.unparseableNumber.message = "Unparseable number: '%s'"
-datatype.unparseableBoolean.message = "Unparseable boolean '%s'"
-datatype.unparseableCharacter.message = "String '%s' is too long"
-datatype.unparseableUuid.message = "Unparseable UUID '%s'"
-datatype.shortOutOfRange.message = "Short range exceeded: '%s'"
-datatype.integerOutOfRange.message = "Integer range exceeded: '%s'"
-datatype.longOutOfRange.message = "Long range exceeded: '%s'"
-datatype.floatOutOfRange.message = "The value is out of Float datatype range: '%s'"
-datatype.doubleOutOfRange.message = "The value is out of Double datatype range: '%s'"
+datatype.unparseableNumber.message = Unparseable number: '%s'
+datatype.unparseableBoolean.message = Unparseable boolean '%s'
+datatype.unparseableCharacter.message = String '%s' is too long
+datatype.unparseableUuid.message = Unparseable UUID '%s'
+datatype.shortOutOfRange.message = Short range exceeded: '%s'
+datatype.integerOutOfRange.message = Integer range exceeded: '%s'
+datatype.longOutOfRange.message = Long range exceeded: '%s'
+datatype.floatOutOfRange.message = The value is out of Float datatype range: '%s'
+datatype.doubleOutOfRange.message = The value is out of Double datatype range: '%s'
 
 # Number separators
 numberDecimalSeparator=.

--- a/jmix-translations/content/io/jmix/core/messages_ru.properties
+++ b/jmix-translations/content/io/jmix/core/messages_ru.properties
@@ -28,6 +28,18 @@ integerFormat=#,##0
 doubleFormat=#,##0.###
 decimalFormat=#,##0.00
 
+#Parse error messages
+numberParseErrorMessage = "Неправильный формат значения \"%s\" для Integer"
+booleanParseErrorMessage = "Неправильный формат значения \"%s\" для Boolean"
+characterParseErrorMessage = "Превышена максимальная длина строки для \"%s\""
+
+#Out of range messages
+shortOutOfRangeMessage = "\"%s\" выходит за допустимый диапазон Short"
+integerOutOfRangeMessage = "\"%s\" выходит за допустимый диапазон Integer"
+longOutOfRangeMessage = "\"%s\" выходит за допустимый диапазон Long"
+floatOutOfRangeMessage = "\"%s\" выходит за допустимый диапазон Float"
+doubleOutOfRangeMessage = "\"%s\" выходит за допустимый диапазон Double"
+
 # Number separators
 numberDecimalSeparator=,
 numberGroupingSeparator=\u0020

--- a/jmix-translations/content/io/jmix/core/messages_ru.properties
+++ b/jmix-translations/content/io/jmix/core/messages_ru.properties
@@ -28,17 +28,16 @@ integerFormat=#,##0
 doubleFormat=#,##0.###
 decimalFormat=#,##0.00
 
-#Parse error messages
-numberParseErrorMessage = "Неправильный формат значения \"%s\" для Integer"
-booleanParseErrorMessage = "Неправильный формат значения \"%s\" для Boolean"
-characterParseErrorMessage = "Превышена максимальная длина строки для \"%s\""
-
-#Out of range messages
-shortOutOfRangeMessage = "\"%s\" выходит за допустимый диапазон Short"
-integerOutOfRangeMessage = "\"%s\" выходит за допустимый диапазон Integer"
-longOutOfRangeMessage = "\"%s\" выходит за допустимый диапазон Long"
-floatOutOfRangeMessage = "\"%s\" выходит за допустимый диапазон Float"
-doubleOutOfRangeMessage = "\"%s\" выходит за допустимый диапазон Double"
+# Datatype parse error messages
+datatype.unparseableNumber.message = "Неправильный формат значения '%s' для Integer"
+datatype.unparseableBoolean.message = "Неправильный формат значения '%s' для Boolean"
+datatype.unparseableCharacter.message = "Превышена максимальная длина строки для '%s'"
+datatype.unparseableUuid.message = "Неправильный формат значения '%s' для UUID"
+datatype.shortOutOfRange.message = "'%s' выходит за допустимый диапазон Short"
+datatype.integerOutOfRange.message = "'%s' выходит за допустимый диапазон Integer"
+datatype.longOutOfRange.message = "'%s' выходит за допустимый диапазон Long"
+datatype.floatOutOfRange.message = "'%s' выходит за допустимый диапазон Float"
+datatype.doubleOutOfRange.message = "'%s' выходит за допустимый диапазон Double"
 
 # Number separators
 numberDecimalSeparator=,

--- a/jmix-translations/content/io/jmix/core/messages_ru.properties
+++ b/jmix-translations/content/io/jmix/core/messages_ru.properties
@@ -29,15 +29,15 @@ doubleFormat=#,##0.###
 decimalFormat=#,##0.00
 
 # Datatype parse error messages
-datatype.unparseableNumber.message = "Неправильный формат значения '%s' для Integer"
-datatype.unparseableBoolean.message = "Неправильный формат значения '%s' для Boolean"
-datatype.unparseableCharacter.message = "Превышена максимальная длина строки для '%s'"
-datatype.unparseableUuid.message = "Неправильный формат значения '%s' для UUID"
-datatype.shortOutOfRange.message = "'%s' выходит за допустимый диапазон Short"
-datatype.integerOutOfRange.message = "'%s' выходит за допустимый диапазон Integer"
-datatype.longOutOfRange.message = "'%s' выходит за допустимый диапазон Long"
-datatype.floatOutOfRange.message = "'%s' выходит за допустимый диапазон Float"
-datatype.doubleOutOfRange.message = "'%s' выходит за допустимый диапазон Double"
+datatype.unparseableNumber.message = Неправильный формат значения '%s' для Integer
+datatype.unparseableBoolean.message = Неправильный формат значения '%s' для Boolean
+datatype.unparseableCharacter.message = Превышена максимальная длина строки для '%s'
+datatype.unparseableUuid.message = Неправильный формат значения '%s' для UUID
+datatype.shortOutOfRange.message = '%s' выходит за допустимый диапазон Short
+datatype.integerOutOfRange.message = '%s' выходит за допустимый диапазон Integer
+datatype.longOutOfRange.message = '%s' выходит за допустимый диапазон Long
+datatype.floatOutOfRange.message = '%s' выходит за допустимый диапазон Float
+datatype.doubleOutOfRange.message = '%s' выходит за допустимый диапазон Double
 
 # Number separators
 numberDecimalSeparator=,


### PR DESCRIPTION
#3284

In the issue the app execution does not get into the validator. Parse exception for jmix datatypes rises before. So localised messages were added to the ParseException constructor.