### PR TITLE
Ability to clear "modified" state of a detail view

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/DataContext.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/DataContext.java
@@ -24,9 +24,7 @@ import io.jmix.flowui.view.Subscribe;
 import org.springframework.lang.Nullable;
 
 import javax.annotation.CheckReturnValue;
-import java.util.Collection;
-import java.util.EventObject;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -156,6 +154,14 @@ public interface DataContext {
      * Returns true if the context has detected changes in the tracked entities.
      */
     boolean hasChanges();
+
+    /**
+     * Clears the lists of modified and removed entities. After calling this method, {@link #hasChanges()} returns false,
+     * {@link #getModified()} and {@link #getRemoved()} return empty sets.
+     */
+    default void clearChanges() {
+        throw new UnsupportedOperationException("Not implemented");
+    }
 
     /**
      * Returns true if the context has detected changes in the given entity.

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -608,6 +608,12 @@ public class DataContextImpl implements DataContextInternal {
     }
 
     @Override
+    public void clearChanges() {
+        modifiedInstances.clear();
+        removedInstances.clear();
+    }
+
+    @Override
     public boolean isModified(Object entity) {
         return modifiedInstances.contains(entity);
     }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/NoopDataContext.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/NoopDataContext.java
@@ -110,6 +110,10 @@ public class NoopDataContext implements DataContext {
     }
 
     @Override
+    public void clearChanges() {
+    }
+
+    @Override
     public boolean isModified(Object entity) {
         return false;
     }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ChangeTracker.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ChangeTracker.java
@@ -24,4 +24,10 @@ public interface ChangeTracker {
      * @return {@code true} if the view has unsaved changes
      */
     boolean hasUnsavedChanges();
+
+    /**
+     * Clears the "modified" state of the view. After calling this method, {@link #hasUnsavedChanges()} should
+     * return {@code false};
+     */
+    default void clearChanges() {}
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
@@ -51,7 +51,10 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.lang.Nullable;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -509,6 +512,12 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
         // if only new entities are registered as modified in DataContext,
         // check whether they were modified after opening the view
         return isModifiedAfterOpen();
+    }
+
+    @Override
+    public void clearChanges() {
+        getViewData().getDataContext().clearChanges();
+        setModifiedAfterOpen(false);
     }
 
     protected InstanceContainer<T> getEditedEntityContainer() {

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextTest.groovy
@@ -711,6 +711,49 @@ class DataContextTest extends DataContextSpec {
         !modified.contains(order)
     }
 
+    def "clear changes"() {
+        DataContext context = factory.createDataContext()
+
+        Order order1 = new Order(number: '1')
+        makeDetached(order1)
+        def mergedOrder1 = context.merge(order1)
+
+        Order order2 = new Order(number: '2')
+        makeDetached(order2)
+        def mergedOrder2 = context.merge(order2)
+
+        Order order3 = new Order(number: '3')
+        makeDetached(order3)
+        def mergedOrder3 = context.merge(order3)
+
+        Order order4 = new Order(number: '4')
+        makeDetached(order4)
+        def mergedOrder4 = context.merge(order4)
+
+        when:
+
+        mergedOrder1.number = '11'
+        mergedOrder2.number = '22'
+        context.remove(mergedOrder3)
+        context.remove(mergedOrder4)
+
+        then:
+
+        context.hasChanges()
+        context.getModified().containsAll(order1, order2)
+        context.getRemoved().containsAll(order3, order4)
+
+        when:
+
+        context.clearChanges()
+
+        then:
+
+        !context.hasChanges()
+        context.getModified().isEmpty()
+        context.getRemoved().isEmpty()
+    }
+
     void "copy generated id"() {
         DataContext context = factory.createDataContext()
         when:


### PR DESCRIPTION
Introduced `io.jmix.flowui.model.DataContext#clearChanges` and  `io.jmix.flowui.view.ChangeTracker#clearChanges` methods.