### PR TITLE
Cannot put newLine symbol into report string arguments #2142

### DIFF
--- a/jmix-reports/reports/src/main/java/io/jmix/reports/ReportsConfiguration.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/ReportsConfiguration.java
@@ -21,6 +21,8 @@ import io.jmix.core.annotation.JmixModule;
 import io.jmix.data.DataConfiguration;
 import io.jmix.eclipselink.EclipselinkConfiguration;
 import io.jmix.reports.libintegration.*;
+import io.jmix.reports.yarg.formatters.impl.docx.MultilineTextProcessor;
+import io.jmix.reports.yarg.formatters.impl.docx.MultilineTextProcessorImpl;
 import io.jmix.reports.yarg.loaders.QueryLoaderPreprocessor;
 import io.jmix.reports.yarg.loaders.ReportDataLoader;
 import io.jmix.reports.yarg.loaders.factory.ReportLoaderFactory;
@@ -220,5 +222,10 @@ public class ReportsConfiguration {
     @Bean("report_StringConverter")
     public JmixObjectToStringConverter objectToStringConverter() {
         return new JmixObjectToStringConverter();
+    }
+
+    @Bean("report_MultilineTextProcessor")
+    public MultilineTextProcessor multilineTextProcessor() {
+        return new MultilineTextProcessorImpl();
     }
 }

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/ReportsProperties.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/ReportsProperties.java
@@ -144,6 +144,11 @@ public class ReportsProperties {
      */
     boolean formulasPostProcessingEvaluationEnabled;
 
+    /**
+     * If enabled - all string parameters with multi-line values will be written with preserved line breaks in the DOCX report.
+     */
+    boolean multilineStringsProcessingEnabled;
+
     public ReportsProperties(@DefaultValue("/") String officePath,
                              @DefaultValue({"8100", "8101", "8102", "8103"}) List<Integer> officePorts,
                              @DefaultValue("20") int docFormatterTimeout,
@@ -166,7 +171,8 @@ public class ReportsProperties {
                              @DefaultValue("1000") int historyCleanupMaxItemsPerReport,
                              @DefaultValue("3") int countOfRetry,
                              @DefaultValue("false") boolean useOfficeForDocumentConversion,
-                             @DefaultValue("false") boolean formulasPostProcessingEvaluationEnabled) {
+                             @DefaultValue("false") boolean formulasPostProcessingEvaluationEnabled,
+                             @DefaultValue("false") boolean multilineStringsProcessingEnabled) {
         this.officePath = officePath;
         this.officePorts = officePorts;
         this.docFormatterTimeout = docFormatterTimeout;
@@ -190,6 +196,7 @@ public class ReportsProperties {
         this.countOfRetry = countOfRetry;
         this.useOfficeForDocumentConversion = useOfficeForDocumentConversion;
         this.formulasPostProcessingEvaluationEnabled = formulasPostProcessingEvaluationEnabled;
+        this.multilineStringsProcessingEnabled = multilineStringsProcessingEnabled;
     }
 
     /**
@@ -342,5 +349,12 @@ public class ReportsProperties {
      */
     public boolean isFormulasPostProcessingEvaluationEnabled() {
         return formulasPostProcessingEvaluationEnabled;
+    }
+
+    /**
+     * @see #multilineStringsProcessingEnabled
+     */
+    public boolean isMultilineStringsProcessingEnabled() {
+        return multilineStringsProcessingEnabled;
     }
 }

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixDocxFormatter.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixDocxFormatter.java
@@ -16,17 +16,54 @@
 
 package io.jmix.reports.libintegration;
 
+import io.jmix.reports.ReportsProperties;
 import io.jmix.reports.yarg.formatters.factory.FormatterFactoryInput;
 import io.jmix.reports.yarg.formatters.impl.DocxFormatter;
+import io.jmix.reports.yarg.formatters.impl.docx.MultilineTextProcessor;
+import io.jmix.reports.yarg.formatters.impl.docx.TableManager;
+import io.jmix.reports.yarg.formatters.impl.docx.TextWrapper;
+import org.docx4j.wml.Text;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
 
 @Component("report_JmixDocxFormatter")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
 public class JmixDocxFormatter extends DocxFormatter {
 
+    @Autowired
+    protected ReportsProperties reportsProperties;
+
+    @Autowired
+    protected MultilineTextProcessor multilineTextProcessor;
+
     public JmixDocxFormatter(FormatterFactoryInput formatterFactoryInput) {
         super(formatterFactoryInput);
+    }
+
+    @Override
+    protected void handleMultilineTexts() {
+        if (reportsProperties.isMultilineStringsProcessingEnabled()) {
+            Set<TextWrapper> texts = documentWrapper.getTexts();
+            texts.forEach(textWrapper -> multilineTextProcessor.process(textWrapper));
+
+            for (TableManager table : documentWrapper.getTables()) {
+                List<Text> multilineTexts = table.getMultilineTexts();
+                multilineTexts.forEach(text -> multilineTextProcessor.process(text));
+            }
+        }
+    }
+
+
+    @Override
+    protected boolean isSupportedMultilineText(Text text) {
+        if (!reportsProperties.isMultilineStringsProcessingEnabled()) {
+            return false;
+        }
+        return super.isSupportedMultilineText(text);
     }
 }

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/DocxFormatter.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/DocxFormatter.java
@@ -15,11 +15,10 @@
  */
 package io.jmix.reports.yarg.formatters.impl;
 
+import io.jmix.reports.yarg.formatters.factory.FormatterFactoryInput;
 import io.jmix.reports.yarg.formatters.impl.docx.*;
 import io.jmix.reports.yarg.formatters.impl.inline.ContentInliner;
 import io.jmix.reports.yarg.formatters.impl.xls.DocumentConverter;
-import io.jmix.reports.yarg.formatters.impl.docx.DocumentWrapper;
-import io.jmix.reports.yarg.formatters.factory.FormatterFactoryInput;
 import io.jmix.reports.yarg.structure.BandData;
 import io.jmix.reports.yarg.structure.ReportFieldFormat;
 import io.jmix.reports.yarg.structure.ReportOutputType;
@@ -88,6 +87,8 @@ public class DocxFormatter extends AbstractFormatter {
 
         handleUrls();
 
+        handleMultilineTexts();
+
         updateTableOfContents();
 
         saveAndClose();
@@ -120,6 +121,10 @@ public class DocxFormatter extends AbstractFormatter {
     protected void handleUrls() {
         UrlVisitor urlVisitor = new UrlVisitor(new io.jmix.reports.yarg.formatters.impl.DocxFormatterDelegate(this), wordprocessingMLPackage.getMainDocumentPart());
         new TraversalUtil(wordprocessingMLPackage.getMainDocumentPart(), urlVisitor);
+    }
+
+    protected void handleMultilineTexts() {
+
     }
 
     protected void loadDocument() {
@@ -283,5 +288,11 @@ public class DocxFormatter extends AbstractFormatter {
         byte[] bytes = new byte[bb.limit()];
         bb.get(bytes);
         return new String(bytes, "UTF-8");
+    }
+
+    protected boolean isSupportedMultilineText(Text text) {
+        String value = text.getValue();
+
+        return value != null && value.lines().count() > 1;
     }
 }

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/DocxFormatterDelegate.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/DocxFormatterDelegate.java
@@ -123,4 +123,8 @@ public class DocxFormatterDelegate {
 
         return result;
     }
+
+    public boolean isSupportedMultilineText(Text text) {
+        return docxFormatter.isSupportedMultilineText(text);
+    }
 }

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/docx/MultilineTextProcessor.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/docx/MultilineTextProcessor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.reports.yarg.formatters.impl.docx;
+
+import org.docx4j.wml.Text;
+
+/**
+ * Processes texts that have a multiline text as value.
+ */
+public interface MultilineTextProcessor {
+
+    /**
+     * Replaces the specified text with the multiline text content if its value is a multiline string.
+     *
+     * @param text a text with value
+     */
+    void process(Text text);
+
+
+    /**
+     * Replaces the text from the specified wrapper with the multiline text content if its value is a multiline string.
+     *
+     * @param wrapper a wrapper for the text with a value
+     */
+    void process(TextWrapper wrapper);
+}

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/docx/MultilineTextProcessorImpl.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/docx/MultilineTextProcessorImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.reports.yarg.formatters.impl.docx;
+
+import org.docx4j.XmlUtils;
+import org.docx4j.wml.Br;
+import org.docx4j.wml.R;
+import org.docx4j.wml.Text;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MultilineTextProcessorImpl implements MultilineTextProcessor {
+
+    @Override
+    public void process(Text text) {
+        List<String> textLines = getTextLines(text);
+        if (textLines.size() < 2) {
+            return;
+        }
+
+        R parent = (R) text.getParent();
+        List<Object> multiLineContent = new ArrayList<>();
+        for (int i = 0; i < textLines.size(); i++) {
+            String lineTextValue = textLines.get(i);
+            Text lineText = createLineText(text, lineTextValue);
+
+            multiLineContent.add(lineText);
+
+            if (i < textLines.size() - 1) {
+                multiLineContent.add(new Br());
+            }
+        }
+
+        parent.getContent().remove(text);
+        parent.getContent().addAll(multiLineContent);
+    }
+
+    @Override
+    public void process(TextWrapper wrapper) {
+        process(wrapper.text);
+    }
+
+    protected Text createLineText(Text sourceText, String lineTextValue) {
+        Text text = XmlUtils.deepCopy(sourceText);
+        text.setValue(lineTextValue);
+
+        return text;
+    }
+
+    protected List<String> getTextLines(Text text) {
+        String value = text.getValue();
+
+        return value != null ? value.lines().toList() : List.of();
+    }
+}

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/docx/TableManager.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/docx/TableManager.java
@@ -25,6 +25,8 @@ import org.docx4j.wml.Tbl;
 import org.docx4j.wml.Text;
 import org.docx4j.wml.Tr;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
@@ -37,6 +39,7 @@ public class TableManager {
     protected Tr rowWithAliases = null;
     protected String bandName = null;
     protected boolean skipIt = false;
+    protected List<Text> multilineTexts = new ArrayList<>();
 
     TableManager(DocxFormatterDelegate docxFormatter, Tbl tbl) {
         this.docxFormatter = docxFormatter;
@@ -83,7 +86,7 @@ public class TableManager {
                 //todo eude the following logic is not full and ignores situation when in 1 text we have both table and not table aliases
                 boolean hasTableAliases = false;
                 Matcher matcher = AbstractFormatter.UNIVERSAL_ALIAS_PATTERN.matcher(textValue);
-                while(matcher.find()) {
+                while (matcher.find()) {
                     AbstractFormatter.BandPathAndParameterName bandAndParameter = docxFormatter.separateBandNameAndParameterName(matcher.group(1));
                     if (isBlank(bandAndParameter.getBandPath()) || isBlank(bandAndParameter.getParameterName())) {
                         hasTableAliases = true;
@@ -93,6 +96,9 @@ public class TableManager {
                 if (hasTableAliases) {
                     String resultString = docxFormatter.insertBandDataToString(band, textValue);
                     text.setValue(resultString);
+                    if (docxFormatter.isSupportedMultilineText(text)) {
+                        multilineTexts.add(text);
+                    }
                 }
                 text.setSpace("preserve");
             }
@@ -143,5 +149,9 @@ public class TableManager {
 
     public void setSkipIt(boolean skipIt) {
         this.skipIt = skipIt;
+    }
+
+    public List<Text> getMultilineTexts() {
+        return multilineTexts;
     }
 }


### PR DESCRIPTION
Add application property `jmix.reports.multilineStringsProcessingEnabled`. Default value: false. If enabled, line breaks in the parameter values are written to the executed report document.