### PR TITLE
Simplify access to FileStorage through generic REST

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/FileStorageLocator.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/FileStorageLocator.java
@@ -16,6 +16,8 @@
 
 package io.jmix.core;
 
+import java.util.Collection;
+
 /**
  * Provides access to all registered file storage beans of the application.
  * <p>
@@ -44,4 +46,9 @@ public interface FileStorageLocator {
      *                               in the {@code jmix.core.defaultFileStorage} application property.
      */
     <T extends FileStorage> T getDefault();
+
+    /**
+     * @return unmodifiable collection of all registered file storages
+     */
+    Collection<? extends FileStorage> getAll();
 }

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/FileStorageLocatorImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/FileStorageLocatorImpl.java
@@ -19,10 +19,11 @@ package io.jmix.core.impl;
 import io.jmix.core.CoreProperties;
 import io.jmix.core.FileStorage;
 import io.jmix.core.FileStorageLocator;
+import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import jakarta.annotation.PostConstruct;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
@@ -88,5 +89,10 @@ public class FileStorageLocatorImpl implements FileStorageLocator {
                         "set 'jmix.core.default-file-storage' property");
             }
         }
+    }
+
+    @Override
+    public Collection<? extends FileStorage> getAll() {
+        return Collections.unmodifiableCollection(storagesByNames.values());
     }
 }

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/filestorage/RestFileStorage.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/filestorage/RestFileStorage.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.restds.filestorage;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jmix.core.FileRef;
+import io.jmix.core.FileStorage;
+import io.jmix.restds.exception.RestDataStoreAccessException;
+import io.jmix.restds.util.RestDataStoreUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+/**
+ * File storage implementation that complements {@link io.jmix.restds.impl.RestDataStore} by the ability to store and load files
+ * using the generic REST /files endpoints.
+ * <p>
+ * To use RestFileStorage, define the bean as follows:
+ * <pre>
+ *     &#064;Bean
+ *     FileStorage backendFileStorage() {
+ *         return new RestFileStorage("backend", "fs");
+ *     }
+ * </pre>
+ * See {@link #RestFileStorage(String, String)} for more information.
+ */
+public class RestFileStorage implements FileStorage {
+
+    // Using field injection to simplify constructor creating this bean in app projects
+    @SuppressWarnings("unused")
+    @Autowired
+    private RestDataStoreUtils restDataStoreUtils;
+
+    private final String dataStoreName;
+    private final String remoteStorageName;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Constructor.
+     *
+     * @param restDataStoreName name of the REST DataStore that represents the remote application
+     * @param remoteStorageName name of the corresponding file storage in the remote application,
+     *                          e.g. 'fs' for local file storage
+     */
+    public RestFileStorage(String restDataStoreName, String remoteStorageName) {
+        this.dataStoreName = restDataStoreName;
+        this.remoteStorageName = remoteStorageName;
+    }
+
+    @Override
+    public String getStorageName() {
+        return dataStoreName + "-fs";
+    }
+
+    /**
+     * @return name of the corresponding file storage in the remote application,
+     * e.g. 'fs' for local file storage
+     */
+    public String getRemoteStorageName() {
+        return remoteStorageName;
+    }
+
+    @Override
+    public FileRef saveStream(String fileName, InputStream inputStream, Map<String, Object> parameters) {
+        RestClient restClient = restDataStoreUtils.getRestClient(dataStoreName);
+
+        String json = restClient.post()
+                .uri("/rest/files?name={fileName}", fileName)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(new InputStreamResource(inputStream))
+                .retrieve()
+                .body(String.class);
+
+        JsonNode rootNode;
+        try {
+            rootNode = objectMapper.readTree(json);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Error parsing JSON", e);
+        }
+        JsonNode fileRefNode = rootNode.get("fileRef");
+        if (fileRefNode == null)
+            throw new IllegalStateException("fileRef property is not found in returned JSON: " + json);
+
+        FileRef remoteFileRef = FileRef.fromString(fileRefNode.asText());
+        return new FileRef(getStorageName(), remoteFileRef.getPath(), remoteFileRef.getFileName(), remoteFileRef.getParameters());
+    }
+
+    @Override
+    public InputStream openStream(FileRef reference) {
+        FileRef fileRef = new FileRef(getRemoteStorageName(), reference.getPath(), reference.getFileName());
+        RestClient restClient = restDataStoreUtils.getRestClient(dataStoreName);
+        try {
+            Resource resource = restClient.get()
+                    .uri("/rest/files?fileRef={fileRef}", fileRef.toString())
+                    .retrieve()
+                    .body(Resource.class);
+            if (resource != null) {
+                return resource.getInputStream();
+            } else {
+                throw new RuntimeException("Cannot download file: response is null");
+            }
+        } catch (ResourceAccessException e) {
+            throw new RestDataStoreAccessException(dataStoreName, e);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void removeFile(FileRef reference) {
+        throw new UnsupportedOperationException("Generic REST does not support removing files");
+    }
+
+    @Override
+    public boolean fileExists(FileRef reference) {
+        throw new UnsupportedOperationException("Generic REST cannot check if a file exists. Use openStream() method.");
+    }
+}

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/filestorage/RestFileStorage.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/filestorage/RestFileStorage.java
@@ -23,10 +23,12 @@ import io.jmix.core.FileRef;
 import io.jmix.core.FileStorage;
 import io.jmix.restds.exception.RestDataStoreAccessException;
 import io.jmix.restds.util.RestDataStoreUtils;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.InputStreamResource;
-import org.springframework.core.io.Resource;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 
@@ -38,24 +40,33 @@ import java.util.Map;
  * File storage implementation that complements {@link io.jmix.restds.impl.RestDataStore} by the ability to store and load files
  * using the generic REST /files endpoints.
  * <p>
- * To use RestFileStorage, define the bean as follows:
+ * To use RestFileStorage, define the following bean in your application:
  * <pre>
  *     &#064;Bean
  *     FileStorage backendFileStorage() {
  *         return new RestFileStorage("backend", "fs");
  *     }
  * </pre>
+ * In this example, 'backend' is the name of REST DataStore representing the remote application and 'fs' is the name of
+ * the corresponding file storage in the remote application.
+ * <p>
  * See {@link #RestFileStorage(String, String)} for more information.
  */
-public class RestFileStorage implements FileStorage {
+public class RestFileStorage implements FileStorage, InitializingBean {
 
-    // Using field injection to simplify constructor creating this bean in app projects
-    @SuppressWarnings("unused")
+    // Using field injection to simplify constructor for creating this bean in app projects
     @Autowired
+    @SuppressWarnings("unused")
     private RestDataStoreUtils restDataStoreUtils;
+    @Autowired
+    @SuppressWarnings("unused")
+    private Environment environment;
 
     private final String dataStoreName;
     private final String remoteStorageName;
+
+    private String basePath;
+    private String filesPath;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -72,8 +83,14 @@ public class RestFileStorage implements FileStorage {
     }
 
     @Override
+    public void afterPropertiesSet() {
+        basePath = environment.getProperty(dataStoreName + ".basePath", "/rest");
+        filesPath = environment.getProperty(dataStoreName + ".filesPath", "/files");
+    }
+
+    @Override
     public String getStorageName() {
-        return dataStoreName + "-fs";
+        return dataStoreName + "-" + remoteStorageName;
     }
 
     /**
@@ -89,7 +106,7 @@ public class RestFileStorage implements FileStorage {
         RestClient restClient = restDataStoreUtils.getRestClient(dataStoreName);
 
         String json = restClient.post()
-                .uri("/rest/files?name={fileName}", fileName)
+                .uri(basePath + filesPath + "?name={fileName}", fileName)
                 .contentType(MediaType.APPLICATION_OCTET_STREAM)
                 .body(new InputStreamResource(inputStream))
                 .retrieve()
@@ -114,19 +131,17 @@ public class RestFileStorage implements FileStorage {
         FileRef fileRef = new FileRef(getRemoteStorageName(), reference.getPath(), reference.getFileName());
         RestClient restClient = restDataStoreUtils.getRestClient(dataStoreName);
         try {
-            Resource resource = restClient.get()
-                    .uri("/rest/files?fileRef={fileRef}", fileRef.toString())
-                    .retrieve()
-                    .body(Resource.class);
-            if (resource != null) {
-                return resource.getInputStream();
-            } else {
-                throw new RuntimeException("Cannot download file: response is null");
-            }
+            return restClient.get()
+                    .uri(basePath + filesPath + "?fileRef={fileRef}", fileRef.toString())
+                    .exchange((request, response) -> {
+                        if (response.getStatusCode().is2xxSuccessful()) {
+                            return new ResponseInputStream(response, response.getBody());
+                        } else {
+                            throw new RuntimeException("Cannot download file '" + fileRef + "': " + response.getStatusCode());
+                        }
+                    }, false);
         } catch (ResourceAccessException e) {
             throw new RestDataStoreAccessException(dataStoreName, e);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
         }
     }
 
@@ -137,6 +152,40 @@ public class RestFileStorage implements FileStorage {
 
     @Override
     public boolean fileExists(FileRef reference) {
-        throw new UnsupportedOperationException("Generic REST cannot check if a file exists. Use openStream() method.");
+        FileRef fileRef = new FileRef(getRemoteStorageName(), reference.getPath(), reference.getFileName());
+        RestClient restClient = restDataStoreUtils.getRestClient(dataStoreName);
+        try {
+            return restClient.get()
+                    .uri(basePath + filesPath + "?fileRef={fileRef}", fileRef.toString())
+                    .exchange((request, response) ->
+                            response.getStatusCode().is2xxSuccessful());
+        } catch (ResourceAccessException e) {
+            throw new RestDataStoreAccessException(dataStoreName, e);
+        }
+    }
+
+    public static class ResponseInputStream extends InputStream {
+
+        private final InputStream inputStream;
+        private final ClientHttpResponse response;
+
+        public ResponseInputStream(ClientHttpResponse response, InputStream inputStream) {
+            this.response = response;
+            this.inputStream = inputStream;
+        }
+
+        @Override
+        public int read() throws IOException {
+            return inputStream.read();
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                inputStream.close();
+            } finally {
+                response.close();
+            }
+        }
     }
 }

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/filestorage/package-info.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/filestorage/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+package io.jmix.restds.filestorage;
+
+import org.springframework.lang.NonNullApi;

--- a/jmix-restds/restds/src/test/java/filestorage/FileStorageTest.java
+++ b/jmix-restds/restds/src/test/java/filestorage/FileStorageTest.java
@@ -67,7 +67,7 @@ public class FileStorageTest extends BaseRestDsIntegrationTest {
         assertThat(fileRef.getFileName()).isEqualTo("doc1.txt");
 
         try (InputStream downloadStream = fileStorage.openStream(fileRef)) {
-            assertThat(downloadStream).isNotNull();
+            assertThat(downloadStream).isInstanceOf(RestFileStorage.ResponseInputStream.class);
             String content = IOUtils.toString(downloadStream, StandardCharsets.UTF_8);
             assertThat(content).isEqualTo("Some content: " + now);
         }
@@ -91,7 +91,7 @@ public class FileStorageTest extends BaseRestDsIntegrationTest {
     }
 
     @Test
-    void test() {
+    void testSaveFileRefAttribute() {
         FileStorage fileStorage = fileStorageLocator.getByName("restService1-fs");
 
         // Upload file
@@ -110,5 +110,17 @@ public class FileStorageTest extends BaseRestDsIntegrationTest {
         // File ref in the loaded entity is the same and points to RestFileStorage
         Customer loadedCustomer = dataManager.load(Customer.class).id(customer.getId()).one();
         assertThat(loadedCustomer.getDocument()).isEqualTo(fileRef);
+    }
+
+    @Test
+    void testFileExists() {
+        FileStorage fileStorage = fileStorageLocator.getByName("restService1-fs");
+
+        Customer customer = dataManager.load(Customer.class).id(TestSupport.UUID_1).one();
+        FileRef fileRef = customer.getDocument();
+        assertThat(fileStorage.fileExists(fileRef)).isTrue();
+
+        FileRef nonExistentFileRef = new FileRef(fileStorage.getStorageName(), "/aaa/bbb.txt", "bbb.txt");
+        assertThat(fileStorage.fileExists(nonExistentFileRef)).isFalse();
     }
 }

--- a/jmix-restds/restds/src/test/java/filestorage/FileStorageTest.java
+++ b/jmix-restds/restds/src/test/java/filestorage/FileStorageTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filestorage;
+
+import io.jmix.core.DataManager;
+import io.jmix.core.FileRef;
+import io.jmix.core.FileStorage;
+import io.jmix.core.FileStorageLocator;
+import io.jmix.restds.filestorage.RestFileStorage;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import test_support.BaseRestDsIntegrationTest;
+import test_support.TestSupport;
+import test_support.entity.Customer;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FileStorageTest extends BaseRestDsIntegrationTest {
+
+    @Autowired
+    DataManager dataManager;
+    @Autowired
+    FileStorageLocator fileStorageLocator;
+
+    LocalDateTime now;
+
+    @BeforeEach
+    void setUp() {
+        now = LocalDateTime.now();
+    }
+
+    @Test
+    void testDefaultFileStorage() {
+        FileStorage fileStorage = fileStorageLocator.getDefault();
+        assertThat(fileStorage).isInstanceOf(RestFileStorage.class);
+    }
+
+    @Test
+    void testUploadAndDownload() throws IOException {
+        FileStorage fileStorage = fileStorageLocator.getByName("restService1-fs");
+
+        ByteArrayInputStream uploadStream = new ByteArrayInputStream(("Some content: " + now).getBytes(StandardCharsets.UTF_8));
+        FileRef fileRef = fileStorage.saveStream("doc1.txt", uploadStream);
+        assertThat(fileRef.getStorageName()).isEqualTo("restService1-fs");
+        assertThat(fileRef.getFileName()).isEqualTo("doc1.txt");
+
+        try (InputStream downloadStream = fileStorage.openStream(fileRef)) {
+            assertThat(downloadStream).isNotNull();
+            String content = IOUtils.toString(downloadStream, StandardCharsets.UTF_8);
+            assertThat(content).isEqualTo("Some content: " + now);
+        }
+    }
+
+    @Test
+    void testLoadFileRefAttribute() throws IOException {
+        Customer customer = dataManager.load(Customer.class).id(TestSupport.UUID_1).one();
+
+        FileRef fileRef = customer.getDocument();
+        assertThat(fileRef).isNotNull();
+
+        FileStorage fileStorage = fileStorageLocator.getByName(fileRef.getStorageName());
+        assertThat(fileStorage).isInstanceOf(RestFileStorage.class);
+
+        try (InputStream inputStream = fileStorage.openStream(fileRef)) {
+            assertThat(inputStream).isNotNull();
+            String content = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
+            assertThat(content).isNotBlank();
+        }
+    }
+
+    @Test
+    void test() {
+        FileStorage fileStorage = fileStorageLocator.getByName("restService1-fs");
+
+        // Upload file
+        ByteArrayInputStream uploadStream = new ByteArrayInputStream(("Some content: " + now).getBytes(StandardCharsets.UTF_8));
+        FileRef fileRef = fileStorage.saveStream("doc1.txt", uploadStream);
+
+        // Save file ref in entity
+        Customer customer = dataManager.create(Customer.class);
+        customer.setLastName("Customer " + now);
+        customer.setDocument(fileRef);
+        Customer savedCustomer = dataManager.save(customer);
+
+        // File ref in the saved entity is the same and points to RestFileStorage
+        assertThat(savedCustomer.getDocument()).isEqualTo(fileRef);
+
+        // File ref in the loaded entity is the same and points to RestFileStorage
+        Customer loadedCustomer = dataManager.load(Customer.class).id(customer.getId()).one();
+        assertThat(loadedCustomer.getDocument()).isEqualTo(fileRef);
+    }
+}

--- a/jmix-restds/restds/src/test/java/rest_ds/RestSaveContextProcessorTest.java
+++ b/jmix-restds/restds/src/test/java/rest_ds/RestSaveContextProcessorTest.java
@@ -59,7 +59,7 @@ public class RestSaveContextProcessorTest extends BaseRestDsIntegrationTest {
 
         SaveContext saveContext = new SaveContext().saving(customer, contact1);
 
-        processor.normalizeCompositionItems(saveContext);
+        processor.process(saveContext);
 
         assertThat(saveContext.getEntitiesToSave()).hasSize(1);
         assertThat(saveContext.getEntitiesToSave()).first().isSameAs(customer);
@@ -88,7 +88,7 @@ public class RestSaveContextProcessorTest extends BaseRestDsIntegrationTest {
 
         SaveContext saveContext = new SaveContext().saving(customer, contact1).removing(contact2);
 
-        processor.normalizeCompositionItems(saveContext);
+        processor.process(saveContext);
 
         assertThat(saveContext.getEntitiesToSave()).hasSize(1);
         assertThat(saveContext.getEntitiesToSave()).first().isEqualTo(customer);

--- a/jmix-restds/restds/src/test/java/test_support/TestRestDsConfiguration.java
+++ b/jmix-restds/restds/src/test/java/test_support/TestRestDsConfiguration.java
@@ -16,10 +16,7 @@
 
 package test_support;
 
-import io.jmix.core.CoreConfiguration;
-import io.jmix.core.JmixModules;
-import io.jmix.core.Resources;
-import io.jmix.core.Stores;
+import io.jmix.core.*;
 import io.jmix.core.annotation.JmixModule;
 import io.jmix.core.cluster.ClusterApplicationEventChannelSupplier;
 import io.jmix.core.cluster.LocalApplicationEventChannelSupplier;
@@ -32,6 +29,7 @@ import io.jmix.data.persistence.DbmsSpecifics;
 import io.jmix.eclipselink.EclipselinkConfiguration;
 import io.jmix.restds.RestDsConfiguration;
 import io.jmix.restds.impl.RestAuthenticationManagerSupplier;
+import io.jmix.restds.filestorage.RestFileStorage;
 import io.jmix.restds.impl.RestPasswordAuthenticator;
 import io.jmix.restds.impl.RestTokenHolder;
 import io.jmix.security.SecurityConfiguration;
@@ -64,6 +62,11 @@ import javax.sql.DataSource;
 @PropertySource("classpath:/test_support/test-app.properties")
 @JmixModule(dependsOn = {RestDsConfiguration.class, SecurityConfiguration.class, EclipselinkConfiguration.class, DataConfiguration.class})
 public class TestRestDsConfiguration {
+
+    @Bean
+    FileStorage restService1FileStorage() {
+        return new RestFileStorage("restService1", "fs");
+    }
 
     // In production code created by autoconfiguration
     @Bean("restds_RestAuthenticationManagerSupplier")

--- a/jmix-restds/restds/src/test/java/test_support/entity/Customer.java
+++ b/jmix-restds/restds/src/test/java/test_support/entity/Customer.java
@@ -1,5 +1,6 @@
 package test_support.entity;
 
+import io.jmix.core.FileRef;
 import io.jmix.core.MetadataTools;
 import io.jmix.core.entity.annotation.JmixEmbedded;
 import io.jmix.core.entity.annotation.JmixGeneratedValue;
@@ -42,6 +43,16 @@ public class Customer {
 
     @JmixEmbedded
     private CustomerAddress address;
+
+    private FileRef document;
+
+    public FileRef getDocument() {
+        return document;
+    }
+
+    public void setDocument(FileRef document) {
+        this.document = document;
+    }
 
     public String getEmail() {
         return email;

--- a/jmix-restds/sample-rest-service/sample-rest-service.gradle
+++ b/jmix-restds/sample-rest-service/sample-rest-service.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation project(':security-starter')
     implementation project(':security-data-starter')
     implementation project(':authserver-starter')
+    implementation project(':localfs-starter')
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
 

--- a/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/SampleDataInitializer.java
+++ b/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/SampleDataInitializer.java
@@ -1,6 +1,8 @@
 package io.jmix.samples.restservice.app;
 
 import io.jmix.core.DataManager;
+import io.jmix.core.FileRef;
+import io.jmix.core.FileStorage;
 import io.jmix.core.security.Authenticated;
 import io.jmix.samples.restservice.entity.ContactType;
 import io.jmix.samples.restservice.entity.Customer;
@@ -12,6 +14,8 @@ import org.springframework.boot.context.event.ApplicationStartedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
@@ -20,9 +24,11 @@ public class SampleDataInitializer {
 
     private static final Logger log = LoggerFactory.getLogger(SampleDataInitializer.class);
     private final DataManager dataManager;
+    private final FileStorage fileStorage;
 
-    public SampleDataInitializer(DataManager dataManager) {
+    public SampleDataInitializer(DataManager dataManager, FileStorage fileStorage) {
         this.dataManager = dataManager;
+        this.fileStorage = fileStorage;
     }
 
     @EventListener(ApplicationStartedEvent.class)
@@ -56,6 +62,7 @@ public class SampleDataInitializer {
         customer.setLastName("Taylor");
         customer.setEmail("robert@example.com");
         customer.setRegion(regions.get(0));
+        customer.setDocument(uploadDocument("doc.txt" , "Initial content\nLine 1\nLine 2"));
 
         // create and save two customer contacts
         CustomerContact contact1 = dataManager.create(CustomerContact.class);
@@ -75,4 +82,10 @@ public class SampleDataInitializer {
 
         log.info("Customers created");
     }
+
+    private FileRef uploadDocument(String name, String content) {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(content.getBytes(StandardCharsets.UTF_8));
+        return fileStorage.saveStream(name, inputStream);
+    }
+
 }

--- a/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/entity/Customer.java
+++ b/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/entity/Customer.java
@@ -1,5 +1,6 @@
 package io.jmix.samples.restservice.entity;
 
+import io.jmix.core.FileRef;
 import io.jmix.core.MetadataTools;
 import io.jmix.core.entity.annotation.EmbeddedParameters;
 import io.jmix.core.entity.annotation.JmixGeneratedValue;
@@ -74,6 +75,17 @@ public class Customer {
             @AttributeOverride(name = "addressLine", column = @Column(name = "ADDRESS_ADDRESS_LINE"))
     })
     private CustomerAddress address;
+
+    @Column(name = "DOCUMENT", length = 1024)
+    private FileRef document;
+
+    public FileRef getDocument() {
+        return document;
+    }
+
+    public void setDocument(FileRef document) {
+        this.document = document;
+    }
 
     public CustomerAddress getAddress() {
         return address;

--- a/jmix-restds/sample-rest-service/src/main/resources/io/jmix/samples/restservice/liquibase/changelog/020-init-customer.xml
+++ b/jmix-restds/sample-rest-service/src/main/resources/io/jmix/samples/restservice/liquibase/changelog/020-init-customer.xml
@@ -26,6 +26,7 @@
                     type="VARCHAR(255)"/>
             <column name="ADDRESS_ZIP"
                     type="VARCHAR(255)"/>
+            <column name="DOCUMENT" type="VARCHAR(1024)"/>
         </createTable>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Created `RestFileStorage` implementation of `FileStorage` interface that loads and saves files using the `/files` endpoints of the generic REST. 

`RestFileStorage` is intended to be used together with the REST DataStore.

To register a `RestFileStorage` in the application, define a bean:
```
@Bean
FileStorage backendFileStorage() {
    return new RestFileStorage("backend", "fs");
}
```
Here 'backend' is the name of REST DataStore representing the remote application and 'fs' is the name of the corresponding file storage in the remote application.
