### PR TITLE
Change CREATED_BY to varchar(255) to reflect username size being the same

### DIFF
--- a/jmix-flowui/flowui-data/src/main/java/io/jmix/flowuidata/entity/UserSettingsItem.java
+++ b/jmix-flowui/flowui-data/src/main/java/io/jmix/flowuidata/entity/UserSettingsItem.java
@@ -46,7 +46,7 @@ public class UserSettingsItem implements Serializable {
     private Date createTs;
 
     @CreatedBy
-    @Column(name = "CREATED_BY", length = 50)
+    @Column(name = "CREATED_BY")
     private String createdBy;
 
     @Column(name = "USERNAME")

--- a/jmix-flowui/flowui-data/src/main/resources/io/jmix/flowuidata/liquibase/changelog/002-flowui-data.xml
+++ b/jmix-flowui/flowui-data/src/main/resources/io/jmix/flowuidata/liquibase/changelog/002-flowui-data.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2023 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="1" author="flowui-data">
+        <modifyDataType tableName="FLOWUI_USER_SETTINGS" columnName="CREATED_BY" newDataType="varchar(255)"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
In our project we served an error in the following lib regarding the createdBy size if the name exceeds 50 chars. For example in emails. This should fix the table for saving the flowui settings for a user.