### PR TITLE
Simplified API for UI asynchronous tasks

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/DelegatingSecurityRunnable.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/DelegatingSecurityRunnable.java
@@ -1,0 +1,37 @@
+package io.jmix.flowui.asynctask;
+
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * Wraps a delegate {@link Runnable} with logic for setting up an {@link SecurityContext} before invoking the delegate
+ * {@link Runnable} and then removing the {@link SecurityContext} after the delegate has completed.
+ * <p>
+ * If there is a {@link SecurityContext} that already exists, it will be restored after the {@link #run()} method is
+ * invoked.
+ */
+public class DelegatingSecurityRunnable implements Runnable {
+
+    private final Runnable delegate;
+    private final SecurityContext securityContext;
+
+    public DelegatingSecurityRunnable(Runnable delegate) {
+        this(delegate, SecurityContextHolder.getContext());
+    }
+
+    public DelegatingSecurityRunnable(Runnable delegate, SecurityContext securityContext) {
+        this.delegate = delegate;
+        this.securityContext = securityContext;
+    }
+
+    @Override
+    public void run() {
+        SecurityContext originalSecurityContext = SecurityContextHolder.getContext();
+        try {
+            SecurityContextHolder.setContext(securityContext);
+            delegate.run();
+        } finally {
+            SecurityContextHolder.setContext(originalSecurityContext);
+        }
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/DelegatingSecuritySupplier.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/DelegatingSecuritySupplier.java
@@ -1,0 +1,39 @@
+package io.jmix.flowui.asynctask;
+
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.function.Supplier;
+
+/**
+ * Wraps a delegate {@link Supplier} with logic for setting up an {@link SecurityContext} before invoking the delegate
+ * {@link Supplier} and then removing the {@link SecurityContext} after the delegate has completed.
+ * <p>
+ * If there is a {@link SecurityContext} that already exists, it will be restored after the {@link #get()} method is
+ * invoked.
+ */
+public class DelegatingSecuritySupplier<T> implements Supplier<T> {
+
+    private final Supplier<T> delegate;
+    private final SecurityContext securityContext;
+
+    public DelegatingSecuritySupplier(Supplier<T> delegate) {
+        this(delegate, SecurityContextHolder.getContext());
+    }
+
+    public DelegatingSecuritySupplier(Supplier<T> delegate, SecurityContext securityContext) {
+        this.delegate = delegate;
+        this.securityContext = securityContext;
+    }
+
+    @Override
+    public T get() {
+        SecurityContext originalSecurityContext = SecurityContextHolder.getContext();
+        try {
+            SecurityContextHolder.setContext(securityContext);
+            return delegate.get();
+        } finally {
+            SecurityContextHolder.setContext(originalSecurityContext);
+        }
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/UiAsyncTaskProperties.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/UiAsyncTaskProperties.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.asynctask;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+/**
+ * Configuration properties for UI asynchronous tasks.
+ */
+@ConfigurationProperties(prefix = "jmix.ui.async")
+public class UiAsyncTaskProperties {
+
+    /**
+     * Configuration for the executor service used for UI asynchronous tasks.
+     */
+    ExecutorServiceConfig executorService;
+
+    /**
+     * Default timeout in seconds for produced completable futures. Default value is 300 seconds (5 minutes).
+     */
+    int defaultTimeoutSec;
+
+    public UiAsyncTaskProperties(
+            @DefaultValue ExecutorServiceConfig executorService,
+            @DefaultValue("300") int defaultTimeoutSec) {
+        this.executorService = executorService;
+        this.defaultTimeoutSec = defaultTimeoutSec;
+    }
+
+    public ExecutorServiceConfig getExecutorService() {
+        return executorService;
+    }
+
+    public int getDefaultTimeoutSec() {
+        return defaultTimeoutSec;
+    }
+
+    public static class ExecutorServiceConfig {
+
+        /**
+         * Maximum pool size for the executor service. Default value is 10.
+         */
+        int maximumPoolSize;
+
+        public ExecutorServiceConfig(
+                @DefaultValue("10") int maximumPoolSize) {
+            this.maximumPoolSize = maximumPoolSize;
+        }
+
+        public int getMaximumPoolSize() {
+            return maximumPoolSize;
+        }
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/UiAsyncTaskProperties.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/UiAsyncTaskProperties.java
@@ -22,7 +22,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
 /**
  * Configuration properties for UI asynchronous tasks.
  */
-@ConfigurationProperties(prefix = "jmix.ui.async")
+@ConfigurationProperties(prefix = "jmix.ui.async-task")
 public class UiAsyncTaskProperties {
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/UiAsyncTasks.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/UiAsyncTasks.java
@@ -1,0 +1,281 @@
+package io.jmix.flowui.asynctask;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.server.Command;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.*;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * The class provides methods for executing asynchronous tasks from UI views. The class may be used when, in the UI
+ * view, you need to execute some long-running task in a separate thread, for example, loading data from a database, and
+ * when the task is completed (data is loaded), update the UI using the returned data.
+ * <p>
+ * Use {@link UiAsyncTasks} when you don't need to handle asynchronous task progress or display a modal dialog with a
+ * progress indicator. Otherwise, consider using {@link io.jmix.flowui.backgroundtask.BackgroundTaskManager} and
+ * {@link io.jmix.flowui.backgroundtask.BackgroundTask}.
+ * <p>
+ * The class wraps actions that perform tasks (for example, loading data) into a special wrapper
+ * ({@link DelegatingSecuritySupplier} or {@link DelegatingSecurityRunnable}). These wrappers set the original
+ * {@link org.springframework.security.core.context.SecurityContext} before executing the action. After that, all
+ * services invoked in the asynchronous task will be executed with the permissions of the current user.
+ * <p>
+ * Actions that process the result can update Vaadin UI components because they are wrapped by the
+ * {@link UI#access(Command)} method.
+ * <p>
+ * Usage example:
+ * <pre>{@code
+ * uiAsyncTasks.supplyAsyncBuilder(() -> customerService.loadCustomers())
+ *      .withResultHandler(customers -> {
+ *          customersDc.getMutableItems().addAll(customers);
+ *          notifications.create("Customers loaded: " + customers.size()).show();
+ *      })
+ *      .supplyAsync();}</pre>
+ * <p>
+ * By default, asynchronous tasks are executed with the default timeout configured by the
+ * {@link UiAsyncTaskProperties#defaultTimeoutSec}. After this timeout, the {@link TimeoutException} is thrown.
+ *
+ * @see UiAsyncTaskProperties
+ * @see #supplyAsyncBuilder(Supplier)
+ * @see #runAsyncBuilder(Runnable)
+ */
+@Component("flowui_UiAsyncTasks")
+public class UiAsyncTasks {
+
+    private static final Logger log = LoggerFactory.getLogger(UiAsyncTasks.class);
+
+    private static final String THREAD_NAME_PREFIX = "UiAsyncTask-";
+
+    private ExecutorService executorService;
+
+    private Function<Throwable, Void> defaultExceptionHandler;
+
+    private final UiAsyncTaskProperties uiAsyncTaskProperties;
+
+    public UiAsyncTasks(UiAsyncTaskProperties uiAsyncTaskProperties) {
+        this.uiAsyncTaskProperties = uiAsyncTaskProperties;
+    }
+
+    @PostConstruct
+    protected void onInit() {
+        executorService = createExecutorService();
+        defaultExceptionHandler = createDefaultExceptionHandler();
+    }
+
+    @PreDestroy
+    protected void preDestroy() {
+        executorService.shutdownNow();
+    }
+
+    protected ExecutorService createExecutorService() {
+        int maximumPoolSize = uiAsyncTaskProperties.getExecutorService().getMaximumPoolSize();
+        executorService = new ThreadPoolExecutor(
+                maximumPoolSize,
+                maximumPoolSize,
+                10L, TimeUnit.MINUTES,
+                new LinkedBlockingQueue<>(),
+                new ThreadFactoryBuilder()
+                        .setNameFormat(THREAD_NAME_PREFIX + "%d")
+                        .build()
+        );
+        ((ThreadPoolExecutor) executorService).allowCoreThreadTimeOut(true);
+        return executorService;
+    }
+
+    /**
+     * Creates a builder for an asynchronous task that returns a result. The task is executed on a separate thread. The
+     * result can be handled with a {@link Consumer} that is set using the
+     * {@link SupplyAsyncBuilder#withResultHandler(Consumer)} or left unhandled to get the result using the
+     * {@link CompletableFuture} API.
+     *
+     * @param asyncTask the task to execute
+     * @param <T>       the result type
+     * @return a builder for an asynchronous task that returns a result
+     */
+    public <T> SupplyAsyncBuilder<T> supplyAsyncBuilder(Supplier<T> asyncTask) {
+        return new SupplyAsyncBuilder<>(asyncTask);
+    }
+
+    /**
+     * Creates a builder for an asynchronous task that does not return a result. The task is executed on a separate
+     * thread. The action that must be performed after the asynchronous task is completed may be set using the
+     * {@link RunAsyncBuilder#withResultHandler(Runnable) method.
+     *
+     * @param asyncTask the task to execute
+     * @return a builder for an asynchronous task that does not return a result
+     */
+    public RunAsyncBuilder runAsyncBuilder(Runnable asyncTask) {
+        return new RunAsyncBuilder(asyncTask);
+    }
+
+    /**
+     * Abstract base class for asynchronous task builders.
+     */
+    protected abstract class AbstractAsyncTaskBuilder {
+        protected Consumer<Throwable> exceptionHandler;
+        protected UI ui;
+        protected int timeout;
+        protected TimeUnit timeoutUnit;
+
+        public AbstractAsyncTaskBuilder() {
+            this.ui = UI.getCurrent();
+        }
+
+        protected void configureTimeout(CompletableFuture<Void> resultCompletableFuture) {
+            if (timeout > 0 && timeoutUnit != null) {
+                resultCompletableFuture.orTimeout(timeout, timeoutUnit);
+            } else {
+                int defaultTimeoutSec = uiAsyncTaskProperties.getDefaultTimeoutSec();
+                if (defaultTimeoutSec > 0) {
+                    resultCompletableFuture.orTimeout(defaultTimeoutSec, TimeUnit.SECONDS);
+                }
+            }
+        }
+
+        protected void configureExceptionHandler(CompletableFuture<Void> completableFuture) {
+            if (exceptionHandler != null) {
+                completableFuture.exceptionally(throwable -> {
+                    ui.access(() -> exceptionHandler.accept(throwable));
+                    return null;
+                });
+            } else {
+                completableFuture.exceptionally(defaultExceptionHandler);
+            }
+        }
+    }
+
+    public class SupplyAsyncBuilder<T> extends AbstractAsyncTaskBuilder {
+        private Supplier<T> asyncTask;
+        private Consumer<? super T> resultHandler;
+
+        public SupplyAsyncBuilder(Supplier<T> asyncTask) {
+            super();
+            this.asyncTask = asyncTask;
+        }
+
+        /**
+         * Sets a handler that is called when the asynchronous task completes successfully. The handler can safely
+         * update Vaadin UI components.
+         */
+        public SupplyAsyncBuilder<T> withResultHandler(Consumer<? super T> resultHandler) {
+            this.resultHandler = resultHandler;
+            return this;
+        }
+
+        /**
+         * Sets a handler that is called when the asynchronous task throws an exception. The handler can safely update
+         * Vaadin UI components. If not set, then the default exception handler will be used.
+         */
+        public SupplyAsyncBuilder<T> withExceptionHandler(Consumer<Throwable> exceptionHandler) {
+            this.exceptionHandler = exceptionHandler;
+            return this;
+        }
+
+        /**
+         * Sets the timeout for the asynchronous task. If the task is not completed within the specified timeout, a
+         * {@link TimeoutException} is thrown.
+         */
+        public SupplyAsyncBuilder<T> withTimeout(int timeout, TimeUnit timeoutUnit) {
+            this.timeout = timeout;
+            this.timeoutUnit = timeoutUnit;
+            return this;
+        }
+
+        /**
+         * Configures and returns a {@link CompletableFuture} that asynchronously executes the task.
+         */
+        public CompletableFuture<Void> supplyAsync() {
+            DelegatingSecuritySupplier<T> wrappedSupplier = new DelegatingSecuritySupplier<>(asyncTask);
+            CompletableFuture<T> future = CompletableFuture.supplyAsync(wrappedSupplier, executorService);
+            CompletableFuture<Void> resultCompletableFuture;
+
+            if (resultHandler != null) {
+                resultCompletableFuture = future.thenAccept(data -> ui.access(() -> resultHandler.accept(data)));
+            } else {
+                resultCompletableFuture = future.thenAccept(t -> {
+                });
+            }
+
+            configureExceptionHandler(resultCompletableFuture);
+            configureTimeout(resultCompletableFuture);
+
+            return resultCompletableFuture;
+        }
+    }
+
+    public class RunAsyncBuilder extends AbstractAsyncTaskBuilder {
+
+        private Runnable asyncTask;
+        private Runnable resultHandler;
+
+        public RunAsyncBuilder(Runnable asyncTask) {
+            super();
+            this.asyncTask = asyncTask;
+        }
+
+        /**
+         * Sets a handler that is called when the asynchronous task completes successfully. The handler can safely
+         * update Vaadin UI components.
+         */
+        public RunAsyncBuilder withResultHandler(Runnable resultHandler) {
+            this.resultHandler = resultHandler;
+            return this;
+        }
+
+        /**
+         * Sets a handler that is called when the asynchronous task throws an exception. The handler can safely update
+         * Vaadin UI components. If not set, then the default exception handler will be used.
+         */
+        public RunAsyncBuilder withExceptionHandler(Consumer<Throwable> exceptionHandler) {
+            this.exceptionHandler = exceptionHandler;
+            return this;
+        }
+
+        /**
+         * Sets the timeout for the asynchronous task. If the task is not completed within the specified timeout, a
+         * {@link TimeoutException} is thrown.
+         */
+        public RunAsyncBuilder withTimeout(int timeout, TimeUnit timeoutUnit) {
+            this.timeout = timeout;
+            this.timeoutUnit = timeoutUnit;
+            return this;
+        }
+
+        /**
+         * Configures and returns a {@link CompletableFuture} that asynchronously executes the task.
+         */
+        public CompletableFuture<Void> runAsync() {
+            DelegatingSecurityRunnable wrappedRunnable = new DelegatingSecurityRunnable(asyncTask);
+            CompletableFuture<Void> completableFuture = CompletableFuture.runAsync(wrappedRunnable, executorService);
+            if (resultHandler != null) {
+                completableFuture = completableFuture.thenRun(() -> ui.access(resultHandler::run));
+            }
+            configureExceptionHandler(completableFuture);
+            configureTimeout(completableFuture);
+            return completableFuture;
+        }
+    }
+
+    protected Function<Throwable, Void> createDefaultExceptionHandler() {
+        return throwable -> {
+            if (throwable instanceof TimeoutException) {
+                log.error("UI async task finished on timeout");
+            } else {
+                log.error("UI async task error", throwable);
+            }
+            return null;
+        };
+    }
+
+    public void setDefaultExceptionHandler(Function<Throwable, Void> defaultExceptionHandler) {
+        this.defaultExceptionHandler = defaultExceptionHandler;
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/UiAsyncTasks.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/UiAsyncTasks.java
@@ -38,6 +38,9 @@ import java.util.function.Supplier;
  *          customersDc.getMutableItems().addAll(customers);
  *          notifications.create("Customers loaded: " + customers.size()).show();
  *      })
+ *      .withExceptionHandler(ex -> {
+ *          errorTextField.setValue(ex.getMessage());
+ *      })
  *      .supplyAsync();}</pre>
  * <p>
  * By default, asynchronous tasks are executed with the default timeout configured by the

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/package-info.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/asynctask/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+package io.jmix.flowui.asynctask;
+
+import org.springframework.lang.NonNullApi;


### PR DESCRIPTION
### Overview

The new API is intended to be used instead of [Background Task](https://docs.jmix.io/jmix/flow-ui/background-tasks.html) in simple cases. Background tasks are powerful, but sometimes users don't need all their featues like showing a modal dialog or handling the task execution progress.

For a problem that sounds like "load some data in the background and after the data is loaded update some UI component" the new `UiAsyncTasks` service may be used.

Usage examples:

```java
        uiAsyncTasks.supplierConfigurer(() -> {
                        return customerService.loadAllCustomersForCurrentUser();
                })
                .withResultHandler(customers -> {
                    customersDc.getMutableItems().addAll(customers);
                    notifications.create("Customers loaded: " + customers.size())
                            .show();
                })
                .supplyAsync();
```

When the asynchronous task returns no result, the `runAsyncBuilder` may be used:

```java
        uiAsyncTasks.runnableConfigurer(() -> customerService.doSomeTaskWithNoResult())
                .withResultHandler(() -> {
                    resultTextField.setValue("Async task completed successfully");
                })
                .runAsync();
```

Both `supplyAsync()` and `runAsync()` method return a `CompletableFuture`.

For the thread that executes the main asynchronous task the current authentication is copied to the SecurityContext, so the code will be executed with the permissions of the user who is working with the UI View.

The code that handles the result may access Vaadin components because the `UiAsyncTasks` service wraps it into the `UI.access(() -> ...)`.

### Exception Handling

The default exception handler will write a stacktrace to the application log. If you need a custom behavior, use the `withExceptionHandler()` method.

```java
        uiAsyncTasks.supplyAsyncBuilder(() ->
                        someService.loadData()
                )
                .withResultHandler(result -> {
                    updateUi(result);
                })
                .withExceptionHandler(ex -> {
                    errorTextField.setValue(ExceptionUtils.getStackTrace(ex));
                })
                .supplyAsync();
```

### Timeout

Timeout may be set for the individual CompletableFuture:

```java
        uiAsyncTasks.supplyAsyncBuilder(() ->
                        customerService.loadAllCustomersForCurrentUser()
                )
                .withResultHandler(customers -> {
                    customersDc.getMutableItems().addAll(customers);
                    notifications.create("Customers loaded: " + customers.size())
                            .show();
                })
                .withTimeout(60, TimeUnit.SECONDS)
                .withExceptionHandler(ex -> {
                    String errorText;
                    if (ex instanceof TimeoutException) {
                        errorText = "Timeout exceeded";
                    } else {
                        errorText = ExceptionUtils.getStackTrace(ex);
                    }
                    errorTextField.setValue(errorText);
                })
                .supplyAsync();
```

When the timeout is exceeded the `TimeoutException` is thrown. The `TimeoutException` can be processed in the `withExceptionHandler()` method.

If no explicit timeout is defined, then the default timeout value from the application properties is used.

### Configuration Properties

```properties
# default timeout value for CompletableFutures
jmix.ui.async-task.default-timeout-sec = 300

# Maximum thread pool size for the executor service used for asynchronous tasks execution
jmix.ui.async-task.executor-service.maximum-pool-size = 10
```
