### PR TITLE
Builders in Dialogs bean should return Dialog instance when it is opened jmix-framework/jmix#3343

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/Dialogs.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/Dialogs.java
@@ -18,6 +18,7 @@ package io.jmix.flowui;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.dialog.Dialog;
 import com.vaadin.flow.component.formlayout.FormLayout;
 import com.vaadin.flow.component.formlayout.FormLayout.ResponsiveStep;
 import com.vaadin.flow.component.html.Paragraph;
@@ -141,9 +142,18 @@ public interface Dialogs {
         Action[] getActions();
 
         /**
-         * Opens the dialog.
+         * Builds option the dialog. Dialog should be shown using {@link Dialog#open()}.
+         *
+         * @return built option dialog
          */
-        void open();
+        Dialog build();
+
+        /**
+         * Opens the option dialog.
+         *
+         * @return opened {@link Dialog} instance
+         */
+        Dialog open();
     }
 
     interface MessageDialogBuilder extends DialogBuilder<MessageDialogBuilder>,
@@ -157,9 +167,18 @@ public interface Dialogs {
             Resizable<MessageDialogBuilder> {
 
         /**
-         * Opens the dialog.
+         * Builds the message dialog. Dialog should be shown using {@link Dialog#open()}.
+         *
+         * @return built message dialog
          */
-        void open();
+        Dialog build();
+
+        /**
+         * Opens the message dialog.
+         *
+         * @return opened {@link Dialog} instance
+         */
+        Dialog open();
     }
 
     interface InputDialogBuilder extends DialogBuilder<InputDialogBuilder> {
@@ -424,9 +443,16 @@ public interface Dialogs {
         boolean isShowProgressInPercentage();
 
         /**
-         * Opens the dialog.
+         * Build the background task dialog. Dialog should be shown using {@link Dialog#open()}.
+         *
+         * @return built background task dialog.
          */
-        void open();
+        Dialog build();
+
+        /**
+         * Opens the background task dialog.
+         */
+        Dialog open();
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/impl/DialogsImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/impl/DialogsImpl.java
@@ -28,32 +28,37 @@ import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
-import com.vaadin.flow.component.orderedlayout.FlexComponent;
-import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.progressbar.ProgressBar;
+import com.vaadin.flow.shared.Registration;
 import io.jmix.core.Messages;
 import io.jmix.flowui.DialogWindows;
 import io.jmix.flowui.Dialogs;
-import io.jmix.flowui.UiViewProperties;
 import io.jmix.flowui.UiComponents;
+import io.jmix.flowui.UiViewProperties;
 import io.jmix.flowui.action.DialogAction;
 import io.jmix.flowui.action.inputdialog.InputDialogAction;
 import io.jmix.flowui.app.inputdialog.DialogActions;
 import io.jmix.flowui.app.inputdialog.InputDialog;
 import io.jmix.flowui.app.inputdialog.InputParameter;
+import io.jmix.flowui.backgroundtask.BackgroundTask;
+import io.jmix.flowui.backgroundtask.BackgroundTaskHandler;
+import io.jmix.flowui.backgroundtask.BackgroundWorker;
+import io.jmix.flowui.backgroundtask.LocalizedTaskWrapper;
 import io.jmix.flowui.component.validation.ValidationErrors;
-import io.jmix.flowui.backgroundtask.*;
 import io.jmix.flowui.kit.action.Action;
 import io.jmix.flowui.kit.component.KeyCombination;
 import io.jmix.flowui.view.DialogWindow;
 import io.jmix.flowui.view.View;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.context.ApplicationContext;
-
 import org.springframework.lang.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -316,7 +321,7 @@ public class DialogsImpl implements Dialogs {
         }
 
         @Override
-        public void open() {
+        public Dialog build() {
             actionButtons.forEach(dialog.getFooter()::remove);
             actionButtons.clear();
 
@@ -360,7 +365,14 @@ public class DialogsImpl implements Dialogs {
                 focusComponent.focus();
             }
 
+            return dialog;
+        }
+
+        @Override
+        public Dialog open() {
+            Dialog dialog = build();
             dialog.open();
+            return dialog;
         }
 
         protected void initKeyCombination(@Nullable DialogAction firstOkAction,
@@ -412,19 +424,6 @@ public class DialogsImpl implements Dialogs {
             dialog.setDraggable(true);
             dialog.setCloseOnOutsideClick(false);
             dialog.setMinWidth(MIN_WIDTH);
-
-            HorizontalLayout buttonsContainer = new HorizontalLayout();
-            buttonsContainer.setJustifyContentMode(FlexComponent.JustifyContentMode.END);
-
-            DialogAction okAction = new DialogAction(DialogAction.Type.OK);
-            okButton = createButton(okAction, dialog);
-
-            KeyCombination saveShortcut = KeyCombination.create(flowUiViewProperties.getSaveShortcut());
-            if (saveShortcut != null) {
-                okButton.addClickShortcut(saveShortcut.getKey(), saveShortcut.getKeyModifiers());
-            }
-
-            dialog.getFooter().add(okButton);
         }
 
         @Override
@@ -613,8 +612,25 @@ public class DialogsImpl implements Dialogs {
         }
 
         @Override
-        public void open() {
+        public Dialog build() {
+            DialogAction okAction = new DialogAction(DialogAction.Type.OK);
+            okButton = createButton(okAction, dialog);
+
+            KeyCombination saveShortcut = KeyCombination.create(flowUiViewProperties.getSaveShortcut());
+            if (saveShortcut != null) {
+                okButton.addClickShortcut(saveShortcut.getKey(), saveShortcut.getKeyModifiers());
+            }
+
+            dialog.getFooter().add(okButton);
+
+            return dialog;
+        }
+
+        @Override
+        public Dialog open() {
+            build();
             dialog.open();
+            return dialog;
         }
     }
 
@@ -989,8 +1005,7 @@ public class DialogsImpl implements Dialogs {
             return dialog.getMaxHeight();
         }
 
-        @Override
-        public void open() {
+        public Dialog build() {
             if (isIndeterminateMode()) {
                 progressTextSpan.setVisible(false);
                 progressBar.setIndeterminate(true);
@@ -999,9 +1014,29 @@ public class DialogsImpl implements Dialogs {
             }
             updateProgress(0);
 
-            dialog.open();
+            AtomicReference<Registration> openedRegistration = new AtomicReference<>();
+            openedRegistration.set(
+                    dialog.addOpenedChangeListener(event -> {
+                        // self-remove
+                        if (openedRegistration.get() != null) {
+                            openedRegistration.getAndSet(null)
+                                    .remove();
+                        }
 
-            startExecution();
+                        if (event.isOpened()) {
+                            startExecution();
+                        }
+                    })
+            );
+
+            return dialog;
+        }
+
+        @Override
+        public Dialog open() {
+            build();
+            dialog.open();
+            return dialog;
         }
 
         protected boolean isIndeterminateMode() {


### PR DESCRIPTION
See: #3343 

`build()` and `open()` methods have been added to all dialog builders.
Why do you need a build method?

After the `build()` method, you can customize the `dialog`: add listeners for closing/opening. And then manually open the `dialog` using the `Dialog#open()` method. If we'll provide only the `Builder#open()` method, it will be impossible to add a listener for opening.

----

Features of the implementation of the `BackgroundTaskDialogBuilder#build` method.

Here is the old implementation of the `BackgroundTaskDialogBuilder#open` method:
```java
        @Override
        public void open() {
            if (isIndeterminateMode()) {
                progressTextSpan.setVisible(false);
                progressBar.setIndeterminate(true);
            } else {
                progressTextSpan.setVisible(true);
            }
            updateProgress(0);

            dialog.open();

            startExecution();
    }
```

As you can see - the background task starts immediately using the `startExecution()` method after opening the dialog. The build method cannot be implemented in a this way.

In order for users to be able to customize the dialog and listeners after the `BackgroundTaskDialogBuilder#build`, a self-removing listener was created that runs the background task once after opening the dialog.

This way the dialog can be opened outside the builder, the background task will be starter in any case.