### PR TITLE
1872 authorization server must use jdbcoauth2authorizationservice

### DIFF
--- a/jmix-authserver/authserver-starter/authserver-starter.gradle
+++ b/jmix-authserver/authserver-starter/authserver-starter.gradle
@@ -19,9 +19,9 @@ archivesBaseName = 'jmix-authserver-starter'
 
 dependencies {
     api project(':authserver')
-    api project(':data')
     api project(':security-resource-server')
 
+    implementation project(':data')
     implementation project(':core-starter')
     implementation project(':security-starter')
     implementation project(':security-resource-server-starter')

--- a/jmix-authserver/authserver-starter/src/main/java/io/jmix/autoconfigure/authserver/AuthServerAutoConfiguration.java
+++ b/jmix-authserver/authserver-starter/src/main/java/io/jmix/autoconfigure/authserver/AuthServerAutoConfiguration.java
@@ -29,6 +29,9 @@ import io.jmix.authserver.roleassignment.RegisteredClientRoleAssignment;
 import io.jmix.authserver.roleassignment.RegisteredClientRoleAssignmentPropertiesMapper;
 import io.jmix.authserver.roleassignment.RegisteredClientRoleAssignmentRepository;
 import io.jmix.authserver.service.OracleJdbcOAuth2AuthorizationService;
+import io.jmix.authserver.service.cleanup.OAuth2ExpiredTokenCleaner;
+import io.jmix.authserver.service.cleanup.impl.InMemoryOAuth2ExpiredTokenCleaner;
+import io.jmix.authserver.service.cleanup.impl.JdbcOAuth2ExpiredTokenCleaner;
 import io.jmix.authserver.service.mapper.JdbcOAuth2AuthorizationServiceObjectMapperCustomizer;
 import io.jmix.core.JmixSecurityFilterChainOrder;
 import io.jmix.data.persistence.DbmsType;
@@ -186,6 +189,16 @@ public class AuthServerAutoConfiguration {
                 authorizationService.setAuthorizationParametersMapper(parametersMapper);
 
                 return authorizationService;
+            }
+        }
+
+        @Bean("authsr_OAuth2ExpiredTokenCleaner")
+        @ConditionalOnMissingBean
+        public OAuth2ExpiredTokenCleaner OAuth2ExpiredTokenCleaner(JdbcOperations jdbcOperations) {
+            if (authServerProperties.isUseInMemoryAuthorizationService()) {
+                return new InMemoryOAuth2ExpiredTokenCleaner();
+            } else {
+                return new JdbcOAuth2ExpiredTokenCleaner(jdbcOperations);
             }
         }
 

--- a/jmix-authserver/authserver/authserver.gradle
+++ b/jmix-authserver/authserver/authserver.gradle
@@ -25,6 +25,7 @@ dependencies {
 
     api 'org.springframework.security:spring-security-oauth2-authorization-server'
     api 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    api 'org.springframework.boot:spring-boot-starter-jdbc'
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/jmix-authserver/authserver/authserver.gradle
+++ b/jmix-authserver/authserver/authserver.gradle
@@ -25,7 +25,7 @@ dependencies {
 
     api 'org.springframework.security:spring-security-oauth2-authorization-server'
     api 'org.springframework.boot:spring-boot-starter-thymeleaf'
-    api 'org.springframework.boot:spring-boot-starter-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-jdbc'
 
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/AuthServerProperties.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/AuthServerProperties.java
@@ -31,6 +31,11 @@ public class AuthServerProperties {
     boolean useDefaultConfiguration;
 
     /**
+     * Whether InMemoryAuthorizationService should be used instead of JdbcOAuth2AuthorizationService
+     */
+    boolean useInMemoryAuthorizationService;
+
+    /**
      * A list of jmix-specific client configurations
      */
     Map<String, JmixClient> client;
@@ -47,11 +52,13 @@ public class AuthServerProperties {
 
     public AuthServerProperties(
             @DefaultValue("true") boolean useDefaultConfiguration,
+            @DefaultValue("false") boolean useInMemoryAuthorizationService,
             @DefaultValue Map<String, JmixClient> client,
             @DefaultValue("/as-login") String loginPageUrl,
             @DefaultValue("as-login.html") String loginPageViewName
             ) {
         this.useDefaultConfiguration = useDefaultConfiguration;
+        this.useInMemoryAuthorizationService = useInMemoryAuthorizationService;
         this.client = client;
         this.loginPageUrl = loginPageUrl;
         this.loginPageViewName = loginPageViewName;
@@ -59,6 +66,10 @@ public class AuthServerProperties {
 
     public boolean isUseDefaultConfiguration() {
         return useDefaultConfiguration;
+    }
+
+    public boolean isUseInMemoryAuthorizationService() {
+        return useInMemoryAuthorizationService;
     }
 
     public Map<String, JmixClient> getClient() {

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/OracleJdbcOAuth2AuthorizationService.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/OracleJdbcOAuth2AuthorizationService.java
@@ -198,7 +198,7 @@ public class OracleJdbcOAuth2AuthorizationService extends JdbcOAuth2Authorizatio
         columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
     }
 
-    protected static OracleJdbcOAuth2AuthorizationService.ColumnMetadata getColumnMetadata(JdbcOperations jdbcOperations, String columnName, int defaultDataType) {
+    private static OracleJdbcOAuth2AuthorizationService.ColumnMetadata getColumnMetadata(JdbcOperations jdbcOperations, String columnName, int defaultDataType) {
         Integer dataType = jdbcOperations.execute((ConnectionCallback<Integer>) conn -> {
             DatabaseMetaData databaseMetaData = conn.getMetaData();
             ResultSet rs = databaseMetaData.getColumns(null, null, TABLE_NAME, columnName);

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/OracleJdbcOAuth2AuthorizationService.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/OracleJdbcOAuth2AuthorizationService.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.authserver.service;
+
+import org.springframework.jdbc.core.*;
+import org.springframework.jdbc.support.lob.LobCreator;
+import org.springframework.lang.Nullable;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class that provides JdbcOAuth2AuthorizationService for Oracle database.
+ */
+public class OracleJdbcOAuth2AuthorizationService extends JdbcOAuth2AuthorizationService {
+
+    private static final String COLUMN_NAMES = "id, "
+            + "registered_client_id, "
+            + "principal_name, "
+            + "authorization_grant_type, "
+            + "authorized_scopes, "
+            + "attributes, "
+            + "state, "
+            + "authorization_code_value, "
+            + "authorization_code_issued_at, "
+            + "authorization_code_expires_at,"
+            + "authorization_code_metadata,"
+            + "access_token_value,"
+            + "access_token_issued_at,"
+            + "access_token_expires_at,"
+            + "access_token_metadata,"
+            + "access_token_type,"
+            + "access_token_scopes,"
+            + "oidc_id_token_value,"
+            + "oidc_id_token_issued_at,"
+            + "oidc_id_token_expires_at,"
+            + "oidc_id_token_metadata,"
+            + "refresh_token_value,"
+            + "refresh_token_issued_at,"
+            + "refresh_token_expires_at,"
+            + "refresh_token_metadata,"
+            + "user_code_value,"
+            + "user_code_issued_at,"
+            + "user_code_expires_at,"
+            + "user_code_metadata,"
+            + "device_code_value,"
+            + "device_code_issued_at,"
+            + "device_code_expires_at,"
+            + "device_code_metadata";
+
+    private static Map<String, ColumnMetadata> columnMetadataMap;
+
+    private final JdbcOperations jdbcOperations;
+
+    private static final String TABLE_NAME = "oauth2_authorization";
+
+    private static final String UNKNOWN_TOKEN_TYPE_FILTER = "state = ? " +
+            "OR dbms_lob.compare(authorization_code_value,?) = 0 " +
+            "OR dbms_lob.compare(access_token_value,?) = 0 " +
+            "OR dbms_lob.compare(refresh_token_value,?) = 0 " +
+            "OR dbms_lob.compare(user_code_value,?) = 0 " +
+            "OR dbms_lob.compare(device_code_value,?) = 0";
+
+    private static final String STATE_FILTER = "state = ?";
+    private static final String AUTHORIZATION_CODE_FILTER = "dbms_lob.compare(authorization_code_value,?) = 0";
+    private static final String ACCESS_TOKEN_FILTER = "dbms_lob.compare(access_token_value,?) = 0";
+    private static final String ID_TOKEN_FILTER = "dbms_lob.compare(oidc_id_token_value,?) = 0";
+    private static final String REFRESH_TOKEN_FILTER = "dbms_lob.compare(refresh_token_value,?) = 0";
+    private static final String USER_CODE_FILTER = "dbms_lob.compare(user_code_value,?) = 0";
+    private static final String DEVICE_CODE_FILTER = "dbms_lob.compare(device_code_value,?) = 0";
+    private static final String LOAD_AUTHORIZATION_SQL = "SELECT " + COLUMN_NAMES
+            + " FROM " + TABLE_NAME
+            + " WHERE ";
+
+
+    public OracleJdbcOAuth2AuthorizationService(JdbcOperations jdbcOperations, RegisteredClientRepository registeredClientRepository) {
+        super(jdbcOperations, registeredClientRepository);
+        this.jdbcOperations = jdbcOperations;
+        initColumnMetadata(jdbcOperations);
+    }
+
+    @Nullable
+    @Override
+    public OAuth2Authorization findByToken(String token, @Nullable OAuth2TokenType tokenType) {
+        Assert.hasText(token, "token cannot be empty");
+        List<SqlParameterValue> parameters = new ArrayList<>();
+        if (tokenType == null) {
+            parameters.add(new SqlParameterValue(Types.VARCHAR, token));
+            parameters.add(mapToSqlParameter("authorization_code_value", token));
+            parameters.add(mapToSqlParameter("access_token_value", token));
+            parameters.add(mapToSqlParameter("oidc_id_token_value", token));
+            parameters.add(mapToSqlParameter("refresh_token_value", token));
+            parameters.add(mapToSqlParameter("user_code_value", token));
+            parameters.add(mapToSqlParameter("device_code_value", token));
+            return findBy(UNKNOWN_TOKEN_TYPE_FILTER, parameters);
+        } else if (OAuth2ParameterNames.STATE.equals(tokenType.getValue())) {
+            parameters.add(new SqlParameterValue(Types.VARCHAR, token));
+            return findBy(STATE_FILTER, parameters);
+        } else if (OAuth2ParameterNames.CODE.equals(tokenType.getValue())) {
+            parameters.add(mapToSqlParameter("authorization_code_value", token));
+            return findBy(AUTHORIZATION_CODE_FILTER, parameters);
+        } else if (OAuth2TokenType.ACCESS_TOKEN.equals(tokenType)) {
+            parameters.add(mapToSqlParameter("access_token_value", token));
+            return findBy(ACCESS_TOKEN_FILTER, parameters);
+        } else if (OidcParameterNames.ID_TOKEN.equals(tokenType.getValue())) {
+            parameters.add(mapToSqlParameter("oidc_id_token_value", token));
+            return findBy(ID_TOKEN_FILTER, parameters);
+        } else if (OAuth2TokenType.REFRESH_TOKEN.equals(tokenType)) {
+            parameters.add(mapToSqlParameter("refresh_token_value", token));
+            return findBy(REFRESH_TOKEN_FILTER, parameters);
+        } else if (OAuth2ParameterNames.USER_CODE.equals(tokenType.getValue())) {
+            parameters.add(mapToSqlParameter("user_code_value", token));
+            return findBy(USER_CODE_FILTER, parameters);
+        } else if (OAuth2ParameterNames.DEVICE_CODE.equals(tokenType.getValue())) {
+            parameters.add(mapToSqlParameter("device_code_value", token));
+            return findBy(DEVICE_CODE_FILTER, parameters);
+        }
+        return null;
+    }
+
+    protected OAuth2Authorization findBy(String filter, List<SqlParameterValue> parameters) {
+        PreparedStatementSetter pss = new LobCreatorArgumentPreparedStatementSetter(getLobHandler().getLobCreator(), parameters.toArray());
+        List<OAuth2Authorization> result = this.jdbcOperations.query(LOAD_AUTHORIZATION_SQL + filter, pss, getAuthorizationRowMapper());
+        return !result.isEmpty() ? result.get(0) : null;
+    }
+
+    protected static void initColumnMetadata(JdbcOperations jdbcOperations) {
+        columnMetadataMap = new HashMap<>();
+        OracleJdbcOAuth2AuthorizationService.ColumnMetadata columnMetadata;
+
+        columnMetadata = getColumnMetadata(jdbcOperations, "attributes", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "authorization_code_value", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "authorization_code_metadata", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "access_token_value", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "access_token_metadata", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "oidc_id_token_value", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "oidc_id_token_metadata", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "refresh_token_value", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "refresh_token_metadata", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "user_code_value", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "user_code_metadata", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "device_code_value", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+        columnMetadata = getColumnMetadata(jdbcOperations, "device_code_metadata", Types.BLOB);
+        columnMetadataMap.put(columnMetadata.getColumnName(), columnMetadata);
+    }
+
+    private static OracleJdbcOAuth2AuthorizationService.ColumnMetadata getColumnMetadata(JdbcOperations jdbcOperations, String columnName, int defaultDataType) {
+        Integer dataType = jdbcOperations.execute((ConnectionCallback<Integer>) conn -> {
+            DatabaseMetaData databaseMetaData = conn.getMetaData();
+            ResultSet rs = databaseMetaData.getColumns(null, null, TABLE_NAME, columnName);
+            if (rs.next()) {
+                return rs.getInt("DATA_TYPE");
+            }
+
+            rs = databaseMetaData.getColumns(null, null, TABLE_NAME.toUpperCase(), columnName.toUpperCase());
+            if (rs.next()) {
+                return rs.getInt("DATA_TYPE");
+            }
+            return null;
+        });
+        return new OracleJdbcOAuth2AuthorizationService.ColumnMetadata(columnName, dataType != null ? dataType : defaultDataType);
+    }
+
+    private static SqlParameterValue mapToSqlParameter(String columnName, String value) {
+        ColumnMetadata columnMetadata = columnMetadataMap.get(columnName);
+        return Types.BLOB == columnMetadata.getDataType() && StringUtils.hasText(value) ?
+                new SqlParameterValue(Types.BLOB, value.getBytes(StandardCharsets.UTF_8)) :
+                new SqlParameterValue(columnMetadata.getDataType(), value);
+    }
+
+    private static final class ColumnMetadata {
+        private final String columnName;
+        private final int dataType;
+
+        private ColumnMetadata(String columnName, int dataType) {
+            this.columnName = columnName;
+            this.dataType = dataType;
+        }
+
+        private String getColumnName() {
+            return this.columnName;
+        }
+
+        private int getDataType() {
+            return this.dataType;
+        }
+    }
+
+    private static final class LobCreatorArgumentPreparedStatementSetter extends ArgumentPreparedStatementSetter {
+        private final LobCreator lobCreator;
+
+        private LobCreatorArgumentPreparedStatementSetter(LobCreator lobCreator, Object[] args) {
+            super(args);
+            this.lobCreator = lobCreator;
+        }
+
+        @Override
+        protected void doSetValue(PreparedStatement ps, int parameterPosition, Object argValue) throws SQLException {
+            if (argValue instanceof SqlParameterValue) {
+                SqlParameterValue paramValue = (SqlParameterValue) argValue;
+                if (paramValue.getSqlType() == Types.BLOB) {
+                    if (paramValue.getValue() != null) {
+                        Assert.isInstanceOf(byte[].class, paramValue.getValue(),
+                                "Value of blob parameter must be byte[]");
+                    }
+                    byte[] valueBytes = (byte[]) paramValue.getValue();
+                    this.lobCreator.setBlobAsBytes(ps, parameterPosition, valueBytes);
+                    return;
+                }
+            }
+            super.doSetValue(ps, parameterPosition, argValue);
+        }
+    }
+}

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/OAuth2ExpiredTokenCleaner.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/OAuth2ExpiredTokenCleaner.java
@@ -25,6 +25,8 @@ public interface OAuth2ExpiredTokenCleaner {
      * Removes expired access token.
      * <p>
      * If access token also has related refresh token then both should be expired to be removed.
+     *
+     * @return amount of removed tokens
      */
-    void removeExpiredAccessTokens();
+    int removeExpiredAccessTokens();
 }

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/OAuth2ExpiredTokenCleaner.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/OAuth2ExpiredTokenCleaner.java
@@ -17,7 +17,7 @@
 package io.jmix.authserver.service.cleanup;
 
 /**
- * Interface that provides functionality to remove expired tokens
+ * Interface that provides functionality to remove expired tokens.
  */
 public interface OAuth2ExpiredTokenCleaner {
 

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/OAuth2ExpiredTokenCleaner.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/OAuth2ExpiredTokenCleaner.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.authserver.service.cleanup;
+
+/**
+ * Interface that provides functionality to remove expired tokens
+ */
+public interface OAuth2ExpiredTokenCleaner {
+
+    /**
+     * Removes expired access token.
+     * <p>
+     * If access token also has related refresh token then both should be expired to be removed.
+     */
+    void removeExpiredAccessTokens();
+}

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/impl/InMemoryOAuth2ExpiredTokenCleaner.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/impl/InMemoryOAuth2ExpiredTokenCleaner.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.authserver.service.cleanup.impl;
+
+import io.jmix.authserver.service.cleanup.OAuth2ExpiredTokenCleaner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InMemoryOAuth2ExpiredTokenCleaner implements OAuth2ExpiredTokenCleaner {
+
+    private static final Logger log = LoggerFactory.getLogger(InMemoryOAuth2ExpiredTokenCleaner.class);
+
+    @Override
+    public void removeExpiredAccessTokens() {
+        log.warn("Cleanup is not supported for InMemoryOAuth2AuthorizationService");
+    }
+}

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/impl/InMemoryOAuth2ExpiredTokenCleaner.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/impl/InMemoryOAuth2ExpiredTokenCleaner.java
@@ -25,7 +25,8 @@ public class InMemoryOAuth2ExpiredTokenCleaner implements OAuth2ExpiredTokenClea
     private static final Logger log = LoggerFactory.getLogger(InMemoryOAuth2ExpiredTokenCleaner.class);
 
     @Override
-    public void removeExpiredAccessTokens() {
+    public int removeExpiredAccessTokens() {
         log.warn("Cleanup is not supported for InMemoryOAuth2AuthorizationService");
+        return 0;
     }
 }

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/impl/JdbcOAuth2ExpiredTokenCleaner.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/impl/JdbcOAuth2ExpiredTokenCleaner.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.authserver.service.cleanup.impl;
+
+import io.jmix.authserver.service.cleanup.OAuth2ExpiredTokenCleaner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcOperations;
+
+import java.util.Date;
+
+public class JdbcOAuth2ExpiredTokenCleaner implements OAuth2ExpiredTokenCleaner {
+
+    private static final Logger log = LoggerFactory.getLogger(JdbcOAuth2ExpiredTokenCleaner.class);
+
+    private static final String TABLE_NAME = "oauth2_authorization";
+
+    private static final String ACCESS_TOKEN_EXISTS_AND_EXPIRED_FILTER = "(access_token_expires_at is not null AND access_token_expires_at < ?)";
+    private static final String REFRESH_TOKEN_EXPIRED_IF_EXISTS_FILTER = "(refresh_token_expires_at is null or refresh_token_expires_at < ?)";
+
+    private static final String DELETE_ACCESS_TOKEN_QUERY = "delete from " + TABLE_NAME
+            + " where " + ACCESS_TOKEN_EXISTS_AND_EXPIRED_FILTER
+            + " and " + REFRESH_TOKEN_EXPIRED_IF_EXISTS_FILTER;
+
+    protected final JdbcOperations jdbcOperations;
+
+    public JdbcOAuth2ExpiredTokenCleaner(JdbcOperations jdbcOperations) {
+        this.jdbcOperations = jdbcOperations;
+    }
+
+    @Override
+    public void removeExpiredAccessTokens() {
+        Date currentDate = new Date();
+        int updated = jdbcOperations.update(DELETE_ACCESS_TOKEN_QUERY, currentDate, currentDate);
+        log.info("Removed {} expired access tokens", updated);
+    }
+}

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/impl/JdbcOAuth2ExpiredTokenCleaner.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/impl/JdbcOAuth2ExpiredTokenCleaner.java
@@ -17,15 +17,11 @@
 package io.jmix.authserver.service.cleanup.impl;
 
 import io.jmix.authserver.service.cleanup.OAuth2ExpiredTokenCleaner;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.JdbcOperations;
 
 import java.util.Date;
 
 public class JdbcOAuth2ExpiredTokenCleaner implements OAuth2ExpiredTokenCleaner {
-
-    private static final Logger log = LoggerFactory.getLogger(JdbcOAuth2ExpiredTokenCleaner.class);
 
     private static final String TABLE_NAME = "oauth2_authorization";
 
@@ -43,9 +39,8 @@ public class JdbcOAuth2ExpiredTokenCleaner implements OAuth2ExpiredTokenCleaner 
     }
 
     @Override
-    public void removeExpiredAccessTokens() {
+    public int removeExpiredAccessTokens() {
         Date currentDate = new Date();
-        int updated = jdbcOperations.update(DELETE_ACCESS_TOKEN_QUERY, currentDate, currentDate);
-        log.info("Removed {} expired access tokens", updated);
+        return jdbcOperations.update(DELETE_ACCESS_TOKEN_QUERY, currentDate, currentDate);
     }
 }

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/impl/package-info.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/impl/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Internal
+@NonNullApi
+package io.jmix.authserver.service.cleanup.impl;
+
+import io.jmix.core.annotation.Internal;
+import org.springframework.lang.NonNullApi;

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/package-info.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/cleanup/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@NonNullApi
+package io.jmix.authserver.service.cleanup;
+
+import org.springframework.lang.NonNullApi;

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/mapper/DefaultOAuth2TokenUserMixin.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/mapper/DefaultOAuth2TokenUserMixin.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
- * Default User mixin that ignores password
+ * Default User mixin that ignores password.
  */
 @JsonIgnoreProperties(
         ignoreUnknown = true

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/mapper/DefaultOAuth2TokenUserMixin.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/mapper/DefaultOAuth2TokenUserMixin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Haulmont.
+ * Copyright 2025 Haulmont.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-group = 'io.jmix.authserver'
-archivesBaseName = 'jmix-authserver-starter'
+package io.jmix.authserver.service.mapper;
 
-dependencies {
-    api project(':authserver')
-    api project(':data')
-    api project(':security-resource-server')
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
-    implementation project(':core-starter')
-    implementation project(':security-starter')
-    implementation project(':security-resource-server-starter')
+/**
+ * Default User mixin that ignores password
+ */
+@JsonIgnoreProperties(
+        ignoreUnknown = true
+)
+public class DefaultOAuth2TokenUserMixin {
 
-    implementation 'org.springframework.boot:spring-boot-autoconfigure'
+    @JsonIgnore
+    private String password;
 }

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/mapper/JdbcOAuth2AuthorizationServiceObjectMapperCustomizer.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/mapper/JdbcOAuth2AuthorizationServiceObjectMapperCustomizer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.authserver.service.mapper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Interface to provide ability to customize ObjectMapper that is used by JdbcOAuth2AuthorizationService.
+ * <p>
+ * JdbcOAuth2AuthorizationService requires mixin for User entity to properly serialize/deserialize it.
+ * Create bean that implements this interface and add mixin for User entity generated in project.
+ * <p>
+ * Custom mixin can be either implemented on project side or {@link DefaultOAuth2TokenUserMixin} can be used.
+ * <p>
+ * Example:
+ * <pre>
+ * &#064;Component
+ * public class MyJdbcOAuth2TokenObjectMapperCustomizer implements JdbcOAuth2AuthorizationServiceObjectMapperCustomizer {
+ *
+ *     &#064;Override
+ *     public void customize(&#064;NonNull ObjectMapper objectMapper) {
+ *         objectMapper.addMixIn(User.class, DefaultOAuth2TokenUserMixin.class);
+ *     }
+ * }
+ * </pre>
+ */
+public interface JdbcOAuth2AuthorizationServiceObjectMapperCustomizer {
+
+    void customize(ObjectMapper objectMapper);
+}

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/mapper/package-info.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/mapper/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Haulmont.
+ * Copyright 2020 Haulmont.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-group = 'io.jmix.authserver'
-archivesBaseName = 'jmix-authserver-starter'
+@NonNullApi
+package io.jmix.authserver.service.mapper;
 
-dependencies {
-    api project(':authserver')
-    api project(':data')
-    api project(':security-resource-server')
-
-    implementation project(':core-starter')
-    implementation project(':security-starter')
-    implementation project(':security-resource-server-starter')
-
-    implementation 'org.springframework.boot:spring-boot-autoconfigure'
-}
+import org.springframework.lang.NonNullApi;

--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/package-info.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/service/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Haulmont.
+ * Copyright 2020 Haulmont.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,17 +14,7 @@
  * limitations under the License.
  */
 
-group = 'io.jmix.authserver'
-archivesBaseName = 'jmix-authserver-starter'
+@NonNullApi
+package io.jmix.authserver.service;
 
-dependencies {
-    api project(':authserver')
-    api project(':data')
-    api project(':security-resource-server')
-
-    implementation project(':core-starter')
-    implementation project(':security-starter')
-    implementation project(':security-resource-server-starter')
-
-    implementation 'org.springframework.boot:spring-boot-autoconfigure'
-}
+import org.springframework.lang.NonNullApi;

--- a/jmix-authserver/authserver/src/main/resources/io/jmix/authserver/liquibase/changelog.xml
+++ b/jmix-authserver/authserver/src/main/resources/io/jmix/authserver/liquibase/changelog.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2020 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <property name="authserver.data.type"
+              value="BLOB"
+              dbms="mysql"/>
+    <property name="authserver.data.type"
+              value="CLOB"
+              dbms="mariadb"/>
+    <property name="authserver.data.type"
+              value="CLOB"
+              dbms="postgresql"/>
+    <property name="authserver.data.type"
+              value="CLOB"
+              dbms="mssql"/>
+    <property name="authserver.data.type"
+              value="BLOB"
+              dbms="oracle"/>
+    <property name="authserver.data.type"
+              value="BLOB"
+              dbms="hsqldb"/>
+    <include file="/io/jmix/authserver/liquibase/changelog/001-authserver.xml"/>
+
+</databaseChangeLog>

--- a/jmix-authserver/authserver/src/main/resources/io/jmix/authserver/liquibase/changelog/001-authserver.xml
+++ b/jmix-authserver/authserver/src/main/resources/io/jmix/authserver/liquibase/changelog/001-authserver.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2024 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+
+    <changeSet id="1" author="authserver">
+        <createTable tableName="oauth2_authorization">
+            <column name="id" type="varchar(100)">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="registered_client_id" type="varchar(100)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="principal_name" type="varchar(200)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="authorization_grant_type" type="varchar(100)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="authorized_scopes" type="varchar(1000)"/>
+            <column name="attributes" type="${authserver.data.type}"/>
+            <column name="state" type="varchar(500)"/>
+            <column name="authorization_code_value" type="${authserver.data.type}"/>
+            <column name="authorization_code_issued_at" type="timestamp"/>
+            <column name="authorization_code_expires_at" type="timestamp"/>
+            <column name="authorization_code_metadata" type="${authserver.data.type}"/>
+            <column name="access_token_value" type="${authserver.data.type}"/>
+            <column name="access_token_issued_at" type="timestamp"/>
+            <column name="access_token_expires_at" type="timestamp"/>
+            <column name="access_token_metadata" type="${authserver.data.type}"/>
+            <column name="access_token_type" type="varchar(100)"/>
+            <column name="access_token_scopes" type="varchar(1000)"/>
+            <column name="oidc_id_token_value" type="${authserver.data.type}"/>
+            <column name="oidc_id_token_issued_at" type="timestamp"/>
+            <column name="oidc_id_token_expires_at" type="timestamp"/>
+            <column name="oidc_id_token_metadata" type="${authserver.data.type}"/>
+            <column name="refresh_token_value" type="${authserver.data.type}"/>
+            <column name="refresh_token_issued_at" type="timestamp"/>
+            <column name="refresh_token_expires_at" type="timestamp"/>
+            <column name="refresh_token_metadata" type="${authserver.data.type}"/>
+            <column name="user_code_value" type="${authserver.data.type}"/>
+            <column name="user_code_issued_at" type="timestamp"/>
+            <column name="user_code_expires_at" type="timestamp"/>
+            <column name="user_code_metadata" type="${authserver.data.type}"/>
+            <column name="device_code_value" type="${authserver.data.type}"/>
+            <column name="device_code_issued_at" type="timestamp"/>
+            <column name="device_code_expires_at" type="timestamp"/>
+            <column name="device_code_metadata" type="${authserver.data.type}"/>
+        </createTable>
+    </changeSet>
+
+</databaseChangeLog>

--- a/jmix-authserver/authserver/src/main/resources/io/jmix/authserver/module.properties
+++ b/jmix-authserver/authserver/src/main/resources/io/jmix/authserver/module.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2025 Haulmont.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+main.datasource.studio.liquibase.exclude-prefixes = oauth2_


### PR DESCRIPTION
See #1872

### Changes

#### Feature toggle

`jmix.authserver.use-in-memory-authorization-service` application property. False by default.

#### Table

Table `oauth2_authorization` was added.

#### Services

- `JdbcOAuth2AuthorizationService` is used for all databases except Oracle.
- `OracleJdbcOAuth2AuthorizationService` is used for Oracle database (Oracle-specific work with LOB data). 
- `InMemoryOAuth2ExpiredTokenCleaner` is used if feature is disabled.

#### ObjectMapper customization & Mixin 

Tokens with project `User` entity as principal (e.g. 'password' grant type) requires a mixin to perform deserialization.
Default mixin `DefaultOAuth2TokenUserMixin` is provided by addon. It also excludes `password` field from being serialized to token metadata.
`JdbcOAuth2AuthorizationServiceObjectMapperCustomizer` interface was introduced to be implemented as a bean on the project side. It allows you to customize `ObjectMapper` that will be used within `JdbcOAuth2AuthorizationService`. 
Mixin (default or custom one) should be added for `User` class within this customization.
```
@Component
public class MyJdbcOAuth2TokenObjectMapperCustomizer implements JdbcOAuth2AuthorizationServiceObjectMapperCustomizer {
    
    @Override
    public void customize(@NonNull ObjectMapper objectMapper) {
        objectMapper.addMixIn(User.class, DefaultOAuth2TokenUserMixin.class);
    }
}
```
This cannot be performed on the addon side because actual `User` class doesn't exist at that moment.

#### Cleanup

OAuth2ExpiredTokenCleaner interface was introduced. It enables removing rows with expired access token. If a row also has non-null refresh token it also has to be expired to remove the entire row.

Two implementation beans:

- `JdbcOAuth2ExpiredTokenCleaner` - removes tokens from `oauth2_authorization` table.
- `InMemoryOAuth2ExpiredTokenCleaner` - stub implementation in case of `InMemoryOAuth2AuthorizationService` usage. It removes nothing because `InMemoryOAuth2AuthorizationService` doesn't provide API for bulk removal based on expiration date.

