### PR TITLE
#4264 - fix wrong openapi spec generation for service method http methods

### DIFF
--- a/jmix-rest/rest/src/main/java/io/jmix/rest/impl/openapi/OpenAPIGeneratorImpl.java
+++ b/jmix-rest/rest/src/main/java/io/jmix/rest/impl/openapi/OpenAPIGeneratorImpl.java
@@ -476,11 +476,11 @@ public class OpenAPIGeneratorImpl implements OpenAPIGenerator {
     /*
      * Services
      */
-    protected void buildServicesPaths(io.swagger.v3.oas.models.OpenAPI openAPI) {
-        for (RestServicesConfiguration.RestServiceInfo serviceInfo : servicesConfiguration.getServiceInfos()) {
+    protected void buildServicesPaths(OpenAPI openAPI) {
+        for (RestServiceInfo serviceInfo : servicesConfiguration.getServiceInfos()) {
             String serviceName = serviceInfo.getName();
 
-            for (RestServicesConfiguration.RestMethodInfo methodInfo : serviceInfo.getMethods()) {
+            for (RestMethodInfo methodInfo : serviceInfo.getMethods()) {
                 openAPI.path(
                         String.format(SERVICE_PATH, serviceName, methodInfo.getName()),
                         createServiceMethodPathItem(serviceName, methodInfo, RestHttpMethod.valueOf(methodInfo.getHttpMethod())));
@@ -488,7 +488,7 @@ public class OpenAPIGeneratorImpl implements OpenAPIGenerator {
         }
     }
 
-    private PathItem createServiceMethodPathItem(String serviceName, RestServicesConfiguration.RestMethodInfo methodInfo, RestHttpMethod restHttpMethod) {
+    private PathItem createServiceMethodPathItem(String serviceName, RestMethodInfo methodInfo, RestHttpMethod restHttpMethod) {
         return switch (restHttpMethod) {
             case GET -> new PathItem()
                     .get(createServiceMethodOp(serviceName, methodInfo, RequestMethod.GET));

--- a/jmix-rest/rest/src/main/java/io/jmix/rest/impl/openapi/OpenAPIGeneratorImpl.java
+++ b/jmix-rest/rest/src/main/java/io/jmix/rest/impl/openapi/OpenAPIGeneratorImpl.java
@@ -477,10 +477,10 @@ public class OpenAPIGeneratorImpl implements OpenAPIGenerator {
      * Services
      */
     protected void buildServicesPaths(OpenAPI openAPI) {
-        for (RestServicesConfiguration.RestServiceInfo serviceInfo : servicesConfiguration.getServiceInfos()) {
+        for (RestServiceInfo serviceInfo : servicesConfiguration.getServiceInfos()) {
             String serviceName = serviceInfo.getName();
 
-            for (RestServicesConfiguration.RestMethodInfo methodInfo : serviceInfo.getMethods()) {
+            for (RestMethodInfo methodInfo : serviceInfo.getMethods()) {
                 String path = String.format(SERVICE_PATH, serviceName, methodInfo.getName());
                 PathItem pathItem = openAPI.getPaths().getOrDefault(path, new PathItem());
 

--- a/jmix-rest/rest/src/main/java/io/jmix/rest/impl/openapi/OpenAPIGeneratorImpl.java
+++ b/jmix-rest/rest/src/main/java/io/jmix/rest/impl/openapi/OpenAPIGeneratorImpl.java
@@ -477,24 +477,21 @@ public class OpenAPIGeneratorImpl implements OpenAPIGenerator {
      * Services
      */
     protected void buildServicesPaths(OpenAPI openAPI) {
-        for (RestServiceInfo serviceInfo : servicesConfiguration.getServiceInfos()) {
+        for (RestServicesConfiguration.RestServiceInfo serviceInfo : servicesConfiguration.getServiceInfos()) {
             String serviceName = serviceInfo.getName();
 
-            for (RestMethodInfo methodInfo : serviceInfo.getMethods()) {
-                openAPI.path(
-                        String.format(SERVICE_PATH, serviceName, methodInfo.getName()),
-                        createServiceMethodPathItem(serviceName, methodInfo, RestHttpMethod.valueOf(methodInfo.getHttpMethod())));
+            for (RestServicesConfiguration.RestMethodInfo methodInfo : serviceInfo.getMethods()) {
+                String path = String.format(SERVICE_PATH, serviceName, methodInfo.getName());
+                PathItem pathItem = openAPI.getPaths().getOrDefault(path, new PathItem());
+
+                switch (RestHttpMethod.valueOf(methodInfo.getHttpMethod())) {
+                    case GET -> pathItem.get(createServiceMethodOp(serviceName, methodInfo, RequestMethod.GET));
+                    case POST -> pathItem.post(createServiceMethodOp(serviceName, methodInfo, RequestMethod.POST));
+                }
+
+                openAPI.path(path, pathItem);
             }
         }
-    }
-
-    private PathItem createServiceMethodPathItem(String serviceName, RestMethodInfo methodInfo, RestHttpMethod restHttpMethod) {
-        return switch (restHttpMethod) {
-            case GET -> new PathItem()
-                    .get(createServiceMethodOp(serviceName, methodInfo, RequestMethod.GET));
-            case POST -> new PathItem()
-                    .post(createServiceMethodOp(serviceName, methodInfo, RequestMethod.POST));
-        };
     }
 
     protected Operation createServiceMethodOp(String service, RestMethodInfo methodInfo, RequestMethod requestMethod) {

--- a/jmix-rest/rest/src/main/java/io/jmix/rest/impl/openapi/OpenAPIGeneratorImpl.java
+++ b/jmix-rest/rest/src/main/java/io/jmix/rest/impl/openapi/OpenAPIGeneratorImpl.java
@@ -26,6 +26,7 @@ import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.core.metamodel.model.MetadataObject;
 import io.jmix.rest.RestProperties;
+import io.jmix.rest.annotation.RestHttpMethod;
 import io.jmix.rest.impl.config.RestQueriesConfiguration;
 import io.jmix.rest.impl.config.RestQueriesConfiguration.QueryInfo;
 import io.jmix.rest.impl.config.RestServicesConfiguration;
@@ -475,17 +476,25 @@ public class OpenAPIGeneratorImpl implements OpenAPIGenerator {
     /*
      * Services
      */
-    protected void buildServicesPaths(OpenAPI openAPI) {
-        for (RestServiceInfo serviceInfo : servicesConfiguration.getServiceInfos()) {
+    protected void buildServicesPaths(io.swagger.v3.oas.models.OpenAPI openAPI) {
+        for (RestServicesConfiguration.RestServiceInfo serviceInfo : servicesConfiguration.getServiceInfos()) {
             String serviceName = serviceInfo.getName();
 
-            for (RestMethodInfo methodInfo : serviceInfo.getMethods()) {
-                openAPI.path(String.format(SERVICE_PATH, serviceName, methodInfo.getName()),
-                        new PathItem()
-                                .get(createServiceMethodOp(serviceName, methodInfo, RequestMethod.GET))
-                                .post(createServiceMethodOp(serviceName, methodInfo, RequestMethod.POST)));
+            for (RestServicesConfiguration.RestMethodInfo methodInfo : serviceInfo.getMethods()) {
+                openAPI.path(
+                        String.format(SERVICE_PATH, serviceName, methodInfo.getName()),
+                        createServiceMethodPathItem(serviceName, methodInfo, RestHttpMethod.valueOf(methodInfo.getHttpMethod())));
             }
         }
+    }
+
+    private PathItem createServiceMethodPathItem(String serviceName, RestServicesConfiguration.RestMethodInfo methodInfo, RestHttpMethod restHttpMethod) {
+        return switch (restHttpMethod) {
+            case GET -> new PathItem()
+                    .get(createServiceMethodOp(serviceName, methodInfo, RequestMethod.GET));
+            case POST -> new PathItem()
+                    .post(createServiceMethodOp(serviceName, methodInfo, RequestMethod.POST));
+        };
     }
 
     protected Operation createServiceMethodOp(String service, RestMethodInfo methodInfo, RequestMethod requestMethod) {


### PR DESCRIPTION
Fixes #4264

Examples:

### Only POST allowed:

```java
@RestService("petclinic_OwnerRegistrationService")
public class OwnerRegistrationService {

    @Autowired
    protected DataManager dataManager;

    @RestMethod(value = "registerOwner", httpMethods = RestHttpMethod.POST)
    public Owner registerOwner(String firstName, String lastName) {
        return dataManager.create(Owner.class);
    };
}
```
leads to the following OpenAPI spec:

![CleanShot 2025-03-15 at 10 42 51@2x](https://github.com/user-attachments/assets/11df7ee2-863e-4813-9c21-a4af4bcb8ea6)


### GET allowed:


```java
@RestService("petclinic_OwnerRegistrationService")
public class OwnerRegistrationService {

    @Autowired
    protected DataManager dataManager;

    @RestMethod(value = "registerOwner", httpMethods = RestHttpMethod.GET)
    public Owner registerOwner(String firstName, String lastName) {
        return dataManager.create(Owner.class);
    };
}
```

leads to the following OpenAPI spec:
![CleanShot 2025-03-15 at 10 45 37@2x](https://github.com/user-attachments/assets/1e602cd4-6bcb-463e-b0fc-7850091a6f79)


### POST & GET allowed:

```java
@RestService("petclinic_OwnerRegistrationService")
public class OwnerRegistrationService {

    @Autowired
    protected DataManager dataManager;

    @RestMethod(value = "registerOwner", httpMethods = {RestHttpMethod.POST, RestHttpMethod.GET})
    public Owner registerOwner(String firstName, String lastName) {
        return dataManager.create(Owner.class);
    };
}
```

leads to the following OpenAPI spec:

![CleanShot 2025-03-15 at 10 57 23@2x](https://github.com/user-attachments/assets/7d3abb84-f428-4103-9776-fca599cbb8fb)
