### PR TITLE
Excel export action should take into account grid columns visibility jmix-framework/jmix#3263

### DIFF
--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/action/StudioGridExportActions.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/action/StudioGridExportActions.java
@@ -49,7 +49,10 @@ public interface StudioGridExportActions {
             },
             items = {
                     @StudioPropertiesItem(xmlAttribute = "availableExportModes", type = StudioPropertyType.VALUES_LIST,
-                            options = {"ALL_ROWS", "CURRENT_PAGE", "SELECTED_ROWS"})
+                            options = {"ALL_ROWS", "CURRENT_PAGE", "SELECTED_ROWS"}),
+                    @StudioPropertiesItem(xmlAttribute = "columnExportFilter", type = StudioPropertyType.ENUMERATION,
+                            options = {"ALL_COLUMNS", "VISIBLE_COLUMNS"}),
+                    @StudioPropertiesItem(xmlAttribute = "columnKeysToExport", type = StudioPropertyType.VALUES_LIST)
             }
     )
     void excelExport();
@@ -78,7 +81,10 @@ public interface StudioGridExportActions {
             },
             items = {
                     @StudioPropertiesItem(xmlAttribute = "availableExportModes", type = StudioPropertyType.VALUES_LIST,
-                            options = {"ALL_ROWS", "CURRENT_PAGE", "SELECTED_ROWS"})
+                            options = {"ALL_ROWS", "CURRENT_PAGE", "SELECTED_ROWS"}),
+                    @StudioPropertiesItem(xmlAttribute = "columnExportFilter", type = StudioPropertyType.ENUMERATION,
+                            options = {"ALL_COLUMNS", "VISIBLE_COLUMNS"}),
+                    @StudioPropertiesItem(xmlAttribute = "columnKeysToExport", type = StudioPropertyType.VALUES_LIST)
             }
     )
     void jsonExport();

--- a/jmix-gridexport/gridexport-flowui/src/main/java/io/jmix/gridexportflowui/GridExportProperties.java
+++ b/jmix-gridexport/gridexport-flowui/src/main/java/io/jmix/gridexportflowui/GridExportProperties.java
@@ -17,6 +17,7 @@
 package io.jmix.gridexportflowui;
 
 import io.jmix.gridexportflowui.action.ExportAction;
+import io.jmix.gridexportflowui.exporter.ColumnExportFilter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 
@@ -44,6 +45,11 @@ public class GridExportProperties {
     List<String> defaultExportModes;
 
     /**
+     * A {@link ColumnExportFilter} that used by default in the {@link ExportAction}
+     */
+    String defaultColumnExportFilter;
+
+    /**
      * Excel exporting configuration.
      */
     ExcelExporterProperties excel;
@@ -52,10 +58,12 @@ public class GridExportProperties {
                                 @DefaultValue("keyset") String exportAllPaginationStrategy,
                                 @DefaultValue({"ALL_ROWS", "CURRENT_PAGE", "SELECTED_ROWS"})
                                 List<String> defaultExportModes,
+                                @DefaultValue("VISIBLE_COLUMNS") String defaultColumnExportFilter,
                                 @DefaultValue ExcelExporterProperties excel) {
         this.exportAllBatchSize = exportAllBatchSize;
         this.exportAllPaginationStrategy = exportAllPaginationStrategy;
         this.defaultExportModes = defaultExportModes;
+        this.defaultColumnExportFilter = defaultColumnExportFilter;
         this.excel = excel;
     }
 
@@ -78,6 +86,13 @@ public class GridExportProperties {
      */
     public List<String> getDefaultExportModes() {
         return defaultExportModes;
+    }
+
+    /**
+     * @see #defaultColumnExportFilter
+     */
+    public String getDefaultColumnExportFilter() {
+        return defaultColumnExportFilter;
     }
 
     public ExcelExporterProperties getExcel() {

--- a/jmix-gridexport/gridexport-flowui/src/main/java/io/jmix/gridexportflowui/exporter/ColumnExportFilter.java
+++ b/jmix-gridexport/gridexport-flowui/src/main/java/io/jmix/gridexportflowui/exporter/ColumnExportFilter.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.gridexportflowui.exporter;
+
+import com.vaadin.flow.component.grid.Grid;
+
+import java.util.function.Predicate;
+
+/**
+ * Column filtering mode for export.
+ */
+public enum ColumnExportFilter {
+
+    /**
+     * Export all columns.
+     */
+    ALL_COLUMNS(column -> true),
+
+    /**
+     * Export only visible columns.
+     */
+    VISIBLE_COLUMNS(Grid.Column::isVisible);
+
+    private final Predicate<Grid.Column<Object>> filterPredicate;
+
+    ColumnExportFilter(Predicate<Grid.Column<Object>> filterPredicate) {
+        this.filterPredicate = filterPredicate;
+    }
+
+    public Predicate<Grid.Column<Object>> getFilterPredicate() {
+        return filterPredicate;
+    }
+}

--- a/jmix-gridexport/gridexport-flowui/src/main/java/io/jmix/gridexportflowui/exporter/DataGridExporter.java
+++ b/jmix-gridexport/gridexport-flowui/src/main/java/io/jmix/gridexportflowui/exporter/DataGridExporter.java
@@ -18,19 +18,38 @@ package io.jmix.gridexportflowui.exporter;
 
 import com.vaadin.flow.component.grid.Grid;
 import io.jmix.flowui.component.ListDataComponent;
+import io.jmix.flowui.component.grid.DataGrid;
 import io.jmix.flowui.download.Downloader;
-
 import org.springframework.lang.Nullable;
+
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 public interface DataGridExporter {
 
     void setFileName(String fileName);
 
     /**
-     * download <code>dataGrid</code> content via <code>downloader</code>
+     * Exports {@link DataGrid} content using {@link Downloader}.
+     *
+     * @param downloader   {@link Downloader} instance
+     * @param dataGrid     {@link DataGrid} to get content
+     * @param exportMode   exportMode
+     * @param columnFilter filter of the {@link Grid.Column}
      */
-    void exportDataGrid(Downloader downloader, Grid<Object> dataGrid, ExportMode exportMode);
+    void exportDataGrid(Downloader downloader, Grid<Object> dataGrid, ExportMode exportMode,
+                        Predicate<Grid.Column<Object>> columnFilter);
+
+    /**
+     * Exports {@link DataGrid} content using {@link Downloader}.
+     *
+     * @param downloader {@link Downloader} instance
+     * @param dataGrid   {@link DataGrid} to get content
+     * @param exportMode exportMode
+     */
+    default void exportDataGrid(Downloader downloader, Grid<Object> dataGrid, ExportMode exportMode) {
+        exportDataGrid(downloader, dataGrid, exportMode, ColumnExportFilter.VISIBLE_COLUMNS.getFilterPredicate());
+    }
 
     /**
      * @return exporter label

--- a/jmix-gridexport/gridexport-flowui/src/main/java/io/jmix/gridexportflowui/exporter/excel/ExcelExporter.java
+++ b/jmix-gridexport/gridexport-flowui/src/main/java/io/jmix/gridexportflowui/exporter/excel/ExcelExporter.java
@@ -65,6 +65,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.*;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static io.jmix.flowui.download.DownloadFormat.XLSX;
@@ -138,7 +139,8 @@ public class ExcelExporter extends AbstractDataGridExporter<ExcelExporter> {
 
     @SuppressWarnings({"unchecked", "rawtypes"})
     @Override
-    public void exportDataGrid(Downloader downloader, Grid<Object> dataGrid, ExportMode exportMode) {
+    public void exportDataGrid(Downloader downloader, Grid<Object> dataGrid, ExportMode exportMode,
+                               Predicate<Grid.Column<Object>> columnFilter) {
         Preconditions.checkNotNullArgument(downloader, "Downloader is null");
 
         createWorkbookWithSheet();
@@ -146,7 +148,9 @@ public class ExcelExporter extends AbstractDataGridExporter<ExcelExporter> {
             createFonts();
             createFormats();
 
-            List<Grid.Column<Object>> columns = dataGrid.getColumns();
+            List<Grid.Column<Object>> columns = dataGrid.getColumns().stream()
+                    .filter(columnFilter)
+                    .toList();
 
             int r = 0;
 
@@ -234,20 +238,20 @@ public class ExcelExporter extends AbstractDataGridExporter<ExcelExporter> {
 
                 AllEntitiesLoader entitiesLoader = allEntitiesLoaderFactory.getEntitiesLoader();
                 entitiesLoader.loadAll(
-                    ((ListDataComponent<?>) dataGrid).getItems(),
-                    context -> {
-                        if (!checkIsRowNumberExceed(context.getEntityNumber())) {
-                            createDataGridRowForEntityInstance(
-                                    dataGrid,
-                                    columns,
-                                    0,
-                                    context.getEntityNumber(),
-                                    context.getEntity(),
-                                    addLevelPadding);
-                            return true;
-                        }
-                        return false;
-                    });
+                        ((ListDataComponent<?>) dataGrid).getItems(),
+                        context -> {
+                            if (!checkIsRowNumberExceed(context.getEntityNumber())) {
+                                createDataGridRowForEntityInstance(
+                                        dataGrid,
+                                        columns,
+                                        0,
+                                        context.getEntityNumber(),
+                                        context.getEntity(),
+                                        addLevelPadding);
+                                return true;
+                            }
+                            return false;
+                        });
             }
 
             for (int c = 0; c < columns.size(); c++) {


### PR DESCRIPTION
See: #3263
A migration issue for the Studio will be created after the merging. The migration should add an application to preserve the old export behavior.
```properties
jmix.gridexport.default-column-export-filter=ALL_COLUMNS
```
----

Added three options for export column filtering:

# Predefined column filter predicate (enumeration)

```java
    /**
     * Export all columns.
     */
    ALL_COLUMNS(column -> true),

    /**
     * Export only visible columns.
     */
    VISIBLE_COLUMNS(Grid.Column::isVisible);
``` 

You can set filtering options using `jmix.gridexport.default-column-export-filter` application property or using a `properteis` in the Component Inspector.
The default value for new projects: `VISIBLE_COLUMNS`
Migration will add the old value to the `application.properties`.

This filtering option **has the lowest priority**.

# Flexible filtering predicate (install point)

```java
    @Install(to = "usersDataGrid.excelExport", subject = "columnExportPredicate")
    private boolean usersDataGridExcelExportColumnExportPredicate(final Grid.Column<Object> column) {
        return column.getKey().contains("name") || column.getKey().contains("zone");
    }
```

Provides the same functionality as enumeration above.

This filtering options **has the secondary priority.**

# Specefying keys of columns for filtering (list of keys)

Using the Component Inspector, you can specify columns to export.

```xml
                <action id="excelExport" type="grdexp_excelExport">
                    <properties>
                        <property name="columnKeysToExport" value="username, firstName, lastName"/>
                    </properties>
                </action>
```

This filtering option **has the primary priority**.