### PR TITLE
Configure export options for the Grid export action jmix-framework/jmix#3497

### DIFF
--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/action/StudioGridExportActions.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/action/StudioGridExportActions.java
@@ -46,6 +46,10 @@ public interface StudioGridExportActions {
                     @StudioProperty(xmlAttribute = "shortcutCombination", category = StudioProperty.Category.GENERAL, type = StudioPropertyType.SHORTCUT_COMBINATION),
                     @StudioProperty(xmlAttribute = "text", category = StudioProperty.Category.GENERAL, type = StudioPropertyType.LOCALIZED_STRING),
                     @StudioProperty(xmlAttribute = "visible", category = StudioProperty.Category.GENERAL, type = StudioPropertyType.BOOLEAN, defaultValue = "true")
+            },
+            items = {
+                    @StudioPropertiesItem(xmlAttribute = "availableExportModes", type = StudioPropertyType.VALUES_LIST,
+                            options = {"ALL_ROWS", "CURRENT_PAGE", "SELECTED_ROWS"})
             }
     )
     void excelExport();
@@ -71,6 +75,10 @@ public interface StudioGridExportActions {
                     @StudioProperty(xmlAttribute = "shortcutCombination", category = StudioProperty.Category.GENERAL, type = StudioPropertyType.SHORTCUT_COMBINATION),
                     @StudioProperty(xmlAttribute = "text", category = StudioProperty.Category.GENERAL, type = StudioPropertyType.LOCALIZED_STRING),
                     @StudioProperty(xmlAttribute = "visible", category = StudioProperty.Category.GENERAL, type = StudioPropertyType.BOOLEAN, defaultValue = "true")
+            },
+            items = {
+                    @StudioPropertiesItem(xmlAttribute = "availableExportModes", type = StudioPropertyType.VALUES_LIST,
+                            options = {"ALL_ROWS", "CURRENT_PAGE", "SELECTED_ROWS"})
             }
     )
     void jsonExport();

--- a/jmix-gridexport/gridexport-flowui/src/main/java/io/jmix/gridexportflowui/GridExportProperties.java
+++ b/jmix-gridexport/gridexport-flowui/src/main/java/io/jmix/gridexportflowui/GridExportProperties.java
@@ -16,8 +16,11 @@
 
 package io.jmix.gridexportflowui;
 
+import io.jmix.gridexportflowui.action.ExportAction;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
+
+import java.util.List;
 
 /**
  * Export actions configuration interface
@@ -36,9 +39,25 @@ public class GridExportProperties {
     String exportAllPaginationStrategy;
 
     /**
+     * A list of mods that used by default in the {@link ExportAction}
+     */
+    List<String> defaultExportModes;
+
+    /**
      * Excel exporting configuration.
      */
     ExcelExporterProperties excel;
+
+    public GridExportProperties(@DefaultValue("1000") int exportAllBatchSize,
+                                @DefaultValue("keyset") String exportAllPaginationStrategy,
+                                @DefaultValue({"ALL_ROWS", "CURRENT_PAGE", "SELECTED_ROWS"})
+                                List<String> defaultExportModes,
+                                @DefaultValue ExcelExporterProperties excel) {
+        this.exportAllBatchSize = exportAllBatchSize;
+        this.exportAllPaginationStrategy = exportAllPaginationStrategy;
+        this.defaultExportModes = defaultExportModes;
+        this.excel = excel;
+    }
 
     /**
      * @see #exportAllBatchSize
@@ -54,12 +73,11 @@ public class GridExportProperties {
         return exportAllPaginationStrategy;
     }
 
-    public GridExportProperties(@DefaultValue("1000") int exportAllBatchSize,
-                                @DefaultValue("keyset") String exportAllPaginationStrategy,
-                                @DefaultValue ExcelExporterProperties excel) {
-        this.exportAllBatchSize = exportAllBatchSize;
-        this.exportAllPaginationStrategy = exportAllPaginationStrategy;
-        this.excel = excel;
+    /**
+     * @see #defaultExportModes
+     */
+    public List<String> getDefaultExportModes() {
+        return defaultExportModes;
     }
 
     public ExcelExporterProperties getExcel() {


### PR DESCRIPTION
See: #3497

# Implementation details
## Previous implementation
All options are visible if it possible:
![image](https://github.com/user-attachments/assets/a185f557-a2b8-4204-8323-1288cfd411a2)

## New implementation
### Application property
A new application property has been created: `jmix.gridexport.default-export-modes`.
<img width="615" alt="Screenshot 2024-08-30 at 16 15 08" src="https://github.com/user-attachments/assets/59def79b-4e44-4ed4-9c6a-c2443ce534b8">

The property defined a default set of options for export modes for `ExportAction`.
![Screenshot 2024-08-30 at 16 15 15](https://github.com/user-attachments/assets/be8b2b3d-3275-4ee5-b22e-68bc66097157)


The order of the options in the application property is taken into account. Options will be added in the order they are added using property:
<img width="542" alt="Screenshot 2024-08-30 at 16 16 59" src="https://github.com/user-attachments/assets/0d9e9497-3c53-482b-b1ae-d423f3f89480">
![Screenshot 2024-08-30 at 16 17 05](https://github.com/user-attachments/assets/bb269abe-a1b6-452a-826e-b5fe131cff9b)

The default value of the property remains the same as in the previous implementation: `ALL_ROWS, CURRENT_PAGE, SELECTED_ROWS`

### New API

* `io.jmix.gridexportflowui.action.ExportAction#setAvailableExportModes`
* `io.jmix.gridexportflowui.action.ExportAction#withAvailableExportModes`

Provides the ability to set available export modes for each `exportAction` separately.
Modes set via API have priority over modes set by default using `application.properties`.

Available modes can be set using the **XML markup** or the **Jmix UI Component Inspector**:
![image](https://github.com/user-attachments/assets/7f9e5d5c-b8df-4f97-9fa8-8b2ffbd3f68f)



