### PR TITLE
Séparateurs de milliers et décimal

### DIFF
--- a/jmix-translations/content/io/jmix/core/messages_fr.properties
+++ b/jmix-translations/content/io/jmix/core/messages_fr.properties
@@ -9,10 +9,10 @@ datatype.unparseableNumber.message = Nombre au mauvais format '%s'
 datatype.unparseableUuid.message = UUID au mauvais format '%s'
 dateFormat = dd/MM/yyyy
 dateTimeFormat = dd/MM/yyyy HH:mm
-decimalFormat = #,##0.00
-doubleFormat = #,##0.###
+decimalFormat = # ##0,00
+doubleFormat = # ##0,###
 falseString = False
-integerFormat = #,##0
+integerFormat = # ##0
 jakarta.validation.constraints.AssertFalse.message = doit être faux
 jakarta.validation.constraints.AssertTrue.message = doit être vrai
 jakarta.validation.constraints.DecimalMax.message = doit être inférieur à ${inclusive == true ? 'ou égale à ' : ''}{value}


### PR DESCRIPTION
Séparateurs de milliers et décimal pour la France, norme ISO 80000-1:2022.