### PR TITLE
Fix KeyValueCollection multiple filters search

### DIFF
--- a/jmix-data/data/src/main/java/io/jmix/data/impl/jpql/generator/ConditionJpqlGenerator.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/impl/jpql/generator/ConditionJpqlGenerator.java
@@ -71,9 +71,7 @@ public class ConditionJpqlGenerator {
     private void copyGenerationContext(ConditionGenerationContext generationContext) {
         for (Condition childCondition:generationContext.getChildContexts().keySet()){
             ConditionGenerationContext childContext = generationContext.getChildContexts().get(childCondition);
-            childContext.setEntityAlias(generationContext.getEntityAlias());
-            childContext.setEntityName(generationContext.getEntityName());
-            childContext.setValueProperties(generationContext.getValueProperties());
+            childContext.copy(generationContext);
             copyGenerationContext(childContext);
         }
     }


### PR DESCRIPTION
Fixes #3980 

The [KeyValuePropertyConditionGenerator#L43](https://github.com/jmix-framework/jmix/blob/e2b937f0644ad0e4782741596426ccf7ad26d640/jmix-data/data/src/main/java/io/jmix/data/impl/jpql/generator/KeyValuePropertyConditionGenerator.java#L43) (required for filtering KeyValueCollections) checks that the context has getSelectedExpressions() != null, however, in [ConditionJpqlGenerator#L74](https://github.com/jmix-framework/jmix/blob/e2b937f0644ad0e4782741596426ccf7ad26d640/jmix-data/data/src/main/java/io/jmix/data/impl/jpql/generator/ConditionJpqlGenerator.java#L74) the selectedExpressions were not being copied to childContexts.