### PR TITLE
Use UUIDv7 for entity identifiers

### DIFF
--- a/jmix-bom/bom.gradle
+++ b/jmix-bom/bom.gradle
@@ -418,6 +418,8 @@ dependencies {
 
         api 'org.opensearch.client:opensearch-java:2.13.0'
         api 'org.opensearch.client:opensearch-rest-client:2.14.0'
+
+        api 'com.github.f4b6a3:uuid-creator:6.0.0'
     }
 }
 

--- a/jmix-core/core/core.gradle
+++ b/jmix-core/core/core.gradle
@@ -58,6 +58,7 @@ dependencies {
     api 'javax.cache:cache-api'
 
     implementation'com.google.code.gson:gson'
+    implementation 'com.github.f4b6a3:uuid-creator'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
     testImplementation 'org.springframework:spring-test'

--- a/jmix-core/core/src/main/java/io/jmix/core/EntityUuidGenerator.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/EntityUuidGenerator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core;
+
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * Generates UUID for using as entity identifiers.
+ */
+@Component("core_EntityIdGenerator")
+public class EntityUuidGenerator implements EnvironmentAware {
+
+    private boolean useLegacyUuid;
+
+    /**
+     * @return new UUID
+     */
+    public UUID generate() {
+        if (useLegacyUuid)
+            return UuidProvider.createUuid();
+        else
+            return UuidProvider.createUuidV7();
+    }
+
+    @Override
+    public void setEnvironment(Environment environment) {
+        String property = environment.getProperty("jmix.core.legacy-entity-uuid");
+        useLegacyUuid = Boolean.parseBoolean(property);
+    }
+}

--- a/jmix-core/core/src/main/java/io/jmix/core/UuidProvider.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/UuidProvider.java
@@ -15,6 +15,8 @@
  */
 package io.jmix.core;
 
+import com.github.f4b6a3.uuid.UuidCreator;
+
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -27,11 +29,18 @@ public final class UuidProvider {
     }
 
     /**
-     * @return new UUID
+     * @return new random UUID
      */
     public static UUID createUuid() {
         ThreadLocalRandom random = ThreadLocalRandom.current();
         return new UUID(random.nextLong(), random.nextLong());
+    }
+
+    /**
+     * @return new UUID v7
+     */
+    public static UUID createUuidV7() {
+        return UuidCreator.getTimeOrderedEpoch();
     }
 
     /**

--- a/jmix-core/core/src/main/java/io/jmix/core/entity/KeyValueEntity.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/entity/KeyValueEntity.java
@@ -97,7 +97,7 @@ public class KeyValueEntity
     }
 
     public KeyValueEntity() {
-        uuid = UuidProvider.createUuid();
+        uuid = UuidProvider.createUuidV7();
     }
 
     public MetaClass getInstanceMetaClass() {

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/GeneratedIdEntityInitializer.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/GeneratedIdEntityInitializer.java
@@ -16,7 +16,10 @@
 
 package io.jmix.core.impl;
 
-import io.jmix.core.*;
+import io.jmix.core.EntityInitializer;
+import io.jmix.core.EntityUuidGenerator;
+import io.jmix.core.JmixOrder;
+import io.jmix.core.Metadata;
 import io.jmix.core.entity.EntityValues;
 import io.jmix.core.entity.annotation.JmixGeneratedValue;
 import io.jmix.core.metamodel.model.MetaClass;
@@ -32,6 +35,9 @@ public class GeneratedIdEntityInitializer implements EntityInitializer, Ordered 
     @Autowired
     private Metadata metadata;
 
+    @Autowired
+    private EntityUuidGenerator uuidGenerator;
+
     @Override
     public void initEntity(Object entity) {
         MetaClass metaClass = metadata.getClass(entity);
@@ -41,7 +47,7 @@ public class GeneratedIdEntityInitializer implements EntityInitializer, Ordered 
                         && property.getAnnotations().get(JmixGeneratedValue.class.getName()) != null)
                 .forEach(property -> {
                     if (EntityValues.getValue(entity, property.getName()) == null) {
-                        EntityValues.setValue(entity, property.getName(), UuidProvider.createUuid());
+                        EntityValues.setValue(entity, property.getName(), uuidGenerator.generate());
                     }
                 });
     }

--- a/jmix-core/core/src/test/groovy/entity_uuid/EntityUuidGeneratorTest.groovy
+++ b/jmix-core/core/src/test/groovy/entity_uuid/EntityUuidGeneratorTest.groovy
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entity_uuid
+
+import io.jmix.core.CoreConfiguration
+import io.jmix.core.EntityUuidGenerator
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+import test_support.base.TestBaseConfiguration
+
+@ContextConfiguration(classes = [CoreConfiguration, TestBaseConfiguration])
+class EntityUuidGeneratorTest extends Specification {
+
+    @Autowired
+    EntityUuidGenerator entityUuidGenerator
+
+    def "test UUID is v7"() {
+        when: "generate UUIDs"
+        List<String> list = []
+        100.times {
+            def uuid = entityUuidGenerator.generate()
+            list << uuid.toString()
+        }
+
+        then: "UUIDs are v7 and increasing"
+        (0..<100).each { i ->
+            list[i][14] == '7'
+            if (i > 0) {
+                list[i] > list[i - 1]
+            }
+        }
+    }
+}

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/report/ReportDetailView.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/report/ReportDetailView.java
@@ -246,6 +246,8 @@ public class ReportDetailView extends StandardDetailView<Report> {
     protected FetchPlans fetchPlans;
     @Autowired
     protected DataManager dataManager;
+    @Autowired
+    private EntityUuidGenerator entityUuidGenerator;
 
     protected JmixComboBoxBinder<String> entityParamFieldBinder;
     protected JmixComboBoxBinder<String> entitiesParamFieldBinder;
@@ -1677,7 +1679,7 @@ public class ReportDetailView extends StandardDetailView<Report> {
         if (template != null) {
 
             ReportTemplate copy = metadataTools.copy(template);
-            copy.setId(UuidProvider.createUuid());
+            copy.setId(entityUuidGenerator.generate());
             copy.setVersion(null);
 
             String copyNamingPattern = messageBundle.getMessage("template.copyNamingPattern");

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/report/ReportListView.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/report/ReportListView.java
@@ -110,6 +110,8 @@ public class ReportListView extends StandardListView<Report> {
     protected ViewNavigators viewNavigators;
     @Autowired
     private Messages messages;
+    @Autowired
+    private EntityUuidGenerator entityUuidGenerator;
 
     @Subscribe
     protected void onInit(InitEvent event) {
@@ -258,11 +260,11 @@ public class ReportListView extends StandardListView<Report> {
                 .fetchPlan("report.edit")
                 .one();
         Report copiedReport = metadataTools.deepCopy(source);
-        copiedReport.setId(UuidProvider.createUuid());
+        copiedReport.setId(entityUuidGenerator.generate());
         copiedReport.setName(reportsUtils.generateReportName(source.getName()));
         copiedReport.setCode(null);
         for (ReportTemplate copiedTemplate : copiedReport.getTemplates()) {
-            copiedTemplate.setId(UuidProvider.createUuid());
+            copiedTemplate.setId(entityUuidGenerator.generate());
         }
 
         reports.save(copiedReport);


### PR DESCRIPTION
I have chosen https://github.com/f4b6a3/uuid-creator library because it can generate increasing UUIDs within a millisecond (see [wiki](https://github.com/f4b6a3/uuid-creator/wiki/1.7.-UUIDv7)). I couldn't do the same with the alternative https://github.com/cowtowncoder/java-uuid-generator.