### PR TITLE
Amend UI minimal policies (3580)

### DIFF
--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/role/UiMinimalPolicies.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/role/UiMinimalPolicies.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.securityflowui.role;
+
+
+import io.jmix.core.entity.KeyValueEntity;
+import io.jmix.security.model.EntityAttributePolicyAction;
+import io.jmix.security.model.EntityPolicyAction;
+import io.jmix.security.role.annotation.EntityAttributePolicy;
+import io.jmix.security.role.annotation.EntityPolicy;
+import io.jmix.securityflowui.role.annotation.ViewPolicy;
+
+public interface UiMinimalPolicies {
+
+    @ViewPolicy(viewIds = {"inputDialog", "multiValueSelectDialog"})
+    void systemDialogs();
+
+    @EntityPolicy(entityClass = KeyValueEntity.class, actions = EntityPolicyAction.READ)
+    @EntityAttributePolicy(entityClass = KeyValueEntity.class, attributes = "*", action = EntityAttributePolicyAction.VIEW)
+    void keyValueEntity();
+}

--- a/jmix-templates/content/project/application-kotlin/src/main/kotlin/${project_rootPath}/security/UiMinimalRole.kt
+++ b/jmix-templates/content/project/application-kotlin/src/main/kotlin/${project_rootPath}/security/UiMinimalRole.kt
@@ -1,17 +1,13 @@
 package ${project_rootPackage}.security
 
-import io.jmix.core.entity.KeyValueEntity
-import io.jmix.security.model.EntityAttributePolicyAction
-import io.jmix.security.model.EntityPolicyAction
 import io.jmix.security.model.SecurityScope
-import io.jmix.security.role.annotation.EntityAttributePolicy
-import io.jmix.security.role.annotation.EntityPolicy
 import io.jmix.security.role.annotation.ResourceRole
 import io.jmix.security.role.annotation.SpecificPolicy
+import io.jmix.securityflowui.role.UiMinimalPolicies
 import io.jmix.securityflowui.role.annotation.ViewPolicy
 
 @ResourceRole(name = "UI: minimal access", code = UiMinimalRole.CODE, scope = [SecurityScope.UI])
-interface UiMinimalRole {
+interface UiMinimalRole : UiMinimalPolicies {
 
     companion object {
         const val CODE = "ui-minimal"
@@ -23,12 +19,4 @@ interface UiMinimalRole {
     @ViewPolicy(viewIds = ["${normalizedPrefix_underscore}LoginView"])
     @SpecificPolicy(resources = ["ui.loginToUi"])
     fun login()
-
-    @EntityPolicy(entityClass = KeyValueEntity::class, actions = [EntityPolicyAction.READ])
-    @EntityAttributePolicy(
-            entityClass = KeyValueEntity::class,
-            attributes = ["*"],
-            action = EntityAttributePolicyAction.VIEW
-    )
-    fun keyValueEntity()
 }

--- a/jmix-templates/content/project/application/src/main/java/${project_rootPath}/security/UiMinimalRole.java
+++ b/jmix-templates/content/project/application/src/main/java/${project_rootPath}/security/UiMinimalRole.java
@@ -1,17 +1,13 @@
 package ${project_rootPackage}.security;
 
-import io.jmix.core.entity.KeyValueEntity;
-import io.jmix.security.model.EntityAttributePolicyAction;
-import io.jmix.security.model.EntityPolicyAction;
 import io.jmix.security.model.SecurityScope;
-import io.jmix.security.role.annotation.EntityAttributePolicy;
-import io.jmix.security.role.annotation.EntityPolicy;
 import io.jmix.security.role.annotation.ResourceRole;
 import io.jmix.security.role.annotation.SpecificPolicy;
+import io.jmix.securityflowui.role.UiMinimalPolicies;
 import io.jmix.securityflowui.role.annotation.ViewPolicy;
 
 @ResourceRole(name = "UI: minimal access", code = UiMinimalRole.CODE, scope = SecurityScope.UI)
-public interface UiMinimalRole {
+public interface UiMinimalRole extends UiMinimalPolicies {
 
     String CODE = "ui-minimal";
 
@@ -21,8 +17,4 @@ public interface UiMinimalRole {
     @ViewPolicy(viewIds = "${normalizedPrefix_underscore}LoginView")
     @SpecificPolicy(resources = "ui.loginToUi")
     void login();
-
-    @EntityPolicy(entityClass = KeyValueEntity.class, actions = EntityPolicyAction.READ)
-    @EntityAttributePolicy(entityClass = KeyValueEntity.class, attributes = "*", action = EntityAttributePolicyAction.VIEW)
-    void keyValueEntity();
 }


### PR DESCRIPTION
This fixes #3580 for new projects.

The idea is to create a base interface for `UiMinimalRole` in the framework and put all system policies there. Then we'll be able to add new minimal system policies and propagate them to app projects without any migrations.