### PR TITLE
Add logout support to auth server

### DIFF
--- a/jmix-authserver/authserver/src/main/java/io/jmix/authserver/AuthServerProperties.java
+++ b/jmix-authserver/authserver/src/main/java/io/jmix/authserver/AuthServerProperties.java
@@ -58,13 +58,27 @@ public class AuthServerProperties {
      */
     String authorizeEndpoint;
 
+    /**
+     * Name of url parameter within logout request which contains url to redirect to after logout
+     */
+    String postLogoutUrlRedirectParameterName;
+
+    /**
+     * Whether referer header value can be used as a target URL after logout.
+     * <p>
+     * Note: URL specified within {@link #postLogoutUrlRedirectParameterName} parameter has more priority
+     */
+    boolean useRefererPostLogout;
+
     public AuthServerProperties(
             @DefaultValue("true") boolean useDefaultConfiguration,
             @DefaultValue("false") boolean useInMemoryAuthorizationService,
             @DefaultValue Map<String, JmixClient> client,
             @DefaultValue("/as-login") String loginPageUrl,
             @DefaultValue("as-login.html") String loginPageViewName,
-            @DefaultValue("/oauth2/authorize") String authorizeEndpoint
+            @DefaultValue("/oauth2/authorize") String authorizeEndpoint,
+            @DefaultValue("false") boolean useRefererPostLogout,
+            String postLogoutUrlRedirectParameterName
     ) {
         this.useDefaultConfiguration = useDefaultConfiguration;
         this.useInMemoryAuthorizationService = useInMemoryAuthorizationService;
@@ -72,6 +86,8 @@ public class AuthServerProperties {
         this.loginPageUrl = loginPageUrl;
         this.loginPageViewName = loginPageViewName;
         this.authorizeEndpoint = authorizeEndpoint;
+        this.postLogoutUrlRedirectParameterName = postLogoutUrlRedirectParameterName;
+        this.useRefererPostLogout = useRefererPostLogout;
     }
 
     public boolean isUseDefaultConfiguration() {
@@ -96,6 +112,14 @@ public class AuthServerProperties {
 
     public String getAuthorizeEndpoint() {
         return authorizeEndpoint;
+    }
+
+    public String getPostLogoutUrlRedirectParameterName() {
+        return postLogoutUrlRedirectParameterName;
+    }
+
+    public boolean isUseRefererPostLogout() {
+        return useRefererPostLogout;
     }
 
     /**


### PR DESCRIPTION
See https://github.com/jmix-framework/jmix/issues/2189

### Solution
Additional filter chain with simple logout support (according to https://youtrack.haulmont.com/articles/PLAT-A-1518/Authorization-Server-logout).

#### New properties

- `jmix.authserver.post-logout-url-redirect-parameter-name` - name of url parameter from` /logout` request. This parameter should contain url to redirect after successful logout. 
Default: null (**should we add some default?**)
- `jmix.authserver.use-referer-post-logout` - allows to use `referer` header value as post logout redirect url. 
Propagate to `useReferer` parameter of `AbstractAuthenticationTargetUrlRequestHandler` that has the following order of redirect url determination: value from url parameter -> referer (if enabled) -> default (`/`), so it has less priority than url from parameter being set via `jmix.authserver.post-logout-url-redirect-parameter-name`.  
Default: false (as the default value of `useReferer` parameter in `AbstractAuthenticationTargetUrlRequestHandler`. **switch to true?**)