### PR TITLE
fix default value of dynamic attribute #3638

### DIFF
--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
@@ -267,9 +267,7 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
     private boolean isRefreshing = false;
 
     @ViewComponent
-    protected TypedTextField<String> defaultStringField; //debug
-    @ViewComponent
-    protected TypedTextField<Integer> defaultIntField; //debug
+    protected TypedTextField<String> defaultStringField;
 
     private final List<String> defaultEnumValues = new ArrayList<>();
 

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
@@ -221,8 +221,6 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
     @ViewComponent
     protected JmixComboBox<String> defaultEnumField;
     @ViewComponent
-    protected TypedTextField<String> defaultStringField;
-    @ViewComponent
     protected JmixComboBox<OptionsLoaderType> optionsLoaderTypeField;
     @ViewComponent
     protected JmixValuePicker<Object> defaultEntityIdField;
@@ -242,6 +240,8 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
     protected JmixTabSheet tabSheet;
     @ViewComponent
     protected TypedTextField<String> codeField;
+    @ViewComponent
+    protected TypedTextField<String> defaultStringField;
     @ViewComponent
     protected TypedTextField<BigDecimal> defaultDecimalField;
     @ViewComponent

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
@@ -221,6 +221,8 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
     @ViewComponent
     protected JmixComboBox<String> defaultEnumField;
     @ViewComponent
+    protected TypedTextField<String> defaultStringField;
+    @ViewComponent
     protected JmixComboBox<OptionsLoaderType> optionsLoaderTypeField;
     @ViewComponent
     protected JmixValuePicker<Object> defaultEntityIdField;
@@ -265,10 +267,6 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
     @ViewComponent
     private JmixButton editEnumerationBtn;
     private boolean isRefreshing = false;
-
-    @ViewComponent
-    protected TypedTextField<String> defaultStringField;
-
     private final List<String> defaultEnumValues = new ArrayList<>();
 
     @Subscribe
@@ -281,10 +279,7 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
     private void initDefaultEnumField() {
         defaultEnumValues.addAll(getEnumValues());
         defaultEnumField.setItems(defaultEnumValues);
-        defaultEnumField.addValueChangeListener(e -> {
-            getEditedEntity().setDefaultString(e.getValue());
-        });
-
+        defaultEnumField.addValueChangeListener(e -> getEditedEntity().setDefaultString(e.getValue()));
         if (StringUtils.isNotBlank(getEditedEntity().getDefaultString())) {
             defaultEnumField.setValue(getEditedEntity().getDefaultString());
         }
@@ -308,8 +303,7 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
 
     @Subscribe
     protected void onAfterShow(BeforeShowEvent event) {
-        if (getEditedEntity().getDataType() != null &&
-                getEditedEntity().getDataType().equals(AttributeType.ENUMERATION)) {
+        if (isDataTypeEnum()) {
             initDefaultEnumField();
         }
         initCategoryAttributeConfigurationField();
@@ -337,6 +331,11 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
         tabSheet.addSelectedChangeListener(e -> refreshOnce());
         screenField.addValueChangeListener(e -> getEditedEntity().setScreen(e.getValue()));
         loadTargetViews();
+    }
+
+    private boolean isDataTypeEnum() {
+        return getEditedEntity().getDataType() != null &&
+                getEditedEntity().getDataType().equals(AttributeType.ENUMERATION);
     }
 
     @Install(to = "nameField", subject = "validator")
@@ -693,7 +692,8 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
             component.setVisible(visible);
 
             if (!visible && component instanceof HasValue) {
-                if (component.equals(defaultStringField) && ENUMERATION.equals(attributeType) &&
+                if (component.equals(defaultStringField) &&
+                        ENUMERATION.equals(attributeType) &&
                         !defaultEnumField.isEmpty()) {
                     continue;
                 }

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
@@ -266,6 +266,11 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
     private JmixButton editEnumerationBtn;
     private boolean isRefreshing = false;
 
+    @ViewComponent
+    protected TypedTextField<String> defaultStringField; //debug
+    @ViewComponent
+    protected TypedTextField<Integer> defaultIntField; //debug
+
     private final List<String> defaultEnumValues = new ArrayList<>();
 
     @Subscribe
@@ -278,7 +283,10 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
     private void initDefaultEnumField() {
         defaultEnumValues.addAll(getEnumValues());
         defaultEnumField.setItems(defaultEnumValues);
-        defaultEnumField.addValueChangeListener(e -> getEditedEntity().setDefaultString(e.getValue()));
+        defaultEnumField.addValueChangeListener(e -> {
+            getEditedEntity().setDefaultString(e.getValue());
+        });
+
         if (StringUtils.isNotBlank(getEditedEntity().getDefaultString())) {
             defaultEnumField.setValue(getEditedEntity().getDefaultString());
         }
@@ -302,7 +310,10 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
 
     @Subscribe
     protected void onAfterShow(BeforeShowEvent event) {
-        initDefaultEnumField();
+        if (getEditedEntity().getDataType() != null &&
+                getEditedEntity().getDataType().equals(AttributeType.ENUMERATION)) {
+            initDefaultEnumField();
+        }
         initCategoryAttributeConfigurationField();
         initLocalizationTab();
         initDependsOnAttributesField();
@@ -684,6 +695,10 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
             component.setVisible(visible);
 
             if (!visible && component instanceof HasValue) {
+                if (component.equals(defaultStringField) && ENUMERATION.equals(attributeType) &&
+                        !defaultEnumField.isEmpty()) {
+                    continue;
+                }
                 ((HasValue<?, ?>) component).clear();
             }
         }


### PR DESCRIPTION
See issue #3638

**Problem:** In the `refreshAttributesUI()` method, both `defaultStringField` and `defaultEnumField` are cleared due to the following code:

```java
if (!visible && component instanceof HasValue) {
    ((HasValue<?, ?>) component).clear();
}
```

When the `defaultEnumField` component is processed, it gets cleared, which triggers a listener attached to it. This listener also clears the `defaultStringField`.

The listener is added in the `initDefaultEnumField()` method, which is called during every initialization:

```java
private void initDefaultEnumField() {
    //...
    defaultEnumField.addValueChangeListener(e -> getEditedEntity().setDefaultString(e.getValue()));
    if (StringUtils.isNotBlank(getEditedEntity().getDefaultString())) {
        defaultEnumField.setValue(getEditedEntity().getDefaultString());
    }
    //...
}
```

**Solution:** As a temporary fix until we refactor the dynamic attribute handling, I propose the following changes:

1. Call `initDefaultEnumField()` only when the component's data type is set to `ENUMERATION`. This prevents the listener from being attached when the data type is a string.

2. Modify the logic in `refreshAttributesUI()` to skip clearing the `defaultStringField` when dealing with an enumeration field. This change will prevent the `defaultEnumField` from being cleared.