### PR TITLE
Re-design the My tasks list view #3752

### DIFF
--- a/jmix-templates/content/flowui/bpm-advanced-task-list/controller.java
+++ b/jmix-templates/content/flowui/bpm-advanced-task-list/controller.java
@@ -305,15 +305,15 @@ public class ${controllerName} extends StandardListView<TaskData> {
             } else {
                 taskQuery.taskCandidateOrAssigned(currentUserName);
             }
-            if (bpmTenantProvider != null && bpmTenantProvider.isMultitenancyActive()) {
-                taskQuery.taskTenantId(bpmTenantProvider.getCurrentUserTenantId());
-            }
 
             if (CollectionUtils.isNotEmpty(userGroupCodes)) {
                 taskQuery.taskCandidateGroupIn(userGroupCodes);
             }
 
             taskQuery.endOr();
+        }
+        if (bpmTenantProvider != null && bpmTenantProvider.isMultitenancyActive()) {
+            taskQuery.taskTenantId(bpmTenantProvider.getCurrentUserTenantId());
         }
     }
 

--- a/jmix-templates/content/flowui/bpm-advanced-task-list/controller.java
+++ b/jmix-templates/content/flowui/bpm-advanced-task-list/controller.java
@@ -1,0 +1,374 @@
+package ${packageName};
+
+<%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%>
+import io.jmix.flowui.view.DefaultMainViewParent;
+<%} else {%>
+import ${routeLayout.getControllerFqn()};
+<%}%>
+import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.html.H5;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import com.vaadin.flow.data.renderer.Renderer;
+import com.vaadin.flow.data.renderer.TextRenderer;
+import com.vaadin.flow.router.Route;
+import io.jmix.bpm.entity.ProcessDefinitionData;
+import io.jmix.bpm.entity.TaskData;
+import io.jmix.bpm.entity.UserGroup;
+import io.jmix.bpm.multitenancy.BpmTenantProvider;
+import io.jmix.bpm.service.UserGroupService;
+import io.jmix.bpm.util.FlowableEntitiesConverter;
+import io.jmix.bpmflowui.event.TaskCompletedUiEvent;
+import io.jmix.bpmflowui.processform.ProcessFormViews;
+import io.jmix.core.DataLoadContext;
+import io.jmix.core.LoadContext;
+import io.jmix.core.Sort;
+import io.jmix.core.metamodel.datatype.EnumClass;
+import io.jmix.core.usersubstitution.CurrentUserSubstitution;
+import io.jmix.flowui.component.UiComponentUtils;
+import io.jmix.flowui.component.details.JmixDetails;
+import io.jmix.flowui.component.formlayout.JmixFormLayout;
+import io.jmix.flowui.component.radiobuttongroup.JmixRadioButtonGroup;
+import io.jmix.flowui.component.textfield.TypedTextField;
+import io.jmix.flowui.kit.action.ActionPerformedEvent;
+import io.jmix.flowui.kit.component.button.JmixButton;
+import io.jmix.flowui.model.CollectionContainer;
+import io.jmix.flowui.model.CollectionLoader;
+import io.jmix.flowui.view.*;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.flowable.common.engine.api.query.Query;
+import org.flowable.engine.RepositoryService;
+import org.flowable.engine.TaskService;
+import org.flowable.task.api.Task;
+import org.flowable.task.api.TaskQuery;
+import org.flowable.task.service.impl.TaskQueryProperty;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.lang.Nullable;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+<%if (classComment) {%>
+${classComment}
+<%}%>@Route(value = "${route}", layout = <%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%> DefaultMainViewParent.class <%} else {%>${routeLayout.getControllerClassName()}.class<%}%>)
+@ViewController(id = "${viewId}")
+@ViewDescriptor(path = "${descriptorName}.xml")
+public class ${controllerName} extends StandardListView<TaskData> {
+    public static final String CREATE_TIME_PROPERTY = "createTime";
+    public static final String NAME_PROPERTY = "name";
+    public static final String DUE_DATE_PROPERTY = "dueDate";
+
+    @ViewComponent
+    private MessageBundle messageBundle;
+
+    @ViewComponent
+    private CollectionLoader<TaskData> tasksDl;
+    @ViewComponent
+    private CollectionContainer<TaskData> tasksDc;
+    @ViewComponent
+    private CollectionContainer<ProcessDefinitionData> processDefinitionsDc;
+
+    @ViewComponent
+    private JmixButton filterBtn;
+    @ViewComponent
+    private Span appliedFiltersCount;
+    @ViewComponent
+    private JmixFormLayout filterFormLayout;
+    @ViewComponent
+    private VerticalLayout filterContainer;
+
+    @ViewComponent
+    private JmixDetails generalFilters;
+    @ViewComponent
+    private JmixDetails assignmentFilters;
+    @ViewComponent
+    private TypedTextField<String> taskNameField;
+    @ViewComponent
+    private TypedTextField<String> processNameField;
+    @ViewComponent
+    private JmixRadioButtonGroup<MyTaskAssignmentType> assignmentTypeField;
+
+    // Flowable API
+    @Autowired
+    private TaskService taskService;
+    @Autowired
+    private RepositoryService repositoryService;
+
+    //Jmix BPM API
+    @Autowired
+    private UserGroupService userGroupService;
+    @Autowired
+    private ProcessFormViews processFormViews;
+    @Autowired
+    private FlowableEntitiesConverter entitiesConverter;
+    @Autowired(required = false)
+    private BpmTenantProvider bpmTenantProvider;
+
+    @Autowired
+    private CurrentUserSubstitution currentUserSubstitution;
+
+    private String currentUserName;
+    private List<String> userGroupCodes;
+
+    @Subscribe
+    public void onInit(final InitEvent event) {
+        assignmentTypeField.setValue(MyTaskAssignmentType.ALL);
+        generalFilters.setSummary(new H5(messageBundle.getMessage("taskFilter.generalGroup.summaryText")));
+        assignmentFilters.setSummary(new H5(messageBundle.getMessage("taskFilter.assignmentGroup.summaryText")));
+    }
+
+    @Subscribe
+    public void onBeforeShow(final BeforeShowEvent event) {
+        currentUserName = currentUserSubstitution.getEffectiveUser().getUsername();
+        userGroupCodes = userGroupService.getUserGroups(currentUserName).stream().map(UserGroup::getCode).toList();
+
+        tasksDl.load();
+    }
+
+    @Install(to = "tasksDl", target = Target.DATA_LOADER)
+    private List<TaskData> tasksDlLoadDelegate(final LoadContext<TaskData> loadContext) {
+        TaskQuery taskQuery = createTaskQuery();
+
+        Sort sort = Optional.ofNullable(loadContext.getQuery()).map(LoadContext.Query::getSort).orElse(null);
+        addSort(taskQuery, sort);
+
+        List<Task> tasks = taskQuery.listPage(loadContext.getQuery().getFirstResult(), loadContext.getQuery().getMaxResults());
+
+        return tasks.stream().map(entitiesConverter::createTaskData).toList();
+    }
+
+    @Subscribe("applyFilter")
+    private void onApplyFilterActionPerformed(ActionPerformedEvent event) {
+        updateAppliedFilterCount();
+        tasksDl.load();
+    }
+
+    @Subscribe("resetFilter")
+    private void onResetFilter(final ActionPerformedEvent event) {
+        taskNameField.clear();
+        processNameField.clear();
+        assignmentTypeField.setValue(MyTaskAssignmentType.ALL);
+
+        updateAppliedFilterCount();
+        tasksDl.load();
+    }
+
+    @Subscribe("tasksDataGrid.openTaskForm")
+    private void onTasksDataGridOpenTaskForm(ActionPerformedEvent event) {
+        Task task = taskService.createTaskQuery().taskId(tasksDc.getItem().getId()).singleResult();
+
+        processFormViews.openTaskProcessForm(task, this, processFormDialog -> {
+            processFormDialog.addAfterCloseListener(afterCloseEvent -> tasksDl.load());
+        });
+    }
+
+    @Install(to = "tasksPagination", subject = "totalCountDelegate")
+    private Integer tasksPaginationTotalCountDelegate(final DataLoadContext loadContext) {
+        TaskQuery taskQuery = createTaskQuery();
+
+        return (int) taskQuery.count();
+    }
+
+    @Subscribe(id = "filterBtn", subject = "clickListener")
+    public void onFilterBtnClick(final ClickEvent<JmixButton> event) {
+        filterContainer.setVisible(!filterContainer.isVisible());
+        if (filterContainer.isVisible()) {
+            filterBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        } else {
+            filterBtn.removeThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        }
+    }
+
+    @Subscribe(id = "tasksDl", target = Target.DATA_LOADER)
+    public void onTasksDlPostLoad(final CollectionLoader.PostLoadEvent<TaskData> event) {
+        loadProcessDefinitions();
+    }
+
+    /**
+     * Shows the number of applied filters to the tasks list on the filter button. Zero is not displayed on the button.
+     */
+    private void updateAppliedFilterCount() {
+        long filterCount = calcAppliedFiltersCount();
+
+        if (filterCount > 0) {
+            appliedFiltersCount.setVisible(true);
+            appliedFiltersCount.setText(String.valueOf(filterCount));
+        } else {
+            appliedFiltersCount.setVisible(false);
+        }
+    }
+
+    /**
+     * Calculates the number of fields that have a non-empty, non-default value in the task filter form.
+     *
+     * @return the number of fields containing a non-empty and non-default value
+     */
+    private long calcAppliedFiltersCount() {
+        return filterFormLayout.getComponents()
+                .stream()
+                .filter(component -> {
+                    if (component instanceof HasValue<?, ?> hasValue) {
+                        Object value = UiComponentUtils.getValue(hasValue);
+                        if (value instanceof MyTaskAssignmentType assignmentType) {
+                            return assignmentType != MyTaskAssignmentType.ALL; // exclude a default filter value
+                        }
+                        return value != null;
+                    }
+                    return false;
+                })
+                .count();
+    }
+
+    @Supply(to = "tasksDataGrid.process", subject = "renderer")
+    private Renderer<TaskData> tasksDataGridProcessRenderer() {
+        return new TextRenderer<>(taskData -> {
+            if (taskData.getProcessDefinitionId() == null) {
+                return null;
+            }
+            ProcessDefinitionData processDefinitionData = processDefinitionsDc.getItemOrNull(taskData.getProcessDefinitionId());
+            return processDefinitionData != null ? processDefinitionData.getName() : null;
+        });
+    }
+
+    @EventListener(TaskCompletedUiEvent.class)
+    public void onTaskCompletedEvent() {
+        tasksDl.load();
+    }
+
+    /**
+     * Loads process definitions for the loaded user tasks to show data in the "Process" column.
+     */
+    private void loadProcessDefinitions() {
+        Set<String> processDefinitionIds = tasksDc.getItems()
+                .stream()
+                .map(TaskData::getProcessDefinitionId)
+                .filter(processDefinitionId -> processDefinitionId != null && !processDefinitionsDc.containsItem(processDefinitionId))
+                .collect(Collectors.toSet());
+
+        if (CollectionUtils.isNotEmpty(processDefinitionIds)) {
+            List<ProcessDefinitionData> processDefinitions = repositoryService.createProcessDefinitionQuery()
+                    .processDefinitionIds(processDefinitionIds)
+                    .list()
+                    .stream()
+                    .map(entitiesConverter::createProcessDefinitionData)
+                    .toList();
+
+            processDefinitionsDc.getMutableItems().addAll(processDefinitions);
+        }
+    }
+
+    /**
+     * Creates a task query to get active user tasks by filter conditions.
+     *
+     * @return created query with filter conditions
+     */
+    private TaskQuery createTaskQuery() {
+        TaskQuery taskQuery = taskService.createTaskQuery().active();
+
+        if (StringUtils.isNotEmpty(taskNameField.getTypedValue())) {
+            taskQuery.taskNameLikeIgnoreCase("%" + taskNameField.getTypedValue() + "%");
+        }
+
+        if (StringUtils.isNotEmpty(processNameField.getTypedValue())) {
+            taskQuery.processDefinitionNameLike("%" + processNameField.getTypedValue() + "%");
+        }
+
+        addAssignmentCondition(taskQuery);
+
+        return taskQuery;
+    }
+
+    /**
+     * Adds a condition related to the task assignment using the following rules:
+     * <ol>
+     *     <li>The "All" option: load tasks that the current user is assigned to or is a candidate for</li>
+     *     <li>The "Assigned to me" option: load tasks that the current user is assigned to</li>
+     *     <li>The "Group" option: load tasks that the current user is a candidate for</li>
+     * </ol>
+     *
+     * @param taskQuery query to load tasks that the current user can perform
+     */
+    private void addAssignmentCondition(TaskQuery taskQuery) {
+        MyTaskAssignmentType assignmentType = assignmentTypeField.getValue();
+        if (assignmentType == MyTaskAssignmentType.ASSIGNED_TO_ME) {
+            taskQuery.taskAssignee(currentUserName);
+        } else {
+            taskQuery.or();
+            if (assignmentType == MyTaskAssignmentType.GROUP) {
+                taskQuery.taskCandidateUser(currentUserName);
+            } else {
+                taskQuery.taskCandidateOrAssigned(currentUserName);
+            }
+            if (bpmTenantProvider != null && bpmTenantProvider.isMultitenancyActive()) {
+                taskQuery.taskTenantId(bpmTenantProvider.getCurrentUserTenantId());
+            }
+
+            if (CollectionUtils.isNotEmpty(userGroupCodes)) {
+                taskQuery.taskCandidateGroupIn(userGroupCodes);
+            }
+
+            taskQuery.endOr();
+        }
+    }
+
+    /**
+     * Adds sort options to the specified query based on the specified {@link Sort} instance.
+     *
+     * @param taskQuery a query to load user tasks
+     * @param sort      options to sort user tasks
+     */
+    private void addSort(TaskQuery taskQuery, @Nullable Sort sort) {
+        if (sort != null && CollectionUtils.isNotEmpty(sort.getOrders())) {
+            List<Sort.Order> orders = sort.getOrders();
+            orders.forEach(order -> {
+                TaskQueryProperty sortProperty = switch (order.getProperty()) {
+                    case CREATE_TIME_PROPERTY -> TaskQueryProperty.CREATE_TIME;
+                    case NAME_PROPERTY -> TaskQueryProperty.NAME;
+                    case DUE_DATE_PROPERTY -> TaskQueryProperty.DUE_DATE;
+                    default -> null;
+                };
+
+                if (sortProperty != null) {
+                    taskQuery.orderBy(sortProperty, Query.NullHandlingOnOrder.NULLS_LAST);
+                    if (order.getDirection() == Sort.Direction.ASC) {
+                        taskQuery.asc();
+                    } else {
+                        taskQuery.desc();
+                    }
+                }
+            });
+        }
+    }
+
+    public enum MyTaskAssignmentType implements EnumClass<String> {
+        ALL("All"),
+        ASSIGNED_TO_ME("Assigned to me"),
+        GROUP("Group");
+
+        private final String id;
+
+        MyTaskAssignmentType(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        @Nullable
+        public static MyTaskAssignmentType fromId(String id) {
+            for (MyTaskAssignmentType at : MyTaskAssignmentType.values()) {
+                if (at.getId().equals(id)) {
+                    return at;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/jmix-templates/content/flowui/bpm-advanced-task-list/controller.kt
+++ b/jmix-templates/content/flowui/bpm-advanced-task-list/controller.kt
@@ -315,15 +315,15 @@ class ${controllerName} : StandardListView<TaskData>() {
             } else {
                 taskQuery.taskCandidateOrAssigned(currentUserName)
             }
-            if (bpmTenantProvider != null && bpmTenantProvider?.isMultitenancyActive == true) {
-                taskQuery.taskTenantId(bpmTenantProvider!!.currentUserTenantId)
-            }
 
             if (userGroupCodes?.isNotEmpty() == true) {
                 taskQuery.taskCandidateGroupIn(userGroupCodes)
             }
 
             taskQuery.endOr()
+        }
+        if (bpmTenantProvider != null && bpmTenantProvider?.isMultitenancyActive == true) {
+            taskQuery.taskTenantId(bpmTenantProvider!!.currentUserTenantId)
         }
     }
 

--- a/jmix-templates/content/flowui/bpm-advanced-task-list/controller.kt
+++ b/jmix-templates/content/flowui/bpm-advanced-task-list/controller.kt
@@ -1,0 +1,382 @@
+package ${packageName}
+
+<%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%>
+import io.jmix.flowui.view.DefaultMainViewParent;
+<%} else {%>
+import ${routeLayout.getControllerFqn()};
+<%}%>
+import com.vaadin.flow.component.ClickEvent
+import com.vaadin.flow.component.Component
+import com.vaadin.flow.component.HasValue
+import com.vaadin.flow.component.button.ButtonVariant
+import com.vaadin.flow.component.html.H5
+import com.vaadin.flow.component.html.Span
+import com.vaadin.flow.component.orderedlayout.VerticalLayout
+import com.vaadin.flow.data.renderer.Renderer
+import com.vaadin.flow.data.renderer.TextRenderer
+import com.vaadin.flow.router.Route
+import io.jmix.bpm.entity.ProcessDefinitionData
+import io.jmix.bpm.entity.TaskData
+import io.jmix.bpm.entity.UserGroup
+import io.jmix.bpm.multitenancy.BpmTenantProvider
+import io.jmix.bpm.service.UserGroupService
+import io.jmix.bpm.util.FlowableEntitiesConverter
+import io.jmix.bpmflowui.event.TaskCompletedUiEvent
+import io.jmix.bpmflowui.processform.ProcessFormViews
+import io.jmix.core.DataLoadContext
+import io.jmix.core.LoadContext
+import io.jmix.core.Sort
+import io.jmix.core.metamodel.datatype.EnumClass
+import io.jmix.core.usersubstitution.CurrentUserSubstitution
+import io.jmix.flowui.component.UiComponentUtils
+import io.jmix.flowui.component.details.JmixDetails
+import io.jmix.flowui.component.formlayout.JmixFormLayout
+import io.jmix.flowui.component.radiobuttongroup.JmixRadioButtonGroup
+import io.jmix.flowui.component.textfield.TypedTextField
+import io.jmix.flowui.kit.action.ActionPerformedEvent
+import io.jmix.flowui.kit.component.button.JmixButton
+import io.jmix.flowui.model.CollectionContainer
+import io.jmix.flowui.model.CollectionLoader
+import io.jmix.flowui.view.*
+import io.jmix.flowui.view.Target
+import org.flowable.engine.RepositoryService
+import org.flowable.engine.TaskService
+import org.flowable.engine.repository.ProcessDefinition
+import org.flowable.task.api.Task
+import org.flowable.task.api.TaskQuery
+import org.flowable.task.service.impl.TaskQueryProperty
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.event.EventListener
+
+<%if (classComment) {%>
+${classComment}
+<%}%>@Route(value = "${route}", layout = <%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%> DefaultMainViewParent::class <%} else {%>${routeLayout.getControllerClassName()}::class<%}%>)
+@ViewController(id = "${viewId}")
+@ViewDescriptor(path = "${descriptorName}.xml")
+class ${controllerName} : StandardListView<TaskData>() {
+    companion object {
+        const val CREATE_TIME_PROPERTY: String = "createTime"
+        const val NAME_PROPERTY: String = "name"
+        const val DUE_DATE_PROPERTY: String = "dueDate"
+    }
+
+    @ViewComponent
+    private lateinit var messageBundle: MessageBundle
+
+    @ViewComponent
+    private lateinit var tasksDl: CollectionLoader<TaskData>
+
+    @ViewComponent
+    private lateinit var tasksDc: CollectionContainer<TaskData>
+
+    @ViewComponent
+    private lateinit var processDefinitionsDc: CollectionContainer<ProcessDefinitionData>
+
+    @ViewComponent
+    private lateinit var filterBtn: JmixButton
+
+    @ViewComponent
+    private lateinit var appliedFiltersCount: Span
+
+    @ViewComponent
+    private lateinit var filterFormLayout: JmixFormLayout
+
+    @ViewComponent
+    private lateinit var filterContainer: VerticalLayout
+
+    @ViewComponent
+    private lateinit var generalFilters: JmixDetails
+
+    @ViewComponent
+    private lateinit var assignmentFilters: JmixDetails
+
+    @ViewComponent
+    private lateinit var taskNameField: TypedTextField<String?>
+
+    @ViewComponent
+    private lateinit var processNameField: TypedTextField<String?>
+
+    @ViewComponent
+    private lateinit var assignmentTypeField: JmixRadioButtonGroup<MyTaskAssignmentType?>
+
+    // Flowable API
+    @Autowired
+    private lateinit var taskService: TaskService
+
+    @Autowired
+    private lateinit var repositoryService: RepositoryService
+
+    //Jmix BPM API
+    @Autowired
+    private lateinit var userGroupService: UserGroupService
+
+    @Autowired
+    private lateinit var processFormViews: ProcessFormViews
+
+    @Autowired
+    private lateinit var entitiesConverter: FlowableEntitiesConverter
+
+    @Autowired(required = false)
+    private var bpmTenantProvider: BpmTenantProvider? = null
+
+    @Autowired
+    private lateinit var currentUserSubstitution: CurrentUserSubstitution
+
+    private var currentUserName: String? = null
+    private var userGroupCodes: List<String>? = null
+
+    @Subscribe
+    private fun onInit(event: InitEvent) {
+        assignmentTypeField.setValue(MyTaskAssignmentType.ALL)
+        generalFilters.setSummary(H5(messageBundle.getMessage("taskFilter.generalGroup.summaryText")))
+        assignmentFilters.setSummary(H5(messageBundle.getMessage("taskFilter.assignmentGroup.summaryText")))
+    }
+
+    @Subscribe
+    private fun onBeforeShow(event: BeforeShowEvent) {
+        currentUserName = currentUserSubstitution.effectiveUser.username
+        userGroupCodes = currentUserName?.let { username ->
+            userGroupService.getUserGroups(username).stream().map(UserGroup::getCode).toList()
+        } ?: listOf()
+
+        tasksDl.load()
+    }
+
+    @Install(to = "tasksDl", target = Target.DATA_LOADER)
+    private fun tasksDlLoadDelegate(loadContext: LoadContext<TaskData>): List<TaskData> {
+        val taskQuery: TaskQuery = createTaskQuery()
+        addSort(taskQuery, loadContext.query?.sort)
+
+        val tasks: List<Task> =
+            loadContext.query?.let { query -> taskQuery.listPage(query.firstResult, query.maxResults) } ?: listOf()
+
+        return tasks.map { task -> entitiesConverter.createTaskData(task)!! }.toList()
+    }
+
+    @Subscribe("applyFilter")
+    private fun onApplyFilterActionPerformed(event: ActionPerformedEvent) {
+        updateAppliedFilterCount()
+        tasksDl.load()
+    }
+
+    @Subscribe("resetFilter")
+    private fun onResetFilter(event: ActionPerformedEvent) {
+        taskNameField.clear()
+        processNameField.clear()
+        assignmentTypeField.setValue(MyTaskAssignmentType.ALL)
+
+        updateAppliedFilterCount()
+        tasksDl.load()
+    }
+
+    @Subscribe("tasksDataGrid.openTaskForm")
+    private fun onTasksDataGridOpenTaskForm(event: ActionPerformedEvent) {
+        val task: Task = taskService.createTaskQuery().taskId(tasksDc.getItem().getId()).singleResult()
+
+        processFormViews.openTaskProcessForm(task, this) { processFormDialog ->
+            processFormDialog.addAfterCloseListener { tasksDl.load() }
+        }
+    }
+
+    @Install(to = "tasksPagination", subject = "totalCountDelegate")
+    private fun tasksPaginationTotalCountDelegate(loadContext: DataLoadContext): Int {
+        val taskQuery: TaskQuery = createTaskQuery()
+
+        return taskQuery.count().toInt()
+    }
+
+    @Subscribe(id = "filterBtn", subject = "clickListener")
+    fun onFilterBtnClick(event: ClickEvent<JmixButton?>?) {
+        filterContainer.isVisible = !filterContainer.isVisible
+        if (filterContainer.isVisible) {
+            filterBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY)
+        } else {
+            filterBtn.removeThemeVariants(ButtonVariant.LUMO_PRIMARY)
+        }
+    }
+
+    @Subscribe(id = "tasksDl", target = Target.DATA_LOADER)
+    fun onTasksDlPostLoad(event: CollectionLoader.PostLoadEvent<TaskData?>?) {
+        loadProcessDefinitions()
+    }
+
+    /**
+     * Shows the number of applied filters to the tasks list on the filter button. Zero is not displayed on the button.
+     */
+    private fun updateAppliedFilterCount() {
+        val filterCount: Long = calcAppliedFiltersCount()
+
+        if (filterCount > 0) {
+            appliedFiltersCount.isVisible = true
+            appliedFiltersCount.text = filterCount.toString()
+        } else {
+            appliedFiltersCount.isVisible = false
+        }
+    }
+
+    /**
+     * Calculates the number of fields that have a non-empty, non-default value in the task filter form.
+     *
+     * @return the number of fields containing a non-empty and non-default value
+     */
+    private fun calcAppliedFiltersCount(): Long {
+        return filterFormLayout.components
+            .stream()
+            .filter { component: Component? ->
+                if (component is HasValue<*, *>) {
+                    val value = UiComponentUtils.getValue(component)
+                    if (value is MyTaskAssignmentType) {
+                        return@filter (value != MyTaskAssignmentType.ALL) // exclude a default filter value
+                    }
+                    return@filter (value != null)
+                }
+                false
+            }
+            .count()
+    }
+
+    @Supply(to = "tasksDataGrid.process", subject = "renderer")
+    private fun tasksDataGridProcessRenderer(): Renderer<TaskData> {
+        return TextRenderer { taskData ->
+            val processDefinitionData =
+                taskData.processDefinitionId?.let { processDefinitionsDc.getItemOrNull(taskData.processDefinitionId) }
+            processDefinitionData?.name
+        }
+    }
+
+    @EventListener(TaskCompletedUiEvent::class)
+    open fun onTaskCompletedEvent() {
+        tasksDl.load()
+    }
+
+    /**
+     * Loads process definitions for the loaded user tasks to show data in the "Process" column.
+     */
+    private fun loadProcessDefinitions() {
+        val processDefinitionIds = tasksDc.items
+            .map { obj: TaskData -> obj.processDefinitionId }
+            .filter { processDefinitionId: String? ->
+                processDefinitionId != null && !processDefinitionsDc.containsItem(processDefinitionId)
+            }
+            .toSet()
+
+        if (processDefinitionIds.isNotEmpty()) {
+            val processDefinitions = repositoryService.createProcessDefinitionQuery()
+                .processDefinitionIds(processDefinitionIds)
+                .list()
+                .map { processDefinition: ProcessDefinition? ->
+                    entitiesConverter.createProcessDefinitionData(processDefinition)
+                }
+                .toList()
+
+            processDefinitionsDc.mutableItems.addAll(processDefinitions)
+        }
+    }
+
+    /**
+     * Creates a task query to get active user tasks by filter conditions.
+     *
+     * @return created query with filter conditions
+     */
+    private fun createTaskQuery(): TaskQuery {
+        val taskQuery = taskService.createTaskQuery().active()
+
+        if (!taskNameField.typedValue.isNullOrEmpty()) {
+            taskQuery.taskNameLikeIgnoreCase("%" + taskNameField.typedValue + "%")
+        }
+
+        if (!processNameField.typedValue.isNullOrEmpty()) {
+            taskQuery.processDefinitionNameLike("%" + processNameField.typedValue + "%")
+        }
+
+        addAssignmentCondition(taskQuery)
+
+        return taskQuery
+    }
+
+    /**
+     * Adds a condition related to the task assignment using the following rules:
+     * <ol>
+     *     <li>The "All" option: load tasks that the current user is assigned to or is a candidate for</li>
+     *     <li>The "Assigned to me" option: load tasks that the current user is assigned to</li>
+     *     <li>The "Group" option: load tasks that the current user is a candidate for</li>
+     * </ol>
+     *
+     * @param taskQuery query to load tasks that the current user can perform
+     */
+    private fun addAssignmentCondition(taskQuery: TaskQuery) {
+        val assignmentType: MyTaskAssignmentType? = assignmentTypeField.value
+        if (assignmentType == MyTaskAssignmentType.ASSIGNED_TO_ME) {
+            taskQuery.taskAssignee(currentUserName)
+        } else {
+            taskQuery.or()
+            if (assignmentType == MyTaskAssignmentType.GROUP) {
+                taskQuery.taskCandidateUser(currentUserName)
+            } else {
+                taskQuery.taskCandidateOrAssigned(currentUserName)
+            }
+            if (bpmTenantProvider != null && bpmTenantProvider?.isMultitenancyActive == true) {
+                taskQuery.taskTenantId(bpmTenantProvider!!.currentUserTenantId)
+            }
+
+            if (userGroupCodes?.isNotEmpty() == true) {
+                taskQuery.taskCandidateGroupIn(userGroupCodes)
+            }
+
+            taskQuery.endOr()
+        }
+    }
+
+    /**
+     * Adds sort options to the specified query based on the specified [Sort] instance.
+     *
+     * @param taskQuery a query to load user tasks
+     * @param sort      options to sort user tasks
+     */
+    private fun addSort(taskQuery: TaskQuery, sort: Sort?) {
+        if (sort != null && sort.orders.isNotEmpty()) {
+            val orders = sort.orders
+            orders.forEach { order: Sort.Order ->
+                val sortProperty: TaskQueryProperty? = when (order.property) {
+                    CREATE_TIME_PROPERTY -> TaskQueryProperty.CREATE_TIME
+                    NAME_PROPERTY -> TaskQueryProperty.NAME
+                    DUE_DATE_PROPERTY -> TaskQueryProperty.DUE_DATE
+                    else -> null
+                }
+
+                sortProperty?.let {
+                    taskQuery.orderBy(
+                        sortProperty,
+                        org.flowable.common.engine.api.query.Query.NullHandlingOnOrder.NULLS_LAST
+                    )
+                    if (order.direction == Sort.Direction.ASC) {
+                        taskQuery.asc()
+                    } else {
+                        taskQuery.desc()
+                    }
+                }
+            }
+        }
+    }
+
+    enum class MyTaskAssignmentType(private val id: String) : EnumClass<String> {
+        ALL("All"),
+        ASSIGNED_TO_ME("Assigned to me"),
+        GROUP("Group");
+
+        override fun getId(): String {
+            return id
+        }
+
+        companion object {
+            fun fromId(id: String): MyTaskAssignmentType? {
+                for (at in entries) {
+                    if (at.getId() == id) {
+                        return at
+                    }
+                }
+                return null
+            }
+        }
+    }
+}

--- a/jmix-templates/content/flowui/bpm-advanced-task-list/descriptor.xml
+++ b/jmix-templates/content/flowui/bpm-advanced-task-list/descriptor.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<view xmlns="http://jmix.io/schema/flowui/view"
+      title="${messageKeys['viewTitle']}"
+      focusComponent="tasksDataGrid">
+    <data>
+        <collection id="tasksDc"
+                    class="io.jmix.bpm.entity.TaskData">
+            <loader id="tasksDl"/>
+        </collection>
+        <collection id="processDefinitionsDc"
+                    class="io.jmix.bpm.entity.ProcessDefinitionData">
+            <loader id="processDefinitionsDl"/>
+        </collection>
+    </data>
+    <facets>
+        <urlQueryParameters>
+            <pagination component="tasksPagination"/>
+        </urlQueryParameters>
+    </facets>
+    <actions>
+        <action id="applyFilter" icon="SEARCH" text="msg:///actions.Apply"/>
+        <action id="resetFilter" icon="ERASER" text="${messageKeys['resetTaskFilterText']}"/>
+    </actions>
+    <layout>
+        <hbox width="100%" height="100%" expand="tasksDataGridBox" themeNames="spacing-s">
+            <!-- The root component of the user task filter panel -->
+            <vbox id="filterContainer" width="25em" height="100%" spacing="false"
+                  classNames="border rounded-l gap-m shadow-m border-contrast-20">
+                <hbox width="100%" padding="false" alignItems="CENTER" themeNames="spacing-xs"
+                      expand="taskFilterHeader">
+                    <h4 id="taskFilterHeader" text="${messageKeys['taskFilterHeaderText']}"/>
+                    <!-- Buttons to apply or reset task filter values -->
+                    <hbox alignSelf="END" justifyContent="END" themeNames="spacing-s">
+                        <button id="applyFilterBtn" action="applyFilter" themeNames="tertiary-inline"/>
+                        <button id="resetFilterBtn" action="resetFilter" themeNames="error tertiary-inline"/>
+                    </hbox>
+                </hbox>
+                <!-- A container with input components for filters that will be applied to the current user's tasks -->
+                <formLayout id="filterFormLayout">
+                    <responsiveSteps>
+                        <responsiveStep minWidth="0" columns="1"/>
+                    </responsiveSteps>
+                    <details id="generalFilters" width="100%" themeNames="reverse small" opened="true">
+                        <textField id="taskNameField" label="${messageKeys['taskFilterTaskNameLabel']}"
+                                   classNames="pt-xs"
+                                   clearButtonVisible="true" width="100%"/>
+                        <textField id="processNameField" label="${messageKeys['taskFilterProcessNameLabel']}"
+                                   classNames="pt-xs"
+                                   clearButtonVisible="true" width="100%"/>
+                    </details>
+                    <details id="assignmentFilters" width="100%" themeNames="reverse small" opened="true">
+                        <radioButtonGroup id="assignmentTypeField" themeNames="vertical" classNames="pt-xs"
+                                          itemsEnum="${packageName}.${controllerName}\$MyTaskAssignmentType"/>
+                    </details>
+                </formLayout>
+            </vbox>
+
+            <!-- A container with a data grid displaying the current user's tasks with filters applied -->
+            <vbox id="tasksDataGridBox" height="100%" themeNames="spacing-s" padding="false">
+                <hbox id="buttonsPanel" classNames="buttons-panel">
+                    <!-- A button that opens and hides a task filter panel.
+                        This button also shows a number of applied filters to the user tasks.
+                    -->
+                    <div id="filterBtnContainer" classNames="relative inline-flex items-start">
+                        <button id="filterBtn" icon="FILTER" themeNames="primary"/>
+                        <span id="appliedFiltersCount" themeNames="badge contrast primary small"
+                              css="border-radius: 50%; left: -0.75em" classNames="relative z-10" visible="false"/>
+                    </div>
+                    <button id="refreshBtn" action="tasksDataGrid.refresh" themeNames="primary success"/>
+                    <button id="openTaskFormBtn" action="tasksDataGrid.openTaskForm"/>
+                    <simplePagination id="tasksPagination" dataLoader="tasksDl"/>
+                </hbox>
+
+                <dataGrid id="tasksDataGrid" width="100%" minHeight="20em" dataContainer="tasksDc"
+                          columnReorderingAllowed="true">
+                    <actions>
+                        <action id="refresh" type="list_refresh"/>
+                        <action id="openTaskForm"
+                                icon="PENCIL"
+                                text="${messageKeys['openTaskFormActionText']}"
+                                type="list_itemTracking"/>
+                    </actions>
+                    <columns resizable="true">
+                        <column property="name"/>
+                        <column key="process" header="${messageKeys['processColumnHeader']}" sortable="false"/>
+                        <column property="createTime" autoWidth="true"/>
+                        <column property="dueDate" autoWidth="true"/>
+                    </columns>
+                </dataGrid>
+            </vbox>
+        </hbox>
+    </layout>
+</view>

--- a/jmix-templates/content/flowui/bpm-advanced-task-list/settings.xml
+++ b/jmix-templates/content/flowui/bpm-advanced-task-list/settings.xml
@@ -1,0 +1,160 @@
+<!--
+  ~ Copyright 2025 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<template xmlns="http://schemas.haulmont.com/studio/template-settings.xsd"
+          icon="resource://template/template_browse.svg"
+          order="900"
+          name="BPM: Advanced task list view">
+    <tags>
+        <tag>BPM</tag>
+    </tags>
+    <description>
+        <![CDATA[<html> Create the view that allows the currently authenticated user to view and work with active user tasks.
+        Displays a list of user tasks in the DataGrid component. </html>]]>
+    </description>
+
+    <locMessages key="viewTitle" expressionKey="${studioUtils.decapitalize(controllerName)}.title">
+        <message lang="default">
+            <![CDATA[${studioUtils.makeScreenNaturalCaption(id, project)}]]>
+        </message>
+    </locMessages>
+
+    <locMessages key="taskFilterHeaderText" expressionKey="${'taskFilter.header.text'}">
+        <message lang="default">
+            <![CDATA[Filter]]>
+        </message>
+    </locMessages>
+
+    <locMessages key="resetTaskFilterText" expressionKey="${'taskFilter.actions.reset.text'}">
+        <message lang="default">
+            <![CDATA[Reset]]>
+        </message>
+    </locMessages>
+
+    <locMessages key="filterGeneralGroupTitle" expressionKey="${'taskFilter.generalGroup.summaryText'}">
+        <message lang="default">
+            <![CDATA[General]]>
+        </message>
+    </locMessages>
+
+    <locMessages key="filterAssignmentGroupTitle" expressionKey="${'taskFilter.assignmentGroup.summaryText'}">
+        <message lang="default">
+            <![CDATA[Assignment]]>
+        </message>
+    </locMessages>
+
+    <locMessages key="taskFilterTaskNameLabel" expressionKey="${'taskFilter.fields.taskName.label'}">
+        <message lang="default">
+            <![CDATA[Task]]>
+        </message>
+    </locMessages>
+
+    <locMessages key="taskFilterProcessNameLabel" expressionKey="${'taskFilter.fields.processName.label'}">
+        <message lang="default">
+            <![CDATA[Process]]>
+        </message>
+    </locMessages>
+
+    <locMessages key="openTaskFormActionText" expressionKey="${'tasksDataGrid.actions.openTaskForm.text'}">
+        <message lang="default">
+            <![CDATA[Open]]>
+        </message>
+    </locMessages>
+
+    <locMessages key="processColumnHeader" expressionKey="${'tasksDataGrid.process.header'}">
+        <message lang="default">
+            <![CDATA[Process]]>
+        </message>
+    </locMessages>
+
+    <locMessages key="assignmentTypeAll" expressionKey="${controllerName.concat('\\$MyTaskAssignmentType.ALL')}">
+        <message lang="default">
+            <![CDATA[All]]>
+        </message>
+    </locMessages>
+
+    <locMessages key="assignmentTypeAssignedToMe"
+                 expressionKey="${controllerName.concat('\\$MyTaskAssignmentType.ASSIGNED_TO_ME')}">
+        <message lang="default">
+            <![CDATA[Assigned to me]]>
+        </message>
+    </locMessages>
+
+    <locMessages key="assignmentTypeGroup" expressionKey="${controllerName.concat('\\$MyTaskAssignmentType.GROUP')}">
+        <message lang="default">
+            <![CDATA[Group]]>
+        </message>
+    </locMessages>
+
+    <property caption="Descriptor name"
+              code="descriptorName"
+              defaultValue="advanced-task-list-view"
+              propertyType="DESCRIPTOR_NAME"
+              required="true"
+              focused="true"
+              sourceName="descriptor"/>
+
+    <property caption="Controller name"
+              code="controllerName"
+              propertyType="CLASS_NAME"
+              required="true"
+              dynamic="true"
+              sourceName="controller"
+              valueTemplate="${api.evaluateScript('controllerNameByDescriptorName.groovy', ['descriptorName': descriptorName])}">
+        <dependency code="descriptorName"/>
+    </property>
+
+    <property caption="View id"
+              code="viewId"
+              propertyType="SCREEN_ID"
+              advanced="true"
+              dynamic="true"
+              required="true"
+              valueTemplate="${api.evaluateScript('screenIdByDescriptorName.groovy', ['descriptorName': descriptorName, 'projectId': project_id])}">
+        <dependency code="descriptorName"/>
+    </property>
+
+    <property caption="View route"
+              code="route"
+              defaultValue="advanced-task-list-view"
+              propertyType="FLOW_VIEW_ROUTE"
+              advanced="true"
+              dynamic="true"
+              required="true"
+              valueTemplate="${descriptorName}">
+        <dependency code="descriptorName"/>
+    </property>
+
+    <property caption="View route layout"
+              code="routeLayout"
+              propertyType="FLOW_VIEW_ROUTE_LAYOUT"
+              visible="false"
+              advanced="true"/>
+
+    <property caption="Parent menu item"
+              code="menuItem"
+              propertyType="FLOW_MENU_ITEM"/>
+
+    <!-- sources -->
+    <source fileExt="xml"
+            name="descriptor"/>
+
+    <source fileExt="java"
+            name="controller"/>
+
+    <source fileExt="kt"
+            name="controller"/>
+</template>

--- a/jmix-templates/content/flowui/bpm-process-form/settings.xml
+++ b/jmix-templates/content/flowui/bpm-process-form/settings.xml
@@ -1,12 +1,12 @@
 <template xmlns="http://schemas.haulmont.com/studio/template-settings.xsd"
           icon="resource://template/template_blank.svg"
           order="1000"
-          name="BPMN process form">
+          name="BPM: process form">
     <tags>
         <tag>BPM</tag>
     </tags>
     <description>
-        <![CDATA[<html>BPMN process form.</html>]]>
+        <![CDATA[<html>BPM: process form.</html>]]>
     </description>
     <locMessages key="title" expressionKey="${studioUtils.decapitalize(controllerName)}.title">
         <message lang="default">


### PR DESCRIPTION
1. Add a new template for advanced implementation of My tasks list view
2. Template is available if the BPM add-on is used in the project (mapped by tag in settings.xml)
3. Advanced implementation suggests out-of-box:
  - User tasks that current user can perform or claim are shown in the DataGrid. Shown columns: task name, process definition name, creation date and due date.
  - A panel with custom filters for task name, process definition name, type of assignment (all tasks available for the current user, assigned and group tasks). Filter panel can be shown/hidden by clicking the button. A count of the applied filters are shown on the button.
  - Sort tasks by name/due date/creation date
  - Opening a task form for the selected task
4. User tasks are loaded using Flowable Java API
5. Update template title and description for BPM process form: use add-on as prefix