### PR TITLE
Annotated interfaces for calling REST services

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/CoreConfiguration.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/CoreConfiguration.java
@@ -64,7 +64,7 @@ public class CoreConfiguration {
     }
 
     @Bean("core_Modules")
-    public JmixModules modules(JmixModulesProcessor processor) {
+    public static JmixModules modules(JmixModulesProcessor processor) {
         return processor.getJmixModules();
     }
 

--- a/jmix-rest/sample-rest/src/main/java/io/jmix/samples/rest/service/RestTestService.java
+++ b/jmix-rest/sample-rest/src/main/java/io/jmix/samples/rest/service/RestTestService.java
@@ -16,6 +16,7 @@
 
 package io.jmix.samples.rest.service;
 
+import io.jmix.core.FileRef;
 import io.jmix.samples.rest.entity.ModelEntity;
 import io.jmix.samples.rest.entity.driver.Car;
 import io.jmix.samples.rest.entity.driver.NotPersistentStringIdEntity;
@@ -106,4 +107,6 @@ public interface RestTestService {
     String overloadedMethodWithOptionalArgs(String arg1);
 
     String overloadedMethodWithOptionalArgs(String arg1, String arg2);
+
+    FileRef fileRefMethod(FileRef fileRef);
 }

--- a/jmix-rest/sample-rest/src/main/java/io/jmix/samples/rest/service/RestTestServiceBean.java
+++ b/jmix-rest/sample-rest/src/main/java/io/jmix/samples/rest/service/RestTestServiceBean.java
@@ -16,10 +16,7 @@
 
 package io.jmix.samples.rest.service;
 
-import io.jmix.core.DataManager;
-import io.jmix.core.FetchPlan;
-import io.jmix.core.FetchPlanRepository;
-import io.jmix.core.Metadata;
+import io.jmix.core.*;
 import io.jmix.core.entity.EntityValues;
 import io.jmix.core.validation.CustomValidationException;
 import io.jmix.samples.rest.controller.CustomHttpClientErrorException;
@@ -293,5 +290,10 @@ public class RestTestServiceBean implements RestTestService {
     @Override
     public String overloadedMethodWithOptionalArgs(String arg1, String arg2) {
         return "two args";
+    }
+
+    @Override
+    public FileRef fileRefMethod(FileRef fileRef) {
+        return fileRef;
     }
 }

--- a/jmix-rest/sample-rest/src/test/resources/test_support/rest-services.xml
+++ b/jmix-rest/sample-rest/src/test/resources/test_support/rest-services.xml
@@ -128,6 +128,10 @@
         <method name="overloadedMethodWithOptionalArgs">
             <param name="arg1"/>
         </method>
+
+        <method name="fileRefMethod">
+            <param name="fileRef"/>
+        </method>
     </service>
 
     <service name="jmix_OtherRestTestService">

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/RestDsConfiguration.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/RestDsConfiguration.java
@@ -17,8 +17,11 @@
 package io.jmix.restds;
 
 import io.jmix.core.CoreConfiguration;
+import io.jmix.core.JmixModules;
 import io.jmix.core.annotation.JmixModule;
+import io.jmix.restds.impl.service.RemoteServiceBeanFactoryPostProcessor;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -27,4 +30,9 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationPropertiesScan
 @JmixModule(dependsOn = {CoreConfiguration.class})
 public class RestDsConfiguration {
+
+    @Bean
+    public static RemoteServiceBeanFactoryPostProcessor remoteServiceBeanFactoryPostProcessor(JmixModules jmixModules) {
+        return new RemoteServiceBeanFactoryPostProcessor(jmixModules);
+    }
 }

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/annotation/RemoteService.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/annotation/RemoteService.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.restds.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+@Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface RemoteService {
+
+    String store();
+}

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/annotation/RemoteService.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/annotation/RemoteService.java
@@ -20,9 +20,20 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+/**
+ * Indicates that the annotated interface is a service exposed through the generic REST API.
+ */
 @Retention(java.lang.annotation.RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface RemoteService {
 
+    /**
+     * Name of the REST data store.
+     */
     String store();
+
+    /**
+     * Name of the remote service. Required if the remote service name is different from the interface name.
+     */
+    String remoteName() default "";
 }

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceBeanFactoryPostProcessor.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceBeanFactoryPostProcessor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.restds.impl.service;
+
+import io.jmix.core.JmixModuleDescriptor;
+import io.jmix.core.JmixModules;
+import io.jmix.restds.annotation.RemoteService;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+
+public class RemoteServiceBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
+
+    private final JmixModules jmixModules;
+
+    public RemoteServiceBeanFactoryPostProcessor(JmixModules jmixModules) {
+        this.jmixModules = jmixModules;
+    }
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        // Create scanner that includes interfaces
+        ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false) {
+            @Override
+            protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
+                return beanDefinition.getMetadata().isInterface();
+            }
+        };
+        scanner.addIncludeFilter(new AnnotationTypeFilter(RemoteService.class));
+
+        jmixModules.getAll().stream()
+                .map(JmixModuleDescriptor::getBasePackage)
+                .forEach(basePackage -> {
+                    scanner.findCandidateComponents(basePackage).forEach(beanDefinition -> {
+                        try {
+                            Class<?> serviceInterface = Class.forName(beanDefinition.getBeanClassName());
+                            registerRemoteServiceBean((BeanDefinitionRegistry) beanFactory, serviceInterface);
+                        } catch (ClassNotFoundException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                });
+    }
+
+    private void registerRemoteServiceBean(BeanDefinitionRegistry registry, Class<?> serviceInterface) {
+        GenericBeanDefinition beanDefinition = new GenericBeanDefinition();
+        beanDefinition.setBeanClass(RemoteServiceProxyFactoryBean.class);
+        beanDefinition.getPropertyValues().add("serviceInterface", serviceInterface);
+
+        String beanName = serviceInterface.getSimpleName().substring(0, 1).toLowerCase() + 
+                         serviceInterface.getSimpleName().substring(1);
+        registry.registerBeanDefinition(beanName, beanDefinition);
+    }
+}

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceInvoker.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceInvoker.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.restds.impl.service;
+
+import io.jmix.core.EntitySerialization;
+import io.jmix.core.Metadata;
+import io.jmix.core.entity.EntityValues;
+import io.jmix.core.metamodel.datatype.Datatype;
+import io.jmix.core.metamodel.datatype.DatatypeRegistry;
+import io.jmix.restds.annotation.RemoteService;
+import io.jmix.restds.util.RestDataStoreUtils;
+import org.springframework.core.env.Environment;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.text.ParseException;
+import java.util.Collection;
+
+@Component("restds_RemoteServiceInvoker")
+public class RemoteServiceInvoker {
+
+    protected final Environment environment;
+    protected final RestDataStoreUtils restDataStoreUtils;
+    protected final EntitySerialization entitySerialization;
+    protected final Metadata metadata;
+    protected final DatatypeRegistry datatypeRegistry;
+
+    public RemoteServiceInvoker(Environment environment, RestDataStoreUtils restDataStoreUtils, EntitySerialization entitySerialization, Metadata metadata, DatatypeRegistry datatypeRegistry) {
+        this.environment = environment;
+        this.restDataStoreUtils = restDataStoreUtils;
+        this.entitySerialization = entitySerialization;
+        this.metadata = metadata;
+        this.datatypeRegistry = datatypeRegistry;
+    }
+
+    @Nullable
+    public Object invokeServiceMethod(Class<?> serviceInterface, Method method, @Nullable Object[] args) {
+        RemoteService remoteServiceAnnotation = serviceInterface.getAnnotation(RemoteService.class);
+        if (remoteServiceAnnotation == null)
+            throw new IllegalStateException("RemoteService annotation is not found for interface " + serviceInterface);
+        String storeName = remoteServiceAnnotation.store();
+
+        RestClient restClient = restDataStoreUtils.getRestClient(storeName);
+
+        String resultJson = restClient.post()
+                .uri(getServiceUri(serviceInterface, storeName, method))
+                .body(getParamsJson(entitySerialization, method, args))
+                .retrieve()
+                .body(String.class);
+
+        return method.getReturnType() == void.class ? null : getResultObject(entitySerialization, method, resultJson);
+    }
+
+    protected String getServiceUri(Class<?> serviceInterface, String storeName, Method method) {
+        String basePath = environment.getProperty(storeName + ".basePath", "/rest");
+        String servicePath = environment.getProperty(storeName + ".servicesPath", "/services");
+        return basePath + servicePath + "/" + serviceInterface.getSimpleName() + "/" + method.getName();
+    }
+
+    protected String getParamsJson(EntitySerialization entitySerialization, Method method, @Nullable Object[] args) {
+        if (args == null) {
+            return "{}";
+        }
+
+        Parameter[] parameters = method.getParameters();
+        if (parameters.length != args.length)
+            throw new IllegalArgumentException("Number of parameters does not match number of arguments");
+
+        StringBuilder paramsJson = new StringBuilder("{");
+        for (int i = 0; i < parameters.length; i++) {
+            String paramName = parameters[i].getName();
+            Object paramValue = args[i];
+            String paramJson;
+
+            if (paramValue == null) {
+                paramJson = "null";
+            } else if (EntityValues.isEntity(paramValue)) {
+                paramJson = entitySerialization.toJson(paramValue);
+            } else {
+                Datatype<?> datatype = datatypeRegistry.find(paramValue.getClass());
+                if (datatype != null) {
+                    String formatted = datatype.format(paramValue);
+                    if (paramValue instanceof Boolean || paramValue instanceof Number) {
+                        paramJson = formatted;
+                    } else {
+                        paramJson = "\"" + formatted + "\"";
+                    }
+                } else {
+                    paramJson = entitySerialization.objectToJson(paramValue);
+                }
+            }
+            paramsJson.append("\"").append(paramName).append("\":").append(paramJson);
+            if (i < parameters.length - 1) {
+                paramsJson.append(",");
+            }
+        }
+        paramsJson.append("}");
+
+        return paramsJson.toString();
+    }
+
+    @Nullable
+    protected Object getResultObject(EntitySerialization entitySerialization, Method method, @Nullable String resultJson) {
+        if (resultJson == null)
+            return null;
+
+        Object result;
+
+        Type returnType = method.getGenericReturnType();
+        Class<?> rawReturnType = method.getReturnType();
+
+        try {
+            if (isEntity(rawReturnType)) {
+                result = entitySerialization.entityFromJson(resultJson, null);
+            } else if (isCollectionOfEntities(returnType)) {
+                result = entitySerialization.entitiesCollectionFromJson(resultJson, null);
+            } else {
+                Datatype<?> datatype = datatypeRegistry.find(rawReturnType);
+                if (datatype != null) {
+                    result = datatype.parse(resultJson);
+                } else {
+                    if (rawReturnType.isPrimitive())
+                        result = deserializePrimitive(resultJson, rawReturnType);
+                    else
+                        result = entitySerialization.objectFromJson(resultJson, returnType);
+                }
+            }
+        } catch (ParseException e) {
+            throw new RuntimeException("Error deserializing response", e);
+        }
+
+        return result;
+    }
+
+    protected boolean isEntity(Class<?> aClass) {
+        return metadata.findClass(aClass) != null;
+    }
+
+    protected boolean isCollectionOfEntities(Type type) {
+        if (!(type instanceof ParameterizedType parameterizedType)) {
+            return false;
+        }
+        // Check if raw type is a collection
+        Class<?> rawType = (Class<?>) parameterizedType.getRawType();
+        if (!Collection.class.isAssignableFrom(rawType)) {
+            return false;
+        }
+        // Check if type argument is an entity
+        Type[] typeArgs = parameterizedType.getActualTypeArguments();
+        if (typeArgs.length != 1 || !(typeArgs[0] instanceof Class<?>)) {
+            return false;
+        }
+        return isEntity((Class<?>) typeArgs[0]);
+    }
+
+    @Nullable
+    protected Object deserializePrimitive(@Nullable String json, Class<?> type) {
+        if (json == null)
+            return null;
+
+        if (type == boolean.class) {
+            return Boolean.parseBoolean(json);
+        } else if (type == int.class) {
+            return Integer.parseInt(json);
+        } else if (type == long.class) {
+            return Long.parseLong(json);
+        } else if (type == double.class) {
+            return Double.parseDouble(json);
+        } else if (type == float.class) {
+            return Float.parseFloat(json);
+        } else if (type == short.class) {
+            return Short.parseShort(json);
+        } else if (type == byte.class) {
+            return Byte.parseByte(json);
+        } else if (type == char.class) {
+            // Assuming char is represented as a single-character string
+            return json.isEmpty() ? '\0' : json.charAt(0);
+        }
+        // Should not reach here
+        throw new IllegalArgumentException("Unsupported primitive type: " + type.getName());
+    }
+}

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceInvoker.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceInvoker.java
@@ -58,11 +58,13 @@ public class RemoteServiceInvoker {
         if (remoteServiceAnnotation == null)
             throw new IllegalStateException("RemoteService annotation is not found for interface " + serviceInterface);
         String storeName = remoteServiceAnnotation.store();
+        String serviceName = remoteServiceAnnotation.remoteName().isEmpty() ?
+                serviceInterface.getSimpleName() : remoteServiceAnnotation.remoteName();
 
         RestClient restClient = restDataStoreUtils.getRestClient(storeName);
 
         String resultJson = restClient.post()
-                .uri(getServiceUri(serviceInterface, storeName, method))
+                .uri(getServiceUri(serviceName, storeName, method))
                 .body(getParamsJson(entitySerialization, method, args))
                 .retrieve()
                 .body(String.class);
@@ -70,10 +72,10 @@ public class RemoteServiceInvoker {
         return method.getReturnType() == void.class ? null : getResultObject(entitySerialization, method, resultJson);
     }
 
-    protected String getServiceUri(Class<?> serviceInterface, String storeName, Method method) {
+    protected String getServiceUri(String serviceName, String storeName, Method method) {
         String basePath = environment.getProperty(storeName + ".basePath", "/rest");
         String servicePath = environment.getProperty(storeName + ".servicesPath", "/services");
-        return basePath + servicePath + "/" + serviceInterface.getSimpleName() + "/" + method.getName();
+        return basePath + servicePath + "/" + serviceName + "/" + method.getName();
     }
 
     protected String getParamsJson(EntitySerialization entitySerialization, Method method, @Nullable Object[] args) {

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceProxyFactoryBean.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceProxyFactoryBean.java
@@ -1,26 +1,34 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.jmix.restds.impl.service;
 
-import io.jmix.core.EntitySerialization;
-import io.jmix.core.Metadata;
-import io.jmix.core.metamodel.datatype.Datatype;
-import io.jmix.core.metamodel.datatype.DatatypeRegistry;
-import io.jmix.restds.annotation.RemoteService;
-import io.jmix.restds.util.RestDataStoreUtils;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.web.client.RestClient;
+import org.springframework.lang.Nullable;
 
-import java.lang.reflect.*;
-import java.text.ParseException;
-import java.util.Collection;
-
-import static io.jmix.core.entity.EntityValues.isEntity;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
 
 public class RemoteServiceProxyFactoryBean implements FactoryBean<Object>, ApplicationContextAware {
 
-    private Class<?> serviceInterface;
-    private ApplicationContext applicationContext;
+    protected Class<?> serviceInterface;
+    protected ApplicationContext applicationContext;
 
     public void setServiceInterface(Class<?> serviceInterface) {
         this.serviceInterface = serviceInterface;
@@ -53,155 +61,9 @@ public class RemoteServiceProxyFactoryBean implements FactoryBean<Object>, Appli
         );
     }
 
-    private Object invokeServiceMethod(Method method, Object[] args) {
-        RestDataStoreUtils restDataStoreUtils = applicationContext.getBean(RestDataStoreUtils.class);
-        EntitySerialization entitySerialization = applicationContext.getBean(EntitySerialization.class);
-
-        RemoteService remoteServiceAnnotation = serviceInterface.getAnnotation(RemoteService.class);
-        if (remoteServiceAnnotation == null)
-            throw new IllegalStateException("RemoteService annotation is not found for interface " + serviceInterface);
-        String storeName = remoteServiceAnnotation.store();
-
-        RestClient restClient = restDataStoreUtils.getRestClient(storeName);
-
-        String resultJson = restClient.post()
-                .uri(getServiceUri(storeName, method))
-                .body(getParamsJson(entitySerialization, method, args))
-                .retrieve()
-                .body(String.class);
-
-        return method.getReturnType() == void.class ? null : getResultObject(entitySerialization, method, resultJson);
-    }
-
-    private String getServiceUri(String storeName, Method method) {
-        String basePath = applicationContext.getEnvironment().getProperty(storeName + ".basePath", "/rest");
-        String servicePath = applicationContext.getEnvironment().getProperty(storeName + ".servicesPath", "/services");
-        return basePath + servicePath + "/" + serviceInterface.getSimpleName() + "/" + method.getName();
-    }
-
-    private String getParamsJson(EntitySerialization entitySerialization, Method method, Object[] args) {
-        if (args == null) {
-            return "{}";
-        }
-
-        Parameter[] parameters = method.getParameters();
-        if (parameters.length != args.length)
-            throw new IllegalArgumentException("Number of parameters does not match number of arguments");
-
-        StringBuilder paramsJson = new StringBuilder("{");
-        for (int i = 0; i < parameters.length; i++) {
-            String paramName = parameters[i].getName();
-            Object paramValue = args[i];
-            String paramJson;
-
-            if (paramValue == null) {
-                paramJson = "null";
-            } else if (isEntity(paramValue)) {
-                paramJson = entitySerialization.toJson(paramValue);
-            } else {
-                Datatype<?> datatype = getDatatypeRegistry().find(paramValue.getClass());
-                if (datatype != null) {
-                    String formatted = datatype.format(paramValue);
-                    if (paramValue instanceof Boolean || paramValue instanceof Number) {
-                        paramJson = formatted;
-                    } else {
-                        paramJson = "\"" + formatted + "\"";
-                    }
-                } else {
-                    paramJson = entitySerialization.objectToJson(paramValue);
-                }
-            }
-            paramsJson.append("\"").append(paramName).append("\":").append(paramJson);
-            if (i < parameters.length - 1) {
-                paramsJson.append(",");
-            }
-        }
-        paramsJson.append("}");
-
-        return paramsJson.toString();
-    }
-
-    private Object getResultObject(EntitySerialization entitySerialization, Method method, String resultJson) {
-        Object result;
-
-        Type returnType = method.getGenericReturnType();
-        Class<?> rawReturnType = method.getReturnType();
-
-        try {
-            if (isEntityType(rawReturnType)) {
-                result = entitySerialization.entityFromJson(resultJson, null);
-            } else if (isCollectionOfEntities(returnType)) {
-                result = entitySerialization.entitiesCollectionFromJson(resultJson, null);
-            } else {
-                Datatype<?> datatype = getDatatypeRegistry().find(rawReturnType);
-                if (datatype != null) {
-                    result = datatype.parse(resultJson);
-                } else {
-                    if (rawReturnType.isPrimitive())
-                        result = deserializePrimitive(resultJson, rawReturnType);
-                    else
-                        result = entitySerialization.objectFromJson(resultJson, returnType);
-                }
-            }
-        } catch (ParseException e) {
-            throw new RuntimeException("Error deserializing response", e);
-        }
-
-        return result;
-    }
-
-    private boolean isEntityType(Class<?> aClass) {
-        return getMetadata().findClass(aClass) != null;
-    }
-
-    private boolean isCollectionOfEntities(Type type) {
-        if (!(type instanceof ParameterizedType parameterizedType)) {
-            return false;
-        }
-        // Check if raw type is a collection
-        Class<?> rawType = (Class<?>) parameterizedType.getRawType();
-        if (!Collection.class.isAssignableFrom(rawType)) {
-            return false;
-        }
-        // Check if type argument is an entity
-        Type[] typeArgs = parameterizedType.getActualTypeArguments();
-        if (typeArgs.length != 1 || !(typeArgs[0] instanceof Class<?>)) {
-            return false;
-        }
-        return isEntityType((Class<?>) typeArgs[0]);
-    }
-
-    private Object deserializePrimitive(String json, Class<?> type) {
-        if (json == null)
-            return null;
-
-        if (type == boolean.class) {
-            return Boolean.parseBoolean(json);
-        } else if (type == int.class) {
-            return Integer.parseInt(json);
-        } else if (type == long.class) {
-            return Long.parseLong(json);
-        } else if (type == double.class) {
-            return Double.parseDouble(json);
-        } else if (type == float.class) {
-            return Float.parseFloat(json);
-        } else if (type == short.class) {
-            return Short.parseShort(json);
-        } else if (type == byte.class) {
-            return Byte.parseByte(json);
-        } else if (type == char.class) {
-            // Assuming char is represented as a single-character string
-            return json.isEmpty() ? '\0' : json.charAt(0);
-        }
-        // Should not reach here
-        throw new IllegalArgumentException("Unsupported primitive type: " + type.getName());
-    }
-
-    private Metadata getMetadata() {
-        return applicationContext.getBean(Metadata.class);
-    }
-
-    private DatatypeRegistry getDatatypeRegistry() {
-        return applicationContext.getBean(DatatypeRegistry.class);
+    @Nullable
+    protected Object invokeServiceMethod(Method method, Object[] args) {
+        RemoteServiceInvoker serviceInvoker = applicationContext.getBean(RemoteServiceInvoker.class);
+        return serviceInvoker.invokeServiceMethod(serviceInterface, method, args);
     }
 }

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceProxyFactoryBean.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceProxyFactoryBean.java
@@ -1,0 +1,207 @@
+package io.jmix.restds.impl.service;
+
+import io.jmix.core.EntitySerialization;
+import io.jmix.core.Metadata;
+import io.jmix.core.metamodel.datatype.Datatype;
+import io.jmix.core.metamodel.datatype.DatatypeRegistry;
+import io.jmix.restds.annotation.RemoteService;
+import io.jmix.restds.util.RestDataStoreUtils;
+import org.springframework.beans.factory.FactoryBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.web.client.RestClient;
+
+import java.lang.reflect.*;
+import java.text.ParseException;
+import java.util.Collection;
+
+import static io.jmix.core.entity.EntityValues.isEntity;
+
+public class RemoteServiceProxyFactoryBean implements FactoryBean<Object>, ApplicationContextAware {
+
+    private Class<?> serviceInterface;
+    private ApplicationContext applicationContext;
+
+    public void setServiceInterface(Class<?> serviceInterface) {
+        this.serviceInterface = serviceInterface;
+    }
+
+    public void setApplicationContext(ApplicationContext applicationContext) {
+        this.applicationContext = applicationContext;
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return serviceInterface;
+    }
+
+    @Override
+    public Object getObject() {
+        InvocationHandler handler = (proxy, method, args) ->
+                switch (method.getName()) {
+                    case "equals" -> proxy == args[0];
+                    case "hashCode" -> System.identityHashCode(proxy);
+                    case "toString" ->
+                            proxy.getClass().getName() + "@" + Integer.toHexString(System.identityHashCode(proxy));
+                    default -> invokeServiceMethod(method, args);
+                };
+
+        return Proxy.newProxyInstance(
+                serviceInterface.getClassLoader(),
+                new Class[]{ serviceInterface },
+                handler
+        );
+    }
+
+    private Object invokeServiceMethod(Method method, Object[] args) {
+        RestDataStoreUtils restDataStoreUtils = applicationContext.getBean(RestDataStoreUtils.class);
+        EntitySerialization entitySerialization = applicationContext.getBean(EntitySerialization.class);
+
+        RemoteService remoteServiceAnnotation = serviceInterface.getAnnotation(RemoteService.class);
+        if (remoteServiceAnnotation == null)
+            throw new IllegalStateException("RemoteService annotation is not found for interface " + serviceInterface);
+        String storeName = remoteServiceAnnotation.store();
+
+        RestClient restClient = restDataStoreUtils.getRestClient(storeName);
+
+        String resultJson = restClient.post()
+                .uri(getServiceUri(storeName, method))
+                .body(getParamsJson(entitySerialization, method, args))
+                .retrieve()
+                .body(String.class);
+
+        return method.getReturnType() == void.class ? null : getResultObject(entitySerialization, method, resultJson);
+    }
+
+    private String getServiceUri(String storeName, Method method) {
+        String basePath = applicationContext.getEnvironment().getProperty(storeName + ".basePath", "/rest");
+        String servicePath = applicationContext.getEnvironment().getProperty(storeName + ".servicesPath", "/services");
+        return basePath + servicePath + "/" + serviceInterface.getSimpleName() + "/" + method.getName();
+    }
+
+    private String getParamsJson(EntitySerialization entitySerialization, Method method, Object[] args) {
+        if (args == null) {
+            return "{}";
+        }
+
+        Parameter[] parameters = method.getParameters();
+        if (parameters.length != args.length)
+            throw new IllegalArgumentException("Number of parameters does not match number of arguments");
+
+        StringBuilder paramsJson = new StringBuilder("{");
+        for (int i = 0; i < parameters.length; i++) {
+            String paramName = parameters[i].getName();
+            Object paramValue = args[i];
+            String paramJson;
+
+            if (paramValue == null) {
+                paramJson = "null";
+            } else if (isEntity(paramValue)) {
+                paramJson = entitySerialization.toJson(paramValue);
+            } else {
+                Datatype<?> datatype = getDatatypeRegistry().find(paramValue.getClass());
+                if (datatype != null) {
+                    String formatted = datatype.format(paramValue);
+                    if (paramValue instanceof Boolean || paramValue instanceof Number) {
+                        paramJson = formatted;
+                    } else {
+                        paramJson = "\"" + formatted + "\"";
+                    }
+                } else {
+                    paramJson = entitySerialization.objectToJson(paramValue);
+                }
+            }
+            paramsJson.append("\"").append(paramName).append("\":").append(paramJson);
+            if (i < parameters.length - 1) {
+                paramsJson.append(",");
+            }
+        }
+        paramsJson.append("}");
+
+        return paramsJson.toString();
+    }
+
+    private Object getResultObject(EntitySerialization entitySerialization, Method method, String resultJson) {
+        Object result;
+
+        Type returnType = method.getGenericReturnType();
+        Class<?> rawReturnType = method.getReturnType();
+
+        try {
+            if (isEntityType(rawReturnType)) {
+                result = entitySerialization.entityFromJson(resultJson, null);
+            } else if (isCollectionOfEntities(returnType)) {
+                result = entitySerialization.entitiesCollectionFromJson(resultJson, null);
+            } else {
+                Datatype<?> datatype = getDatatypeRegistry().find(rawReturnType);
+                if (datatype != null) {
+                    result = datatype.parse(resultJson);
+                } else {
+                    if (rawReturnType.isPrimitive())
+                        result = deserializePrimitive(resultJson, rawReturnType);
+                    else
+                        result = entitySerialization.objectFromJson(resultJson, returnType);
+                }
+            }
+        } catch (ParseException e) {
+            throw new RuntimeException("Error deserializing response", e);
+        }
+
+        return result;
+    }
+
+    private boolean isEntityType(Class<?> aClass) {
+        return getMetadata().findClass(aClass) != null;
+    }
+
+    private boolean isCollectionOfEntities(Type type) {
+        if (!(type instanceof ParameterizedType parameterizedType)) {
+            return false;
+        }
+        // Check if raw type is a collection
+        Class<?> rawType = (Class<?>) parameterizedType.getRawType();
+        if (!Collection.class.isAssignableFrom(rawType)) {
+            return false;
+        }
+        // Check if type argument is an entity
+        Type[] typeArgs = parameterizedType.getActualTypeArguments();
+        if (typeArgs.length != 1 || !(typeArgs[0] instanceof Class<?>)) {
+            return false;
+        }
+        return isEntityType((Class<?>) typeArgs[0]);
+    }
+
+    private Object deserializePrimitive(String json, Class<?> type) {
+        if (json == null)
+            return null;
+
+        if (type == boolean.class) {
+            return Boolean.parseBoolean(json);
+        } else if (type == int.class) {
+            return Integer.parseInt(json);
+        } else if (type == long.class) {
+            return Long.parseLong(json);
+        } else if (type == double.class) {
+            return Double.parseDouble(json);
+        } else if (type == float.class) {
+            return Float.parseFloat(json);
+        } else if (type == short.class) {
+            return Short.parseShort(json);
+        } else if (type == byte.class) {
+            return Byte.parseByte(json);
+        } else if (type == char.class) {
+            // Assuming char is represented as a single-character string
+            return json.isEmpty() ? '\0' : json.charAt(0);
+        }
+        // Should not reach here
+        throw new IllegalArgumentException("Unsupported primitive type: " + type.getName());
+    }
+
+    private Metadata getMetadata() {
+        return applicationContext.getBean(Metadata.class);
+    }
+
+    private DatatypeRegistry getDatatypeRegistry() {
+        return applicationContext.getBean(DatatypeRegistry.class);
+    }
+}

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/package-info.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@Internal
+@NonNullApi
+package io.jmix.restds.impl.service;
+
+import io.jmix.core.annotation.Internal;
+import org.springframework.lang.NonNullApi;

--- a/jmix-restds/restds/src/test/java/remote_service/RemoteServiceTest.java
+++ b/jmix-restds/restds/src/test/java/remote_service/RemoteServiceTest.java
@@ -83,7 +83,7 @@ public class RemoteServiceTest extends BaseRestDsIntegrationTest {
     }
 
     @Test
-    void testServiceCall() {
+    void testServiceWithDifferentRemoteName() {
         customer.setContacts(null);
 
         CustomerContact contact = customerService.getPreferredContact(customer);

--- a/jmix-restds/restds/src/test/java/remote_service/RemoteServiceTest.java
+++ b/jmix-restds/restds/src/test/java/remote_service/RemoteServiceTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright 2024 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package remote_service;
+
+import io.jmix.core.DataManager;
+import io.jmix.core.FileRef;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import test_support.BaseRestDsIntegrationTest;
+import test_support.entity.ContactType;
+import test_support.entity.Customer;
+import test_support.entity.CustomerContact;
+import test_support.service.CustomerService;
+import test_support.service.SampleService;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RemoteServiceTest extends BaseRestDsIntegrationTest {
+
+    @Autowired
+    DataManager dataManager;
+
+    @Autowired
+    CustomerService customerService;
+
+    @Autowired
+    SampleService sampleService;
+
+    private Customer customer;
+    private CustomerContact contact1;
+    private CustomerContact contact2;
+
+    @BeforeEach
+    void setUp() {
+        // create customer and 2 contacts and save
+
+        customer = dataManager.create(Customer.class);
+        customer.setFirstName("John");
+        customer.setLastName("Smith");
+        customer.setEmail("john@example.com");
+        customer.setContacts(new HashSet<>());
+
+        contact1 = dataManager.create(CustomerContact.class);
+        contact1.setCustomer(customer);
+        contact1.setContactType(ContactType.PHONE);
+        contact1.setContactValue("333-333-3333");
+        contact1.setPreferred(true);
+        customer.getContacts().add(contact1);
+
+        contact2 = dataManager.create(CustomerContact.class);
+        contact2.setCustomer(customer);
+        contact2.setContactType(ContactType.EMAIL);
+        contact2.setContactValue("john@example.com");
+        customer.getContacts().add(contact2);
+
+        dataManager.save(customer);
+    }
+
+    @Test
+    void testServiceCall() {
+        customer.setContacts(null);
+
+        CustomerContact contact = customerService.getPreferredContact(customer);
+
+        assertThat(contact).isEqualTo(contact1);
+    }
+
+    @AfterEach
+    void tearDown() {
+        dataManager.remove(contact1, contact2, customer);
+    }
+
+    @Test
+    void testSimpleTypes() throws Exception {
+        sampleService.voidMethod();
+
+        String s = sampleService.stringMethod("hello");
+        assertThat(s).isEqualTo("hello");
+
+        String s1 = sampleService.stringMethod(null);
+        assertThat(s1).isNull();
+
+        boolean b = sampleService.booleanMethod(true);
+        assertThat(b).isTrue();
+
+        Boolean b1 = sampleService.booleanWrapperMethod(true);
+        assertThat(b1).isTrue();
+
+        int i = sampleService.intMethod(1);
+        assertThat(i).isEqualTo(1);
+
+        Integer i1 = sampleService.intWrapperMethod(1);
+        assertThat(i1).isEqualTo(1);
+    }
+
+    @Test
+    void testOtherTypes() throws Exception{
+        // todo
+
+//        byte[] resultBytes = sampleService.binaryMethod("hello".getBytes(StandardCharsets.UTF_8));
+//        assertThat(resultBytes).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
+
+//        FileRef fileRef = FileRef.create("fileStorage1", "/path1", "file1.txt");
+//        FileRef resultFileRef = sampleService.fileRefMethod(fileRef);
+//        assertThat(resultFileRef).isEqualTo(fileRef);
+
+//        URI uri = new URI("https://jmix.io");
+//        URI resultUri = sampleService.uriMethod(uri);
+//        assertThat(resultUri).isEqualTo(uri);
+
+        UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        UUID resultUuid = sampleService.uuidMethod(uuid);
+        assertThat(resultUuid).isEqualTo(uuid);
+    }
+
+    @Test
+    void testDates() throws Exception {
+        Date date = new SimpleDateFormat("yyyy-MM-dd HH:mm").parse("2025-04-26 18:44");
+        Date resultDate = sampleService.dateMethod(date);
+        assertThat(resultDate).isEqualTo(date);
+
+        LocalDateTime localDateTime = LocalDateTime.parse("2025-04-26T18:44");
+        LocalDateTime resultLocalDateTime = sampleService.localDateTimeMethod(localDateTime);
+        assertThat(resultLocalDateTime).isEqualTo(localDateTime);
+
+        OffsetDateTime offsetDateTime = OffsetDateTime.parse("2025-04-26T18:44+04:00");
+        OffsetDateTime resultOffsetDateTime = sampleService.offsetDateTimeMethod(offsetDateTime);
+        assertThat(resultOffsetDateTime).isEqualTo(offsetDateTime);
+
+        // todo
+//        ZonedDateTime zonedDateTime = ZonedDateTime.parse("2025-04-26T18:44+04:00[Europe/Samara]");
+//        ZonedDateTime resultZonedDateTime = sampleService.zonedDateTimeMethod(zonedDateTime);
+//        assertThat(resultZonedDateTime).isEqualTo(zonedDateTime);
+    }
+
+    @Test
+    void testEntities() {
+        Customer resultCustomer = sampleService.entityMethod(customer);
+        assertThat(resultCustomer).isNotNull();
+        assertThat(resultCustomer).isEqualTo(customer);
+
+        Customer resultCustomer1 = sampleService.entityMethod(null);
+        assertThat(resultCustomer1).isNull();
+
+        List<Customer> customers = sampleService.entityCollectionMethod(List.of(customer));
+        assertThat(customers).isNotEmpty();
+        assertThat(customers.get(0)).isEqualTo(customer);
+    }
+
+    @Test
+    void testEnums() {
+        ContactType resultEnum = sampleService.enumMethod(ContactType.PHONE);
+        assertThat(resultEnum).isEqualTo(ContactType.PHONE);
+    }
+
+    @Test
+    void testPojos() {
+        SampleService.SamplePojo pojo = new SampleService.SamplePojo();
+        pojo.setName("John");
+        pojo.setAge(25);
+
+        SampleService.SamplePojo resultPojo = sampleService.pojoMethod(pojo);
+        assertThat(resultPojo).isNotNull();
+        assertThat(resultPojo.getName()).isEqualTo("John");
+        assertThat(resultPojo.getAge()).isEqualTo(25);
+
+        SampleService.SamplePojoWithEntity pojoWithEntity = new SampleService.SamplePojoWithEntity();
+        pojoWithEntity.setName("John");
+        pojoWithEntity.setCustomer(customer);
+
+        SampleService.SamplePojoWithEntity resultPojoWithEntity = sampleService.pojoWithEntityMethod(pojoWithEntity);
+        assertThat(resultPojoWithEntity).isNotNull();
+        assertThat(resultPojoWithEntity.getName()).isEqualTo("John");
+        assertThat(resultPojoWithEntity.getCustomer()).isEqualTo(customer);
+
+        SampleService.SampleRecord record = new SampleService.SampleRecord("John", 25);
+        SampleService.SampleRecord resultRecord = sampleService.recordMethod(record);
+        assertThat(resultRecord).isEqualTo(record);
+
+        SampleService.SampleRecordWithEntity recordWithEntity = new SampleService.SampleRecordWithEntity("John", customer);
+        SampleService.SampleRecordWithEntity resultRecordWithEntity = sampleService.recordWithEntityMethod(recordWithEntity);
+        assertThat(resultRecordWithEntity).isEqualTo(recordWithEntity);
+    }
+
+    @Test
+    void testMultipleParams() {
+        SampleService.SamplePojo pojo = new SampleService.SamplePojo();
+        pojo.setName("John");
+        pojo.setAge(25);
+
+        SampleService.MultipleParamsPojo resultPojo = sampleService.multipleParamsMethod(10, "hello", customer, pojo);
+        assertThat(resultPojo).isNotNull();
+        assertThat(resultPojo.number()).isEqualTo(10);
+        assertThat(resultPojo.str()).isEqualTo("hello");
+        assertThat(resultPojo.entity()).isEqualTo(customer);
+        assertThat(resultPojo.pojo()).isEqualTo(pojo);
+    }
+}

--- a/jmix-restds/restds/src/test/java/remote_service/RemoteServiceTest.java
+++ b/jmix-restds/restds/src/test/java/remote_service/RemoteServiceTest.java
@@ -121,18 +121,16 @@ public class RemoteServiceTest extends BaseRestDsIntegrationTest {
 
     @Test
     void testOtherTypes() throws Exception{
-        // todo
+        FileRef fileRef = FileRef.create("fileStorage1", "/path1", "file1.txt");
+        FileRef resultFileRef = sampleService.fileRefMethod(fileRef);
+        assertThat(resultFileRef).isEqualTo(fileRef);
 
-//        byte[] resultBytes = sampleService.binaryMethod("hello".getBytes(StandardCharsets.UTF_8));
-//        assertThat(resultBytes).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
+        byte[] resultBytes = sampleService.binaryMethod("hello".getBytes(StandardCharsets.UTF_8));
+        assertThat(resultBytes).isEqualTo("hello".getBytes(StandardCharsets.UTF_8));
 
-//        FileRef fileRef = FileRef.create("fileStorage1", "/path1", "file1.txt");
-//        FileRef resultFileRef = sampleService.fileRefMethod(fileRef);
-//        assertThat(resultFileRef).isEqualTo(fileRef);
-
-//        URI uri = new URI("https://jmix.io");
-//        URI resultUri = sampleService.uriMethod(uri);
-//        assertThat(resultUri).isEqualTo(uri);
+        URI uri = new URI("https://jmix.io");
+        URI resultUri = sampleService.uriMethod(uri);
+        assertThat(resultUri).isEqualTo(uri);
 
         UUID uuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
         UUID resultUuid = sampleService.uuidMethod(uuid);
@@ -153,10 +151,7 @@ public class RemoteServiceTest extends BaseRestDsIntegrationTest {
         OffsetDateTime resultOffsetDateTime = sampleService.offsetDateTimeMethod(offsetDateTime);
         assertThat(resultOffsetDateTime).isEqualTo(offsetDateTime);
 
-        // todo
-//        ZonedDateTime zonedDateTime = ZonedDateTime.parse("2025-04-26T18:44+04:00[Europe/Samara]");
-//        ZonedDateTime resultZonedDateTime = sampleService.zonedDateTimeMethod(zonedDateTime);
-//        assertThat(resultZonedDateTime).isEqualTo(zonedDateTime);
+        // ZonedDateTime is not supported by entities and REST
     }
 
     @Test
@@ -184,11 +179,14 @@ public class RemoteServiceTest extends BaseRestDsIntegrationTest {
         SampleService.SamplePojo pojo = new SampleService.SamplePojo();
         pojo.setName("John");
         pojo.setAge(25);
+        FileRef fileRef = FileRef.create("fileStorage1", "/path1", "file1.txt");
+        pojo.setFileRef(fileRef);
 
         SampleService.SamplePojo resultPojo = sampleService.pojoMethod(pojo);
         assertThat(resultPojo).isNotNull();
         assertThat(resultPojo.getName()).isEqualTo("John");
         assertThat(resultPojo.getAge()).isEqualTo(25);
+        assertThat(resultPojo.getFileRef()).isEqualTo(fileRef);
 
         SampleService.SamplePojoWithEntity pojoWithEntity = new SampleService.SamplePojoWithEntity();
         pojoWithEntity.setName("John");

--- a/jmix-restds/restds/src/test/java/test_support/service/CustomerService.java
+++ b/jmix-restds/restds/src/test/java/test_support/service/CustomerService.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.service;
+
+import io.jmix.restds.annotation.RemoteService;
+import test_support.entity.Customer;
+import test_support.entity.CustomerContact;
+
+@RemoteService(store = "restService1")
+public interface CustomerService {
+
+    CustomerContact getPreferredContact(Customer customer);
+}

--- a/jmix-restds/restds/src/test/java/test_support/service/CustomerService.java
+++ b/jmix-restds/restds/src/test/java/test_support/service/CustomerService.java
@@ -20,7 +20,7 @@ import io.jmix.restds.annotation.RemoteService;
 import test_support.entity.Customer;
 import test_support.entity.CustomerContact;
 
-@RemoteService(store = "restService1")
+@RemoteService(store = "restService1", remoteName = "app_Customers")
 public interface CustomerService {
 
     CustomerContact getPreferredContact(Customer customer);

--- a/jmix-restds/restds/src/test/java/test_support/service/SampleService.java
+++ b/jmix-restds/restds/src/test/java/test_support/service/SampleService.java
@@ -24,7 +24,6 @@ import test_support.entity.Customer;
 import java.net.URI;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -55,8 +54,6 @@ public interface SampleService {
 
     OffsetDateTime offsetDateTimeMethod(OffsetDateTime param);
 
-    ZonedDateTime zonedDateTimeMethod(ZonedDateTime param);
-
     UUID uuidMethod(UUID param);
 
     URI uriMethod(URI param);
@@ -82,6 +79,7 @@ public interface SampleService {
     class SamplePojo {
         private String name;
         private int age;
+        private FileRef fileRef;
 
         public String getName() {
             return name;
@@ -99,15 +97,23 @@ public interface SampleService {
             this.age = age;
         }
 
+        public FileRef getFileRef() {
+            return fileRef;
+        }
+
+        public void setFileRef(FileRef fileRef) {
+            this.fileRef = fileRef;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (!(o instanceof SamplePojo that)) return false;
-            return getAge() == that.getAge() && Objects.equals(getName(), that.getName());
+            return getAge() == that.getAge() && Objects.equals(getName(), that.getName()) && Objects.equals(getFileRef(), that.getFileRef());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(getName(), getAge());
+            return Objects.hash(getName(), getAge(), getFileRef());
         }
     }
 

--- a/jmix-restds/restds/src/test/java/test_support/service/SampleService.java
+++ b/jmix-restds/restds/src/test/java/test_support/service/SampleService.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.service;
+
+import io.jmix.core.FileRef;
+import io.jmix.restds.annotation.RemoteService;
+import test_support.entity.ContactType;
+import test_support.entity.Customer;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@RemoteService(store = "restService1")
+public interface SampleService {
+
+    void voidMethod();
+
+    String stringMethod(String param);
+
+    boolean booleanMethod(boolean param);
+
+    Boolean booleanWrapperMethod(Boolean param);
+
+    int intMethod(int param);
+
+    Integer intWrapperMethod(Integer param);
+
+    byte[] binaryMethod(byte[] param);
+
+    FileRef fileRefMethod(FileRef param);
+
+    Date dateMethod(Date param);
+
+    LocalDateTime localDateTimeMethod(LocalDateTime param);
+
+    OffsetDateTime offsetDateTimeMethod(OffsetDateTime param);
+
+    ZonedDateTime zonedDateTimeMethod(ZonedDateTime param);
+
+    UUID uuidMethod(UUID param);
+
+    URI uriMethod(URI param);
+
+    Customer entityMethod(Customer param);
+
+    List<Customer> entityCollectionMethod(List<Customer> param);
+
+    ContactType enumMethod(ContactType param);
+
+    SamplePojo pojoMethod(SamplePojo param);
+
+    SamplePojoWithEntity pojoWithEntityMethod(SamplePojoWithEntity param);
+
+    SampleRecord recordMethod(SampleRecord param);
+
+    SampleRecordWithEntity recordWithEntityMethod(SampleRecordWithEntity param);
+
+    MultipleParamsPojo multipleParamsMethod(int number, String str, Customer entity, SamplePojo pojo);
+
+    record MultipleParamsPojo(int number, String str, Customer entity, SamplePojo pojo) {}
+
+    class SamplePojo {
+        private String name;
+        private int age;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof SamplePojo that)) return false;
+            return getAge() == that.getAge() && Objects.equals(getName(), that.getName());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getName(), getAge());
+        }
+    }
+
+    class SamplePojoWithEntity {
+        private String name;
+        private Customer customer;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Customer getCustomer() {
+            return customer;
+        }
+
+        public void setCustomer(Customer customer) {
+            this.customer = customer;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof SamplePojoWithEntity that)) return false;
+            return Objects.equals(getName(), that.getName()) && Objects.equals(getCustomer(), that.getCustomer());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getName(), getCustomer());
+        }
+    }
+
+    record SampleRecord(String name, int age) {}
+
+    record SampleRecordWithEntity(String name, Customer customer) {}
+}

--- a/jmix-restds/restds/src/test/resources/logback-test.xml
+++ b/jmix-restds/restds/src/test/resources/logback-test.xml
@@ -26,6 +26,7 @@
     </root>
 
     <logger name="io.jmix.restds" level="TRACE"/>
+    <logger name="io.jmix.restds.impl.service" level="DEBUG"/>
     <logger name="io.jmix.core.datastore" level="DEBUG"/>
     <logger name="io.jmix.core.AccessLogger" level="DEBUG"/>
 

--- a/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/CustomerService.java
+++ b/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/CustomerService.java
@@ -23,7 +23,7 @@ import io.jmix.samples.restservice.entity.Customer;
 import io.jmix.samples.restservice.entity.CustomerContact;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@RestService("CustomerService")
+@RestService("app_Customers")
 public class CustomerService {
 
     @Autowired

--- a/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/SampleService.java
+++ b/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/SampleService.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.samples.restservice.app;
+
+import io.jmix.core.DataManager;
+import io.jmix.core.FileRef;
+import io.jmix.rest.annotation.RestMethod;
+import io.jmix.rest.annotation.RestService;
+import io.jmix.samples.restservice.entity.ContactType;
+import io.jmix.samples.restservice.entity.Customer;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@RestService("SampleService")
+public class SampleService {
+
+    private final DataManager dataManager;
+
+    public SampleService(DataManager dataManager) {
+        this.dataManager = dataManager;
+    }
+
+    @RestMethod
+    public void voidMethod() {
+    }
+
+    @RestMethod
+    public String stringMethod(String param) {
+        return param;
+    }
+
+    @RestMethod
+    public boolean booleanMethod(boolean param) {
+        return param;
+    }
+
+    @RestMethod
+    public Boolean booleanWrapperMethod(Boolean param) {
+        return true;
+    }
+
+    @RestMethod
+    public int intMethod(int param) {
+        return param;
+    }
+
+    @RestMethod
+    public Integer intWrapperMethod(Integer param) {
+        return param;
+    }
+
+    @RestMethod
+    public byte[] binaryMethod(byte[] param) {
+        return param;
+    }
+
+    @RestMethod
+    public FileRef fileRefMethod(FileRef param) {
+        return param;
+    }
+
+    @RestMethod
+    public Date dateMethod(Date param) {
+        return param;
+    }
+
+    @RestMethod
+    public LocalDateTime localDateTimeMethod(LocalDateTime param) {
+        return param;
+    }
+
+    @RestMethod
+    public OffsetDateTime offsetDateTimeMethod(OffsetDateTime param) {
+        return param;
+    }
+
+    @RestMethod
+    public ZonedDateTime zonedDateTimeMethod(ZonedDateTime param) {
+        return param;
+    }
+
+    @RestMethod
+    public UUID uuidMethod(UUID param) {
+        return param;
+    }
+
+    @RestMethod
+    public URI uriMethod(URI param) {
+        return param;
+    }
+
+    @RestMethod
+    public Customer entityMethod(Customer param) {
+        return param;
+    }
+
+    @RestMethod
+    public List<Customer> entityCollectionMethod(List<Customer> param) {
+        return param;
+    }
+
+    @RestMethod
+    public ContactType enumMethod(ContactType param) {
+        return param;
+    }
+
+    @RestMethod
+    public SamplePojo pojoMethod(SamplePojo param) {
+        return param;
+    }
+
+    @RestMethod
+    public SamplePojoWithEntity pojoWithEntityMethod(SamplePojoWithEntity param) {
+        return param;
+    }
+
+    @RestMethod
+    public SampleRecord recordMethod(SampleRecord param) {
+        return param;
+    }
+
+    @RestMethod
+    public SampleRecordWithEntity recordWithEntityMethod(SampleRecordWithEntity param) {
+        return param;
+    }
+
+    @RestMethod
+    public void booleanParamMethod(boolean param) {
+    }
+
+    @RestMethod
+    public void booleanWrapperParamMethod(Boolean param) {
+    }
+
+    @RestMethod
+    public void intParamMethod(int param) {
+    }
+
+    @RestMethod
+    public void intWrapperParamMethod(Integer param) {
+    }
+
+    @RestMethod
+    public void stringParamMethod(String param) {
+    }
+
+    @RestMethod
+    public MultipleParamsPojo multipleParamsMethod(int number, String str, Customer entity, SamplePojo pojo) {
+        return new MultipleParamsPojo(number, str, entity, pojo);
+    }
+
+    public record MultipleParamsPojo(int number, String str, Customer entity, SamplePojo pojo) {}
+
+    public static class SamplePojo {
+        private String name;
+        private int age;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+
+        public void setAge(int age) {
+            this.age = age;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof SamplePojo that)) return false;
+            return getAge() == that.getAge() && Objects.equals(getName(), that.getName());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getName(), getAge());
+        }
+    }
+
+    public static class SamplePojoWithEntity {
+        private String name;
+        private Customer customer;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Customer getCustomer() {
+            return customer;
+        }
+
+        public void setCustomer(Customer customer) {
+            this.customer = customer;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof SamplePojoWithEntity that)) return false;
+            return Objects.equals(getName(), that.getName()) && Objects.equals(getCustomer(), that.getCustomer());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getName(), getCustomer());
+        }
+    }
+
+    public record SampleRecord(String name, int age) {}
+
+    public record SampleRecordWithEntity(String name, Customer customer) {}
+}

--- a/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/SampleService.java
+++ b/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/SampleService.java
@@ -26,7 +26,6 @@ import io.jmix.samples.restservice.entity.Customer;
 import java.net.URI;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
-import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
@@ -92,11 +91,6 @@ public class SampleService {
 
     @RestMethod
     public OffsetDateTime offsetDateTimeMethod(OffsetDateTime param) {
-        return param;
-    }
-
-    @RestMethod
-    public ZonedDateTime zonedDateTimeMethod(ZonedDateTime param) {
         return param;
     }
 
@@ -175,6 +169,7 @@ public class SampleService {
     public static class SamplePojo {
         private String name;
         private int age;
+        private FileRef fileRef;
 
         public String getName() {
             return name;
@@ -192,15 +187,23 @@ public class SampleService {
             this.age = age;
         }
 
+        public FileRef getFileRef() {
+            return fileRef;
+        }
+
+        public void setFileRef(FileRef fileRef) {
+            this.fileRef = fileRef;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (!(o instanceof SamplePojo that)) return false;
-            return getAge() == that.getAge() && Objects.equals(getName(), that.getName());
+            return getAge() == that.getAge() && Objects.equals(getName(), that.getName()) && Objects.equals(getFileRef(), that.getFileRef());
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(getName(), getAge());
+            return Objects.hash(getName(), getAge(), getFileRef());
         }
     }
 


### PR DESCRIPTION
Introduced `@RemoteService` annotation to enable defining remote services. Added a proxy mechanism (`RemoteServiceProxyFactoryBean`) and bean processor (`RemoteServiceBeanFactoryPostProcessor`) to handle service instantiation and method calls. Included tests and updated configurations.

### Example usage

Definition on the server side:
```
@RestService("InventoryService")
public class InventoryService {

    @RestMethod
    public Double getAvailableInStock(Product product) {
        return (double) Math.round(Math.random() * 100);
    }
}
```

Definition on the client side:
```
@RemoteService(store = "products")
public interface InventoryService {

    Double getAvailableInStock(Product product);
}
```

Invocation on the client side:
```
@Autowired
private InventoryService inventoryService;

@Subscribe(id = "availableBtn", subject = "clickListener")
public void onAvailableBtnClick(final ClickEvent<JmixButton> event) {
    Double inStock = inventoryService.getAvailableInStock(getEditedEntity().getProduct());
    notifications.show("Available in stock: " + inStock);
}
```

See also `jmix-restds/restds/src/test/java/test_support/service/SampleService.java` and `jmix-restds/restds/src/test/java/remote_service/RemoteServiceTest.java`.