### PR TITLE
Improve performance of EntityStates.isLoaded operation

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/EntityEntry.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/EntityEntry.java
@@ -16,10 +16,7 @@
 
 package io.jmix.core;
 
-import io.jmix.core.entity.BaseEntityEntry;
-import io.jmix.core.entity.EntityPropertyChangeListener;
-import io.jmix.core.entity.NullableIdEntityEntry;
-import io.jmix.core.entity.SecurityState;
+import io.jmix.core.entity.*;
 import io.jmix.core.entity.annotation.JmixGeneratedValue;
 import io.jmix.core.entity.annotation.JmixId;
 import io.jmix.core.impl.EntityInternals;
@@ -101,12 +98,17 @@ public interface EntityEntry extends Serializable {
     void setRemoved(boolean removed);
 
     /**
-     * Optional set of names of properties loaded from data store.
+     * @return {@link LoadedPropertiesInfo} which is set for this entity instance or null
      */
     @Nullable
-    Set<String> getLoadedProperties();
+    LoadedPropertiesInfo getLoadedPropertiesInfo();
 
-    void setLoadedProperties(@Nullable Set<String> loadedProperties);
+    /**
+     * Sets a {@link LoadedPropertiesInfo} for this entity instance.
+     *
+     * @param loadedPropertiesInfo {@link LoadedPropertiesInfo} implementation
+     */
+    void setLoadedPropertiesInfo(@Nullable LoadedPropertiesInfo loadedPropertiesInfo);
 
     SecurityState getSecurityState();
 

--- a/jmix-core/core/src/main/java/io/jmix/core/EntityStates.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/EntityStates.java
@@ -19,7 +19,9 @@ package io.jmix.core;
 import com.google.common.collect.Sets;
 import io.jmix.core.common.util.StackTrace;
 import io.jmix.core.entity.EntityPreconditions;
+import io.jmix.core.entity.EntitySystemAccess;
 import io.jmix.core.entity.EntityValues;
+import io.jmix.core.entity.LoadedPropertiesInfo;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
 import org.slf4j.Logger;
@@ -124,8 +126,8 @@ public class EntityStates {
     }
 
     /**
-     * Checks if the property is loaded from DB.
-     * <p>Non-persistent attributes are considered loaded if they do not have related properties, or all related
+     * Checks if the property is loaded from the data store.
+     * <p>Non-stored attributes are considered loaded if they do not have related properties, or all related
      * properties are loaded.
      *
      * @param entity   entity
@@ -133,11 +135,18 @@ public class EntityStates {
      * @return true if loaded
      */
     public boolean isLoaded(Object entity, String property) {
-        return checker.isLoaded(entity, property);
+        log.trace("Checking is loaded {}.{}", entity, property);
+
+        LoadedPropertiesInfo loadedPropertiesInfo = EntitySystemAccess.getEntityEntry(entity).getLoadedPropertiesInfo();
+        if (loadedPropertiesInfo != null) {
+            return loadedPropertiesInfo.isLoaded(entity, property, checker);
+        } else {
+            return checker.isLoaded(entity, property);
+        }
     }
 
     /**
-     * Check that entity has all specified properties loaded from DB.
+     * Check that entity has all specified properties loaded from the data store.
      * Throw exception if property is not loaded.
      *
      * @param entity     entity
@@ -199,7 +208,7 @@ public class EntityStates {
     }
 
     /**
-     * Check that all properties of the fetch plan are loaded from DB for the passed entity.
+     * Check that all properties of the fetch plan are loaded from the data store for the passed entity.
      * Throws exception if some property is not loaded.
      *
      * @param entity    entity
@@ -214,7 +223,7 @@ public class EntityStates {
     }
 
     /**
-     * Check that all properties of the fetch plan are loaded from DB for the passed entity.
+     * Check that all properties of the fetch plan are loaded from the data store for the passed entity.
      * Throws exception if some property is not loaded.
      *
      * @param entity        entity

--- a/jmix-core/core/src/main/java/io/jmix/core/entity/BaseEntityEntry.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/entity/BaseEntityEntry.java
@@ -48,7 +48,7 @@ public abstract class BaseEntityEntry implements EntityEntry, Cloneable {
     protected transient Collection<WeakReference<EntityPropertyChangeListener>> weakPropertyChangeListeners;
     protected Collection<EntityPropertyChangeListener> propertyChangeListeners;
     protected Entity source;
-    protected Set<String> loadedProperties;
+    protected LoadedPropertiesInfo loadedPropertiesInfo;
     protected Map<Class<?>, EntityEntryExtraState> extraStateMap;
     protected Map<Class<?>, EntityValuesProvider> entityValuesProviders;
 
@@ -151,12 +151,13 @@ public abstract class BaseEntityEntry implements EntityEntry, Cloneable {
 
     @Nullable
     @Override
-    public Set<String> getLoadedProperties() {
-        return loadedProperties;
+    public LoadedPropertiesInfo getLoadedPropertiesInfo() {
+        return loadedPropertiesInfo;
     }
 
-    public void setLoadedProperties(@Nullable Set<String> loadedProperties) {
-        this.loadedProperties = loadedProperties;
+    @Override
+    public void setLoadedPropertiesInfo(@Nullable LoadedPropertiesInfo loadedPropertiesInfo) {
+        this.loadedPropertiesInfo = loadedPropertiesInfo;
     }
 
     @NonNull
@@ -263,7 +264,7 @@ public abstract class BaseEntityEntry implements EntityEntry, Cloneable {
             setManaged(entry.isManaged());
             setRemoved(entry.isRemoved());
 
-            loadedProperties = entry.getLoadedProperties();
+            loadedPropertiesInfo = entry.getLoadedPropertiesInfo();
 
             if (entry instanceof BaseEntityEntry baseEntityEntry && baseEntityEntry.propertyChangeListeners != null) {
                 for (EntityPropertyChangeListener listener : baseEntityEntry.propertyChangeListeners) {

--- a/jmix-core/core/src/main/java/io/jmix/core/entity/LoadedPropertiesInfo.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/entity/LoadedPropertiesInfo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core.entity;
+
+import io.jmix.core.PersistentAttributesLoadChecker;
+import io.jmix.core.annotation.Internal;
+
+import java.io.Serializable;
+
+/**
+ * Provides information about properties loaded from data store.
+ * <p>
+ * Implementations of this interface are used in {@link io.jmix.core.EntityEntry}.
+ */
+@Internal
+public interface LoadedPropertiesInfo extends Serializable {
+
+    boolean isLoaded(Object entity, String property, PersistentAttributesLoadChecker checker);
+
+    void registerProperty(String name, boolean loaded);
+}

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/CachingLoadedPropertiesInfo.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/CachingLoadedPropertiesInfo.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core.impl;
+
+import io.jmix.core.PersistentAttributesLoadChecker;
+import io.jmix.core.entity.EntitySystemAccess;
+import io.jmix.core.entity.LoadedPropertiesInfo;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Implementation of {@link LoadedPropertiesInfo} that caches information about loaded properties to avoid
+ * expensive operations for the same instance and property.
+ * <p>
+ * Used by default for JPA entities.
+ */
+public class CachingLoadedPropertiesInfo implements LoadedPropertiesInfo {
+
+    private Map<String, Boolean> cache = new HashMap<>();
+
+    @Override
+    public boolean isLoaded(Object entity, String property, PersistentAttributesLoadChecker checker) {
+        if (EntitySystemAccess.getEntityEntry(entity).isManaged()) {
+            return checker.isLoaded(entity, property);
+        }
+        return cache.computeIfAbsent(property, name ->
+                checker.isLoaded(entity, name));
+    }
+
+    @Override
+    public void registerProperty(String name, boolean loaded) {
+        cache.put(name, loaded);
+    }
+}

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/CorePersistentAttributesLoadChecker.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/CorePersistentAttributesLoadChecker.java
@@ -30,7 +30,6 @@ import org.springframework.stereotype.Component;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 
 @Component("core_PersistentAttributesLoadChecker")
 public class CorePersistentAttributesLoadChecker implements PersistentAttributesLoadChecker {
@@ -52,13 +51,6 @@ public class CorePersistentAttributesLoadChecker implements PersistentAttributes
         if (entity instanceof KeyValueEntity) {
             KeyValueEntity keyValue = (KeyValueEntity) entity;
             return keyValue.getInstanceMetaClass() != null && keyValue.getInstanceMetaClass().findProperty(property) != null;
-        }
-
-        if (entity instanceof Entity e) {
-            Set<String> loadedProperties = e.__getEntityEntry().getLoadedProperties();
-            if (loadedProperties != null) {
-                return loadedProperties.contains(property);
-            }
         }
 
         MetaClass metaClass = metadata.getClass(entity);

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/LoadedPropertiesInfoFactory.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/LoadedPropertiesInfoFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core.impl;
+
+import io.jmix.core.entity.LoadedPropertiesInfo;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Creates {@link CachingLoadedPropertiesInfo} instances to be used in JPA entities.
+ */
+@Component("core_LoadedPropertiesInfoFactory")
+public class LoadedPropertiesInfoFactory {
+
+    @Value("${jmix.core.disable-caching-loaded-properties:false}")
+    private Boolean disableCaching;
+
+    @Nullable
+    public LoadedPropertiesInfo create() {
+        if (disableCaching) {
+            return null;
+        } else {
+            return new CachingLoadedPropertiesInfo();
+        }
+    }
+}

--- a/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/EclipselinkPersistenceSupport.java
+++ b/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/EclipselinkPersistenceSupport.java
@@ -23,6 +23,7 @@ import io.jmix.core.common.util.StackTrace;
 import io.jmix.core.entity.EntityValues;
 import io.jmix.core.event.AttributeChanges;
 import io.jmix.core.event.EntityChangedEvent;
+import io.jmix.core.impl.LoadedPropertiesInfoFactory;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.security.EntityOp;
 import io.jmix.data.AttributeChangesProvider;
@@ -100,6 +101,9 @@ public class EclipselinkPersistenceSupport implements ApplicationContextAware {
 
     @Autowired
     protected ObjectProvider<DeletePolicyProcessor> deletePolicyProcessorProvider;
+
+    @Autowired
+    protected LoadedPropertiesInfoFactory loadedPropertiesInfoFactory;
 
     protected List<BeforeCommitTransactionListener> beforeCommitTxListeners;
 
@@ -353,6 +357,7 @@ public class EclipselinkPersistenceSupport implements ApplicationContextAware {
         if (instance instanceof ChangeTracker) {
             ((ChangeTracker) instance)._persistence_setPropertyChangeListener(null);
         }
+        getUncheckedEntityEntry(instance).setLoadedPropertiesInfo(loadedPropertiesInfoFactory.create());
     }
 
     protected void fireFlush(String storeName) {

--- a/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/lazyloading/AbstractValueHolder.java
+++ b/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/lazyloading/AbstractValueHolder.java
@@ -20,7 +20,9 @@ import io.jmix.core.FetchPlans;
 import io.jmix.core.Metadata;
 import io.jmix.core.MetadataTools;
 import io.jmix.core.UnconstrainedDataManager;
+import io.jmix.core.entity.EntitySystemAccess;
 import io.jmix.core.entity.EntityValues;
+import io.jmix.core.entity.LoadedPropertiesInfo;
 import io.jmix.core.metamodel.model.MetaProperty;
 import org.eclipse.persistence.indirection.ValueHolderInterface;
 import org.eclipse.persistence.indirection.WeavedAttributeValueHolderInterface;
@@ -276,6 +278,7 @@ public abstract class AbstractValueHolder extends UnitOfWorkValueHolder implemen
                 synchronized (this) {
                     value = loadValue();
                     afterLoadValue(value);
+                    registerLoadedProperty();
                 }
             }
             isInstantiated = true;
@@ -286,6 +289,13 @@ public abstract class AbstractValueHolder extends UnitOfWorkValueHolder implemen
     protected abstract Object loadValue();
 
     protected abstract void afterLoadValue(Object value);
+
+    protected void registerLoadedProperty() {
+        LoadedPropertiesInfo loadedPropertiesInfo = EntitySystemAccess.getEntityEntry(getOwner()).getLoadedPropertiesInfo();
+        if (loadedPropertiesInfo != null) {
+            loadedPropertiesInfo.registerProperty(getPropertyInfo().getName(), true);
+        }
+    }
 
     @Override
     public void setValue(Object value) {

--- a/jmix-data/eclipselink/src/test/groovy/entity_states/EntityStatesIsLoadedTest.groovy
+++ b/jmix-data/eclipselink/src/test/groovy/entity_states/EntityStatesIsLoadedTest.groovy
@@ -1,0 +1,299 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entity_states
+
+import io.jmix.core.DataManager
+import io.jmix.core.EntityStates
+import io.jmix.core.FetchPlan
+import jakarta.persistence.EntityManager
+import jakarta.persistence.PersistenceContext
+import org.springframework.beans.factory.annotation.Autowired
+import test_support.DataSpec
+import test_support.entity.sales.*
+
+class EntityStatesIsLoadedTest extends DataSpec {
+
+    @Autowired
+    DataManager dataManager
+    @Autowired
+    EntityStates entityStates
+    @PersistenceContext
+    EntityManager entityManager
+
+    private Customer customer
+    private Order order
+    private OrderLineA line1
+    private OrderLineB line2
+    private Product product1
+    private Product product2
+
+    @Override
+    void setup() {
+        this.customer = dataManager.create(Customer)
+        this.customer.name = 'cust-1'
+        this.customer.status = Status.OK
+        dataManager.save(this.customer)
+
+        this.order = dataManager.create(Order)
+        this.order.customer = this.customer
+        this.order.number = '1'
+        dataManager.save(this.order)
+
+        product1 = dataManager.create(Product)
+        product1.name = 'p1'
+        dataManager.save(product1)
+
+        product2 = dataManager.create(Product)
+        product2.name = 'p1'
+        dataManager.save(product2)
+
+        line1 = dataManager.create(OrderLineA)
+        line1.order = this.order
+        line1.product = product1
+        line1.quantity = 1
+        line1.param1 = 'value1'
+        dataManager.save(line1)
+
+        line2 = dataManager.create(OrderLineB)
+        line2.order = this.order
+        line2.product = product2
+        line2.quantity = 2
+        line2.param2 = 'value2'
+        dataManager.save(line2)
+    }
+
+    def "test load single entity"() {
+        when:
+        def customer1 = dataManager.load(Customer).id(this.customer.id).one()
+
+        then:
+        ['deleteTs', 'updatedBy', 'createdBy', 'name', 'createTs', 'id', 'version', 'updateTs', 'deletedBy', 'status'].each {
+            assert entityStates.isLoaded(customer1, it)
+        }
+
+        when:
+        def customer2 = dataManager.load(Customer).id(this.customer.id).fetchPlanProperties('name').one()
+
+        then:
+        ['id', 'version', 'name', 'deleteTs', 'deletedBy'].each {
+            assert entityStates.isLoaded(customer2, it)
+        }
+        ['createTs', 'createdBy', 'updateTs', 'updatedBy', 'status'].each {
+            assert !entityStates.isLoaded(customer2, it)
+        }
+    }
+
+    def "test load graph"() {
+        def order
+
+        when:
+        order = dataManager.load(Order).id(this.order.id).one()
+
+        then:
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+         'user' /*user is not included in _base fetch plan but marked as loaded because the reference is null*/ ].each {
+            assert entityStates.isLoaded(order, it)
+        }
+
+        ['customer', 'orderLines'].each {
+            assert !entityStates.isLoaded(order, it)
+        }
+
+        when:
+        order = dataManager.load(Order)
+                .id(this.order.id)
+                .fetchPlan(fpb ->
+                        fpb.addFetchPlan(FetchPlan.BASE).add('customer'))
+                .one()
+
+        then:
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+         'user', 'customer'].each {
+            assert entityStates.isLoaded(order, it)
+        }
+
+        ['id', 'version', 'deleteTs', 'deletedBy'].each {
+            assert entityStates.isLoaded(order.customer, it)
+        }
+        ['name', 'status'].each {
+            assert !entityStates.isLoaded(order.customer, it)
+        }
+
+
+        when:
+        order = dataManager.load(Order)
+                .id(this.order.id)
+                .fetchPlan(fpb -> fpb.addFetchPlan(FetchPlan.BASE).add('customer', FetchPlan.BASE))
+                .one()
+
+        then:
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'name', 'status'].each {
+            assert entityStates.isLoaded(order.customer, it)
+        }
+
+        when:
+        order = dataManager.load(Order)
+                .id(this.order.id)
+                .fetchPlan(fpb -> fpb.addFetchPlan(FetchPlan.BASE).add('orderLines', FetchPlan.BASE))
+                .one()
+
+        then:
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'quantity'].each {
+            assert entityStates.isLoaded(order.orderLines.find({ it instanceof OrderLineA }), it)
+        }
+
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'quantity'].each {
+            assert entityStates.isLoaded(order.orderLines.find({ it instanceof OrderLineB }), it)
+        }
+    }
+
+    def "test lazy loading"() {
+        when:
+        def order = dataManager.load(Order).id(this.order.id).one()
+
+        then:
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+         'user' /*user is not included in _base fetch plan but marked as loaded because the reference is null*/ ].each {
+            assert entityStates.isLoaded(order, it)
+        }
+
+        ['customer', 'orderLines'].each {
+            assert !entityStates.isLoaded(order, it)
+        }
+
+        when:
+        def customer = order.customer
+
+        then:
+        customer != null
+
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+         'user', 'customer'].each {
+            assert entityStates.isLoaded(order, it)
+        }
+
+        ['deleteTs', 'updatedBy', 'createdBy', 'name', 'createTs', 'id', 'version', 'updateTs', 'deletedBy', 'status'].each {
+            assert entityStates.isLoaded(customer, it)
+        }
+
+        when:
+        def orderLines = order.orderLines
+        orderLines.size() == 2
+
+        then:
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+         'user', 'customer', 'orderLines'].each {
+            assert entityStates.isLoaded(order, it)
+        }
+
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'quantity'].each {
+            assert entityStates.isLoaded(orderLines.find({ it instanceof OrderLineA }), it)
+        }
+
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'quantity'].each {
+            assert entityStates.isLoaded(orderLines.find({ it instanceof OrderLineB }), it)
+        }
+    }
+
+    def "test fetching in managed state"() {
+        expect:
+
+        transaction.executeWithoutResult {
+            def order = entityManager.find(Order, this.order.id)
+
+            ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+             'user' /*user is not local but loaded because the reference is null*/ ].each {
+                assert entityStates.isLoaded(order, it)
+            }
+
+            ['customer', 'orderLines'].each {
+                assert !entityStates.isLoaded(order, it)
+            }
+
+            def customer = order.customer
+
+            assert entityStates.isLoaded(order, 'customer')
+
+            ['deleteTs', 'updatedBy', 'createdBy', 'name', 'createTs', 'id', 'version', 'updateTs', 'deletedBy', 'status'].each {
+                assert entityStates.isLoaded(customer, it)
+            }
+        }
+    }
+
+    def "test persist"() {
+        when:
+        def order = new Order(number: '1')
+
+        then:
+        // new
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+         'user', 'customer', 'orderLines'].each {
+            assert entityStates.isLoaded(order, it)
+        }
+
+        and:
+        transaction.executeWithoutResult {
+            entityManager.persist(order)
+            // managed
+            ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+             'user', 'customer', 'orderLines'].each {
+                assert entityStates.isLoaded(order, it)
+            }
+        }
+        // detached
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+         'user', 'customer', 'orderLines'].each {
+            assert entityStates.isLoaded(order, it)
+        }
+    }
+
+    def "test merge"() {
+        Order order
+
+        when:
+        order = dataManager.load(Order).id(this.order.id).one()
+
+        def customer = dataManager.create(Customer)
+        customer.name = 'cust-2'
+        dataManager.save(customer)
+
+        order.setDate(new Date())
+        order.setCustomer(customer) // lazy loading occurs
+
+        then:
+        // detached
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+         'user'].each {
+            assert entityStates.isLoaded(order, it)
+        }
+        def mergedDetachedOrder = transaction.execute {
+            def mergedOrder = entityManager.merge(order)
+            // merged managed
+            ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+             'user', 'customer'].each {
+                assert entityStates.isLoaded(mergedOrder, it)
+            }
+            return mergedOrder
+        }
+        // merged detached
+        ['id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+         'user', 'customer'].each {
+            assert entityStates.isLoaded(mergedDetachedOrder, it)
+        }
+        order.customer == customer
+    }
+}

--- a/jmix-data/eclipselink/src/test/groovy/lazy_loading/EmbeddedIdReferenceTest.groovy
+++ b/jmix-data/eclipselink/src/test/groovy/lazy_loading/EmbeddedIdReferenceTest.groovy
@@ -17,6 +17,7 @@
 package lazy_loading
 
 import io.jmix.core.DataManager
+import io.jmix.core.EntityStates
 import io.jmix.core.FetchPlan
 import io.jmix.core.Id
 import io.jmix.core.Metadata
@@ -31,6 +32,8 @@ class EmbeddedIdReferenceTest extends DataSpec {
     DataManager dataManager
     @Autowired
     Metadata metadata
+    @Autowired
+    EntityStates entityStates
 
 
     void "test o2m loading"() {
@@ -71,6 +74,8 @@ class EmbeddedIdReferenceTest extends DataSpec {
         then:
         fullyLoaded.branches[0].root.name == "root1"
         fullyLoaded.branches[1].root.name == "root1"
+
+        entityStates.isLoaded(fullyLoaded.branches[0], "root")
 
         when:
         var partiallyLoaded = dataManager.load(Id.of(root)).one()
@@ -145,7 +150,10 @@ class EmbeddedIdReferenceTest extends DataSpec {
 
         then:
         partiallyLoadedO2oBranch.o2oRoot.o2oBranch.name == "o2oBranch1"
+        entityStates.isLoaded(partiallyLoadedO2oBranch.o2oRoot, 'o2oBranch')
+
         partiallyLoadedO2oBranch.root.branches[0].name == "o2oBranch1"
+        entityStates.isLoaded(partiallyLoadedO2oBranch.root.branches[0], 'root')
 
 
         cleanup:

--- a/jmix-data/eclipselink/src/test/java/test_support/entity/sales/OrderLine.java
+++ b/jmix-data/eclipselink/src/test/java/test_support/entity/sales/OrderLine.java
@@ -42,6 +42,14 @@ public class OrderLine extends BaseEntity {
     @JoinColumn(name = "ORDER_ID")
     protected Order order;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "SECOND_ORDER_ID")
+    protected Order secondOrder;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "SECOND_PRODUCT_ID")
+    protected Product secondProduct;
+
     @InstanceName
     public String getCaption() {
         return getProduct().getName() + " " + getQuantity();
@@ -69,5 +77,21 @@ public class OrderLine extends BaseEntity {
 
     public Integer getQuantity() {
         return quantity;
+    }
+
+    public Order getSecondOrder() {
+        return secondOrder;
+    }
+
+    public void setSecondOrder(Order secondOrder) {
+        this.secondOrder = secondOrder;
+    }
+
+    public Product getSecondProduct() {
+        return secondProduct;
+    }
+
+    public void setSecondProduct(Product secondProduct) {
+        this.secondProduct = secondProduct;
     }
 }

--- a/jmix-data/eclipselink/src/test/resources/logback-test.xml
+++ b/jmix-data/eclipselink/src/test/resources/logback-test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2024 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="io.jmix.core.datastore" level="DEBUG"/>
+    <logger name="eclipselink.logging.sql" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/jmix-flowui/flowui/src/test/resources/logback-test.xml
+++ b/jmix-flowui/flowui/src/test/resources/logback-test.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2024 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="eclipselink.logging.sql" level="DEBUG"/>
+<!--    <logger name="io.jmix.core.EntityStates" level="TRACE"/>-->
+    <logger name="io.jmix.core.impl.CorePersistentAttributesLoadChecker" level="TRACE"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/impl/RestDsLoadedPropertiesInfoFactory.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/impl/RestDsLoadedPropertiesInfoFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.restds.impl;
+
+import io.jmix.core.entity.LoadedPropertiesInfo;
+import org.springframework.stereotype.Component;
+
+/**
+ * Creates {@link StaticLoadedPropertiesInfo} instances to be used in entities loaded by REST DataStore.
+ */
+@Component("restds_LoadedPropertiesInfoFactory")
+public class RestDsLoadedPropertiesInfoFactory {
+
+    public LoadedPropertiesInfo create() {
+        return new StaticLoadedPropertiesInfo();
+    }
+}

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/impl/StaticLoadedPropertiesInfo.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/impl/StaticLoadedPropertiesInfo.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.restds.impl;
+
+import io.jmix.core.PersistentAttributesLoadChecker;
+import io.jmix.core.entity.LoadedPropertiesInfo;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Implementation of {@link LoadedPropertiesInfo} that stores names of loaded properties.
+ * <p>
+ * Used by default for DTO entities loaded by REST DataStore.
+ */
+public class StaticLoadedPropertiesInfo implements LoadedPropertiesInfo {
+
+    private Set<String> loadedProperties = new HashSet<>();
+
+    @Override
+    public boolean isLoaded(Object entity, String property, PersistentAttributesLoadChecker checker) {
+        return loadedProperties.contains(property);
+    }
+
+    @Override
+    public void registerProperty(String name, boolean loaded) {
+        if (loaded)
+            loadedProperties.add(name);
+        else
+            loadedProperties.remove(name);
+    }
+}


### PR DESCRIPTION
Introduced `LoadedPropertiesInfo` interface that can be set for any entity instance in its `EntityEntry`. Different types of entities can have different implementations of this interface.

The `LoadedPropertiesInfo` of an entity instance, if its is set, is used by `EntityStates.isLoaded()` instead of direct call to `PersistentAttributesLoadChecker`.

For JPA entities, `CachingLoadedPropertiesInfo` is used by default. If the `jmix.core.disable-caching-loaded-properties` property is true in the project, the `CachingLoadedPropertiesInfo` is not created and behavior is identical to the previous.

JPA entities in managed state do not have `CachingLoadedPropertiesInfo`, because automatic loading of attributes is uncontrollable and cache invalidation is impossible. So the isLoaded check goes directly to `PersistentAttributesLoadChecker`.

For entities loaded by REST DataStore, `StaticLoadedPropertiesInfo` is used, which provides the same behavior as the set of strings introduced in Jmix 2.4.

An alternative solution was considered in https://github.com/jmix-framework/jmix/pull/4003
