### PR TITLE
Register loaded properties at load time and keep them in EntityEntry

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/FetchPlanBuilder.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/FetchPlanBuilder.java
@@ -112,7 +112,7 @@ public class FetchPlanBuilder {
         if (metaProperty.getRange().isClass()) {
             if (!builders.containsKey(propName)) {
                 Class<?> refClass = metaProperty.getRange().asClass().getJavaClass();
-                builders.put(propName, fetchPlans.builder(refClass));
+                builders.put(propName, fetchPlans.builder(refClass).partial(loadPartialEntities));
             }
         }
         if (parts.length > 1) {

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/MetaModelLoader.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/MetaModelLoader.java
@@ -597,7 +597,7 @@ public class MetaModelLoader {
     protected void assignStore(MetaProperty metaProperty) {
         Store classStore = metaProperty.getDomain().getStore();
         if (hasJpaAnnotation(metaProperty.getDomain().getJavaClass())
-                && !hasJpaAnnotation(metaProperty.getAnnotatedElement())) {
+                && isTransient(metaProperty)) {
             ((MetaPropertyImpl) metaProperty).setStore(stores.get(Stores.UNDEFINED));
         } else {
             ((MetaPropertyImpl) metaProperty).setStore(classStore);
@@ -747,6 +747,12 @@ public class MetaModelLoader {
         return javaClass.isAnnotationPresent(jakarta.persistence.Entity.class)
                 || javaClass.isAnnotationPresent(Embeddable.class)
                 || javaClass.isAnnotationPresent(MappedSuperclass.class);
+    }
+
+    protected boolean isTransient(MetaProperty metaProperty) {
+        return metaProperty.getAnnotatedElement().isAnnotationPresent(Transient.class)
+                || metaProperty.getAnnotatedElement() instanceof Method
+                || (metaProperty.getAnnotatedElement() instanceof Field field && Modifier.isTransient(field.getModifiers()));
     }
 
     protected boolean isCollection(Field field) {

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/model/impl/MetaClassImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/model/impl/MetaClassImpl.java
@@ -17,6 +17,7 @@
 package io.jmix.core.metamodel.model.impl;
 
 import io.jmix.core.metamodel.model.*;
+import org.springframework.lang.Nullable;
 
 import java.util.*;
 
@@ -84,6 +85,7 @@ public class MetaClassImpl extends MetadataObjectImpl implements MetaClass {
     }
 
     @Override
+    @Nullable
     public MetaProperty findProperty(String name) {
 		return propertyByName.get(name);
 	}

--- a/jmix-core/core/src/test/java/test_support/app/entity/Pet.java
+++ b/jmix-core/core/src/test/java/test_support/app/entity/Pet.java
@@ -34,6 +34,7 @@ public class Pet extends BaseEntity {
     private String name;
 
     @JmixProperty
+    @Transient
     private String nick;
 
     @JmixProperty

--- a/jmix-data/data/src/main/java/io/jmix/data/impl/EntityFetcher.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/impl/EntityFetcher.java
@@ -58,6 +58,9 @@ public class EntityFetcher {
     @Autowired
     protected StoreAwareLocator storeAwareLocator;
 
+    @Autowired
+    protected JpaLoadedPropertiesCreator loadedPropertiesCreator;
+
     /**
      * Fetch instance by fetch plan.
      *
@@ -126,6 +129,9 @@ public class EntityFetcher {
         MetaClass metaClass = metadata.getClass(entity);
         for (FetchPlanProperty property : fetchPlan.getProperties()) {
             MetaProperty metaProperty = metaClass.getProperty(property.getName());
+
+            loadedPropertiesCreator.addProperty(entity, metaProperty.getName());
+
             if (!metaProperty.getRange().isClass() && !isLazyFetchedLocalAttribute(metaProperty)
                     || !metadataTools.isJpa(metaProperty))
                 continue;

--- a/jmix-data/data/src/main/java/io/jmix/data/impl/JpaLoadedPropertiesCreator.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/impl/JpaLoadedPropertiesCreator.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.data.impl;
+
+import io.jmix.core.Metadata;
+import io.jmix.core.MetadataTools;
+import io.jmix.core.entity.EntitySystemAccess;
+import io.jmix.core.entity.EntityValues;
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.metamodel.model.MetaProperty;
+import jakarta.persistence.EntityManagerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+@Component("data_JpaLoadedPropertiesCreator")
+public class JpaLoadedPropertiesCreator {
+
+    private static final Logger log = LoggerFactory.getLogger(JpaLoadedPropertiesCreator.class);
+
+    private final MetadataTools metadataTools;
+    private final Metadata metadata;
+
+    public JpaLoadedPropertiesCreator(MetadataTools metadataTools, Metadata metadata) {
+        this.metadataTools = metadataTools;
+        this.metadata = metadata;
+    }
+
+    public void addProperty(Object entity, String attributeName) {
+        getLoadedProperties(entity).add(attributeName);
+    }
+
+    public void fillLoadedProperties(Object entity, EntityManagerFactory emf) {
+        fillLoadedProperties(entity, emf, new HashSet<>());
+    }
+
+    private void fillLoadedProperties(Object entity, EntityManagerFactory emf, Set<Object> visited) {
+        if (visited.contains(entity))
+            return;
+        visited.add(entity);
+
+        MetaClass metaClass = metadata.getClass(entity);
+
+        for (MetaProperty property : metaClass.getProperties()) {
+            if (metadataTools.isJpa(property)) {
+                boolean loaded;
+                if (metadataTools.isJpaEmbeddable(metaClass)) {
+                    // this is a workaround for unexpected EclipseLink behaviour when PersistenceUnitUtil.isLoaded
+                    // throws exception if embedded entity refers to persistent entity
+                    loaded = checkIsLoadedWithGetter(entity, property.getName());
+                } else {
+                    loaded = emf.getPersistenceUnitUtil().isLoaded(entity, property.getName());
+                }
+                log.trace("Check: {}.{} is loaded = {}", entity, property.getName(), loaded);
+                if (loaded) {
+                    addProperty(entity, property.getName());
+                    if (property.getRange().isClass()) {
+                        Object value = EntityValues.getValue(entity, property.getName());
+                        if (value != null) {
+                            if (value instanceof Collection) {
+                                for (Object item : ((Collection<?>) value)) {
+                                    fillLoadedProperties(item, emf, visited);
+                                }
+                            } else {
+                                fillLoadedProperties(value, emf, visited);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean checkIsLoadedWithGetter(Object entity, String property) {
+        try {
+            Object value = EntityValues.getValue(entity, property);
+            if (value instanceof Collection) {
+                //check for IndirectCollection behaviour, should fail if property is not loaded
+                //noinspection ResultOfMethodCallIgnored
+                ((Collection<?>) value).size();
+            }
+            return true;
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private Set<String> getLoadedProperties(Object entity) {
+        Set<String> loadedProperties = EntitySystemAccess.getEntityEntry(entity).getLoadedProperties();
+        if (loadedProperties == null) {
+            loadedProperties = new HashSet<>();
+            EntitySystemAccess.getEntityEntry(entity).setLoadedProperties(loadedProperties);
+        }
+        return loadedProperties;
+    }
+}

--- a/jmix-data/eclipselink/eclipselink.gradle
+++ b/jmix-data/eclipselink/eclipselink.gradle
@@ -41,6 +41,5 @@ dependencies {
     testImplementation 'com.fasterxml.jackson.core:jackson-databind'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
-    testRuntimeOnly 'org.slf4j:slf4j-simple'
     testRuntimeOnly 'org.hsqldb:hsqldb'
 }

--- a/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/FetchGroupManager.java
+++ b/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/FetchGroupManager.java
@@ -519,7 +519,9 @@ public class FetchGroupManager {
             String propertyName = property.getName();
             MetaProperty metaProperty = entityMetaClass.getProperty(propertyName);
 
-            if (metadataTools.isJpa(metaProperty) && (metaProperty.getRange().isClass() || useFetchGroup)) {
+            if (metadataTools.isJpa(metaProperty)
+                    && metaProperty.getStore().equals(entityMetaClass.getStore())
+                    && (metaProperty.getRange().isClass() || useFetchGroup)) {
                 FetchGroupField field = createFetchGroupField(entityClass, parentField, propertyName, property.getFetchMode());
                 fetchGroupFields.add(field);
                 if (property.getFetchPlan() != null) {
@@ -558,7 +560,9 @@ public class FetchGroupManager {
 
         if (useFetchGroup) {
             for (MetaProperty metaProperty : entityMetaClass.getProperties()) {
-                if (metaProperty.getRange().isClass() && metadataTools.isJpa(metaProperty)
+                if (metaProperty.getRange().isClass()
+                        && metadataTools.isJpa(metaProperty)
+                        && metaProperty.getStore().equals(entityMetaClass.getStore())
                         && !metadataTools.isEmbedded(metaProperty)
                         && !fetchPlan.containsProperty(metaProperty.getName())) {
                     fetchGroupFields.add(createFetchGroupField(entityClass, parentField, metaProperty.getName(), FetchMode.AUTO, true));

--- a/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/lazyloading/AbstractValueHolder.java
+++ b/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/lazyloading/AbstractValueHolder.java
@@ -22,6 +22,7 @@ import io.jmix.core.MetadataTools;
 import io.jmix.core.UnconstrainedDataManager;
 import io.jmix.core.entity.EntityValues;
 import io.jmix.core.metamodel.model.MetaProperty;
+import io.jmix.data.impl.JpaLoadedPropertiesCreator;
 import org.eclipse.persistence.indirection.ValueHolderInterface;
 import org.eclipse.persistence.indirection.WeavedAttributeValueHolderInterface;
 import org.eclipse.persistence.internal.indirection.UnitOfWorkValueHolder;
@@ -276,6 +277,7 @@ public abstract class AbstractValueHolder extends UnitOfWorkValueHolder implemen
                 synchronized (this) {
                     value = loadValue();
                     afterLoadValue(value);
+                    registerLoadedProperty();
                 }
             }
             isInstantiated = true;
@@ -286,6 +288,10 @@ public abstract class AbstractValueHolder extends UnitOfWorkValueHolder implemen
     protected abstract Object loadValue();
 
     protected abstract void afterLoadValue(Object value);
+
+    protected void registerLoadedProperty() {
+        getLoadedPropertiesCreator().addProperty(getOwner(), getPropertyInfo().getName());
+    }
 
     @Override
     public void setValue(Object value) {
@@ -368,5 +374,9 @@ public abstract class AbstractValueHolder extends UnitOfWorkValueHolder implemen
 
     protected FetchPlans getFetchPlans() {
         return beanFactory.getBean(FetchPlans.class);
+    }
+
+    protected JpaLoadedPropertiesCreator getLoadedPropertiesCreator() {
+        return beanFactory.getBean(JpaLoadedPropertiesCreator.class);
     }
 }

--- a/jmix-data/eclipselink/src/test/groovy/loaded_attributes/LoadedPropertiesTest.groovy
+++ b/jmix-data/eclipselink/src/test/groovy/loaded_attributes/LoadedPropertiesTest.groovy
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package loaded_attributes
+
+import io.jmix.core.DataManager
+import io.jmix.core.FetchPlan
+import io.jmix.core.entity.EntitySystemAccess
+import org.springframework.beans.factory.annotation.Autowired
+import test_support.DataSpec
+import test_support.entity.sales.*
+
+class LoadedPropertiesTest extends DataSpec {
+
+    @Autowired
+    DataManager dataManager
+
+    private Customer customer
+    private Order order
+    private OrderLineA line1
+    private OrderLineB line2
+    private Product product1
+    private Product product2
+
+    @Override
+    void setup() {
+        this.customer = dataManager.create(Customer)
+        this.customer.name = 'cust-1'
+        this.customer.status = Status.OK
+        dataManager.save(this.customer)
+
+        order = dataManager.create(Order)
+        order.customer = this.customer
+        order.number = '1'
+        dataManager.save(order)
+
+        product1 = dataManager.create(Product)
+        product1.name = 'p1'
+        dataManager.save(product1)
+
+        product2 = dataManager.create(Product)
+        product2.name = 'p1'
+        dataManager.save(product2)
+
+        line1 = dataManager.create(OrderLineA)
+        line1.order = order
+        line1.product = product1
+        line1.quantity = 1
+        line1.param1 = 'value1'
+        dataManager.save(line1)
+
+        line2 = dataManager.create(OrderLineB)
+        line2.order = order
+        line2.product = product2
+        line2.quantity = 2
+        line2.param2 = 'value2'
+        dataManager.save(line2)
+    }
+
+    def "test single entity"() {
+        when:
+        def customer = dataManager.load(Customer).id(this.customer.id).one()
+
+        then:
+        EntitySystemAccess.getEntityEntry(customer).loadedProperties == [
+                'deleteTs', 'updatedBy', 'createdBy', 'name', 'createTs', 'id', 'version', 'updateTs', 'deletedBy', 'status'
+        ] as Set
+
+        when:
+        def cust2 = dataManager.load(Customer).id(this.customer.id).fetchPlanProperties('name').one()
+
+        then:
+        EntitySystemAccess.getEntityEntry(cust2).loadedProperties == [
+                'id', 'version', 'name', 'deleteTs', 'deletedBy'
+        ] as Set
+    }
+
+    def "test graph"() {
+        def order
+
+        when:
+        order = dataManager.load(Order).id(this.order.id).one()
+
+        then:
+        EntitySystemAccess.getEntityEntry(order).loadedProperties == [
+                'id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+                'user' // user is not included in _base fetch plan but marked as loaded because the reference is null
+        ] as Set
+
+        when:
+        order = dataManager.load(Order)
+                .id(this.order.id)
+                .fetchPlan(fpb ->
+                        fpb.addFetchPlan(FetchPlan.BASE).add('customer'))
+                .one()
+
+        then:
+        EntitySystemAccess.getEntityEntry(order).loadedProperties == [
+                'id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+                'user', 'customer'
+        ] as Set
+
+        EntitySystemAccess.getEntityEntry(order.customer).loadedProperties == [
+                'id', 'version', 'deleteTs', 'deletedBy'
+        ] as Set
+
+        when:
+        order = dataManager.load(Order)
+                .id(this.order.id)
+                .fetchPlan(fpb -> fpb.addFetchPlan(FetchPlan.BASE).add('customer', FetchPlan.BASE))
+                .one()
+
+        then:
+        EntitySystemAccess.getEntityEntry(order.customer).loadedProperties == [
+                'id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'name', 'status'
+        ] as Set
+
+        when:
+        order = dataManager.load(Order)
+                .id(this.order.id)
+                .fetchPlan(fpb -> fpb.addFetchPlan(FetchPlan.BASE).add('orderLines', FetchPlan.BASE))
+                .one()
+
+        then:
+        EntitySystemAccess.getEntityEntry(order.orderLines.find({ it instanceof OrderLineA })).loadedProperties == [
+                'id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'quantity'
+        ] as Set
+        EntitySystemAccess.getEntityEntry(order.orderLines.find({ it instanceof OrderLineB })).loadedProperties == [
+                'id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'quantity'
+        ] as Set
+    }
+
+    def "test lazy loading"() {
+        when:
+        def order = dataManager.load(Order).id(this.order.id).one()
+
+        then:
+        EntitySystemAccess.getEntityEntry(order).loadedProperties == [
+                'id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+                'user' // user is not included in _base fetch plan but marked as loaded because the reference is null
+        ] as Set
+
+        when:
+        def customer = order.customer
+
+        then:
+        customer != null
+
+        EntitySystemAccess.getEntityEntry(order).loadedProperties == [
+                'id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+                'user', 'customer'
+        ] as Set
+
+        EntitySystemAccess.getEntityEntry(customer).loadedProperties == [
+                'deleteTs', 'updatedBy', 'createdBy', 'name', 'createTs', 'id', 'version', 'updateTs', 'deletedBy', 'status'
+        ] as Set
+
+        when:
+        def orderLines = order.orderLines
+        orderLines.size() == 2
+
+        then:
+        EntitySystemAccess.getEntityEntry(order).loadedProperties == [
+                'id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'number', 'date', 'amount',
+                'user', 'customer', 'orderLines'
+        ] as Set
+
+        EntitySystemAccess.getEntityEntry(orderLines.find({ it instanceof OrderLineA })).loadedProperties == [
+                'id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'quantity'
+        ] as Set
+        EntitySystemAccess.getEntityEntry(orderLines.find({ it instanceof OrderLineB })).loadedProperties == [
+                'id', 'version', 'deleteTs', 'deletedBy', 'updateTs', 'updatedBy', 'createTs', 'createdBy', 'quantity'
+        ] as Set
+    }
+}

--- a/jmix-data/eclipselink/src/test/java/test_support/entity/multidb/MainReport.java
+++ b/jmix-data/eclipselink/src/test/java/test_support/entity/multidb/MainReport.java
@@ -48,6 +48,10 @@ public class MainReport {
     @Column(name = "DB1_ORDER_ID")
     private Long db1OrderId;
 
+    @Transient
+    @JmixProperty
+    private String alpha;
+
     public UUID getId() {
         return id;
     }
@@ -78,5 +82,13 @@ public class MainReport {
 
     public void setDb1OrderId(Long db1OrderId) {
         this.db1OrderId = db1OrderId;
+    }
+
+    public String getAlpha() {
+        return alpha;
+    }
+
+    public void setAlpha(String alpha) {
+        this.alpha = alpha;
     }
 }

--- a/jmix-data/eclipselink/src/test/resources/logback-test.xml
+++ b/jmix-data/eclipselink/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2024 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="eclipselink.logging.sql" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/jmix-flowui/flowui/src/test/resources/logback-test.xml
+++ b/jmix-flowui/flowui/src/test/resources/logback-test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  ~ Copyright 2024 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<configuration>
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
+    <import class="ch.qos.logback.core.ConsoleAppender"/>
+
+    <appender name="STDOUT" class="ConsoleAppender">
+        <encoder class="PatternLayoutEncoder">
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} -%kvp- %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="eclipselink.logging.sql" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/jmix-restds/restds/src/test/java/rest_ds/LoadedAttributesTest.java
+++ b/jmix-restds/restds/src/test/java/rest_ds/LoadedAttributesTest.java
@@ -53,7 +53,6 @@ public class LoadedAttributesTest extends BaseRestDsIntegrationTest {
         assertThatLocalAttributesAreLoaded(customer);
         assertThat(entityStates.isLoaded(customer, "region")).isFalse();
         assertThat(entityStates.isLoaded(customer, "contacts")).isFalse();
-        assertThat(entityStates.isLoaded(customer, "nonExistingProperty")).isFalse();
 
         customer = dataManager.load(Customer.class).id(TestSupport.UUID_1).fetchPlan("customer-with-region").one();
 
@@ -92,7 +91,6 @@ public class LoadedAttributesTest extends BaseRestDsIntegrationTest {
         assertThatLocalAttributesAreLoaded(customer);
         assertThat(entityStates.isLoaded(customer, "region")).isFalse();
         assertThat(entityStates.isLoaded(customer, "contacts")).isFalse();
-        assertThat(entityStates.isLoaded(customer, "nonExistingProperty")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Experimental improvement of EntityStates.isLoaded operation.

Abandoned as ineffective because of extra performance cost at loading/merging time and constant memory footprint.