### PR TITLE
Dynamic attributes view redesign

### DIFF
--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/category/CategoryDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/category/CategoryDetailView.java
@@ -18,7 +18,6 @@ package io.jmix.dynattrflowui.view.category;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.HasValue;
-import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.tabs.Tab;
@@ -33,10 +32,12 @@ import io.jmix.dynattrflowui.view.localization.AttributeLocalizationComponent;
 import io.jmix.flowui.UiComponents;
 import io.jmix.flowui.component.combobox.JmixComboBox;
 import io.jmix.flowui.component.tabsheet.JmixTabSheet;
+import io.jmix.flowui.component.textfield.TypedTextField;
 import io.jmix.flowui.model.DataComponents;
 import io.jmix.flowui.model.DataContext;
 import io.jmix.flowui.model.InstanceContainer;
 import io.jmix.flowui.view.*;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Comparator;
@@ -82,6 +83,8 @@ public class CategoryDetailView extends StandardDetailView<Category> {
     @ViewComponent
     protected JmixComboBox<MetaClass> entityTypeField;
     @ViewComponent
+    protected TypedTextField<String> nameField;
+    @ViewComponent
     protected JmixTabSheet tabSheet;
     @ViewComponent
     protected VerticalLayout localizationTabContainer;
@@ -107,7 +110,17 @@ public class CategoryDetailView extends StandardDetailView<Category> {
     protected void onEntityTypeFieldValueChange(AbstractField.ComponentValueChangeEvent<ComboBox<MetaClass>, MetaClass> event) {
         if (event.getValue() != null) {
             getEditedEntity().setEntityType(event.getValue().getName());
+
+            if (nameField.getTypedValue() == null) {
+                getEditedEntity().setName(generateCategoryNameByEntityType());
+            }
         }
+    }
+
+    protected String generateCategoryNameByEntityType() {
+        String entityTypeCaption = messageTools.getEntityCaption(entityTypeField.getValue());
+        String categoryEntityCaption = messageTools.getEntityCaption(categoryDc.getEntityMetaClass());
+        return StringUtils.capitalize(entityTypeCaption) + " " + StringUtils.uncapitalize(categoryEntityCaption);
     }
 
     @Subscribe("isDefaultField")

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/category/CategoryDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/category/CategoryDetailView.java
@@ -18,58 +18,38 @@ package io.jmix.dynattrflowui.view.category;
 
 import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.HasValue;
-import com.vaadin.flow.component.Text;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.combobox.ComboBox;
-import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.tabs.Tab;
-import com.vaadin.flow.data.renderer.ComponentRenderer;
-import com.vaadin.flow.data.renderer.Renderer;
-import com.vaadin.flow.data.selection.SelectionEvent;
 import com.vaadin.flow.router.Route;
 import io.jmix.core.*;
 import io.jmix.core.accesscontext.CrudEntityContext;
-import io.jmix.core.metamodel.datatype.FormatStringsRegistry;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetadataObject;
-import io.jmix.core.security.CurrentAuthentication;
-import io.jmix.dynattr.AttributeType;
 import io.jmix.dynattr.MsgBundleTools;
 import io.jmix.dynattr.model.Category;
-import io.jmix.dynattr.model.CategoryAttribute;
-import io.jmix.dynattrflowui.utils.DynAttrUiHelper;
-import io.jmix.dynattrflowui.view.categoryattr.CategoryAttributesDetailView;
 import io.jmix.dynattrflowui.view.localization.AttributeLocalizationComponent;
-import io.jmix.flowui.DialogWindows;
 import io.jmix.flowui.UiComponents;
 import io.jmix.flowui.component.combobox.JmixComboBox;
-import io.jmix.flowui.component.grid.DataGrid;
 import io.jmix.flowui.component.tabsheet.JmixTabSheet;
-import io.jmix.flowui.kit.action.Action;
-import io.jmix.flowui.kit.action.ActionPerformedEvent;
-import io.jmix.flowui.model.CollectionContainer;
 import io.jmix.flowui.model.DataComponents;
 import io.jmix.flowui.model.DataContext;
 import io.jmix.flowui.model.InstanceContainer;
 import io.jmix.flowui.view.*;
-import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.lang.Nullable;
-import org.springframework.util.Assert;
 
-import java.math.BigDecimal;
-import java.text.SimpleDateFormat;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.util.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Route(value = "dynat/category/:id", layout = DefaultMainViewParent.class)
 @ViewController("dynat_CategoryView.detail")
 @ViewDescriptor("category-detail-view.xml")
 @PrimaryDetailView(Category.class)
 @EditedEntityContainer("categoryDc")
-@DialogMode(width = "50em", maxWidth = "80%")
+@DialogMode(width = "50em")
 public class CategoryDetailView extends StandardDetailView<Category> {
 
     @Autowired
@@ -91,62 +71,28 @@ public class CategoryDetailView extends StandardDetailView<Category> {
     @Autowired
     protected Messages messages;
     @Autowired
-    protected CurrentAuthentication currentAuthentication;
-    @Autowired
-    protected ReferenceToEntitySupport referenceToEntitySupport;
-    @Autowired
-    protected FetchPlanRepository fetchPlanRepository;
-    @Autowired
     protected UiComponents uiComponents;
-    @Autowired
-    protected FormatStringsRegistry formatStringsRegistry;
-    @Autowired
-    protected DialogWindows dialogWindows;
-    @Autowired
-    protected DynAttrUiHelper dynAttrUiHelper;
     @Autowired
     protected DataComponents dataComponents;
     @Autowired
     protected MsgBundleTools msgBundleTools;
 
-
     @ViewComponent
     protected InstanceContainer<Category> categoryDc;
-    @ViewComponent
-    protected CollectionContainer<CategoryAttribute> categoryAttributesDc;
     @ViewComponent
     protected JmixComboBox<MetaClass> entityTypeField;
     @ViewComponent
     protected JmixTabSheet tabSheet;
     @ViewComponent
     protected VerticalLayout localizationTabContainer;
-    @ViewComponent
-    protected DataGrid<CategoryAttribute> categoryAttrsGrid;
-    @ViewComponent
-    protected Button moveUpBtn;
-    @ViewComponent
-    protected Button moveDownBtn;
-    @ViewComponent("categoryAttrsGrid.edit")
-    protected Action editAction;
-    @ViewComponent("categoryAttrsGrid.remove")
-    protected Action removeAction;
-    @ViewComponent("categoryAttrsGrid.moveUp")
-    protected Action moveUpAction;
-    @ViewComponent("categoryAttrsGrid.moveDown")
-    protected Action moveDownAction;
-    protected AttributeLocalizationComponent localizationComponent;
 
-    @Subscribe
-    public void onInitEvent(InitEvent event) {
-        sortCategoryAttrsGridByOrderNo();
-    }
+    protected AttributeLocalizationComponent localizationComponent;
 
     @Subscribe
     protected void onBeforeShow(BeforeShowEvent event) {
         initEntityTypeField();
         initLocalizationTab();
         setupFieldsLock();
-        setGridActionsEnabled(!categoryAttrsGrid.getSelectedItems().isEmpty());
     }
 
     protected void setupFieldsLock() {
@@ -162,11 +108,6 @@ public class CategoryDetailView extends StandardDetailView<Category> {
         if (event.getValue() != null) {
             getEditedEntity().setEntityType(event.getValue().getName());
         }
-    }
-
-    private void setGridActionsEnabled(boolean enabled) {
-        List.of(editAction, removeAction, moveUpAction, moveDownAction)
-                .forEach(button -> button.setEnabled(enabled));
     }
 
     @Subscribe("isDefaultField")
@@ -197,7 +138,6 @@ public class CategoryDetailView extends StandardDetailView<Category> {
             options.put(metaClass, messageTools.getDetailedEntityCaption(metaClass));
         }
         entityTypeField.setItemLabelGenerator(options::get);
-        //noinspection unchecked
         entityTypeField.setItems(options.keySet().stream()
                 .sorted(Comparator.comparing(MetadataObject::getName))
                 .toList());
@@ -231,235 +171,6 @@ public class CategoryDetailView extends StandardDetailView<Category> {
             localizationTabContainer.add(localizationComponent);
             localizationTabContainer.expand(localizationComponent);
         }
-    }
-
-    @Supply(to = "categoryAttrsGrid.defaultValue", subject = "renderer")
-    protected Renderer<CategoryAttribute> createCategoryAttrsGridDefaultValueRenderer() {
-        return new ComponentRenderer<>(this::categoryAttrsGridDefaultValueColumnComponent,
-                this::categoryAttrsGridDefaultValueColumnUpdater);
-    }
-
-    protected Span categoryAttrsGridDefaultValueColumnComponent() {
-        return uiComponents.create(Span.class);
-    }
-
-    protected void categoryAttrsGridDefaultValueColumnUpdater(Span defaultValueLabel, CategoryAttribute attribute) {
-        String defaultValue = "";
-
-        AttributeType dataType = attribute.getDataType();
-        switch (dataType) {
-            case BOOLEAN -> {
-                Boolean b = attribute.getDefaultBoolean();
-                if (b != null)
-                    defaultValue = BooleanUtils.isTrue(b)
-                            ? messages.getMessage("trueString")
-                            : messages.getMessage("falseString");
-            }
-            case DATE -> {
-                Date dateTime = attribute.getDefaultDate();
-                if (dateTime != null) {
-                    String dateTimeFormat = formatStringsRegistry.getFormatStrings(currentAuthentication.getLocale()).getDateTimeFormat();
-                    SimpleDateFormat simpleDateFormat = new SimpleDateFormat(dateTimeFormat);
-                    defaultValue = simpleDateFormat.format(dateTime);
-                } else if (BooleanUtils.isTrue(attribute.getDefaultDateIsCurrent())) {
-                    defaultValue = messages.getMessage(getClass(), "categoryAttrsGrid.currentDate");
-                }
-            }
-            case DATE_WITHOUT_TIME -> {
-                LocalDate dateWoTime = attribute.getDefaultDateWithoutTime();
-                if (dateWoTime != null) {
-                    String dateWoTimeFormat = formatStringsRegistry.getFormatStrings(currentAuthentication.getLocale()).getDateFormat();
-                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateWoTimeFormat);
-                    defaultValue = dateWoTime.format(formatter);
-                } else if (BooleanUtils.isTrue(attribute.getDefaultDateIsCurrent())) {
-                    defaultValue = messages.getMessage(getClass(), "categoryAttrsGrid.currentDate");
-                }
-            }
-            case DECIMAL -> {
-                BigDecimal defaultDecimal = attribute.getDefaultDecimal();
-                if (defaultDecimal != null) {
-                    defaultValue = defaultDecimal.toString();
-                }
-            }
-            case DOUBLE -> {
-                Double defaultDouble = attribute.getDefaultDouble();
-                if (defaultDouble != null) {
-                    defaultValue = defaultDouble.toString();
-                }
-            }
-            case ENTITY -> {
-                Class<?> entityClass = attribute.getJavaType();
-                if (entityClass != null) {
-                    defaultValue = "";
-                    if (attribute.getObjectDefaultEntityId() != null) {
-                        MetaClass metaClass = metadata.getClass(entityClass);
-                        LoadContext<?> lc = new LoadContext<>(metadata.getClass(attribute.getJavaType()));
-                        FetchPlan fetchPlan = fetchPlanRepository.getFetchPlan(metaClass, FetchPlan.INSTANCE_NAME);
-                        lc.setFetchPlan(fetchPlan);
-                        String pkName = referenceToEntitySupport.getPrimaryKeyForLoadingEntity(metaClass);
-                        lc.setQueryString(String.format("select e from %s e where e.%s = :entityId", metaClass.getName(), pkName))
-                                .setParameter("entityId", attribute.getObjectDefaultEntityId());
-                        Object entity = dataManager.load(lc);
-                        if (entity != null) {
-                            defaultValue = metadataTools.getInstanceName(entity);
-                        }
-                    }
-                } else {
-                    defaultValue = messages.getMessage(getClass(), "categoryAttrsGrid.entityNotFound");
-                }
-            }
-            case ENUMERATION, STRING -> defaultValue = attribute.getDefaultString();
-            case INTEGER -> {
-                Integer defaultInt = attribute.getDefaultInt();
-                if (defaultInt != null) {
-                    defaultValue = defaultInt.toString();
-                }
-            }
-        }
-
-        defaultValueLabel.setText(defaultValue);
-    }
-
-    @Supply(to = "categoryAttrsGrid.dataType", subject = "renderer")
-    protected Renderer<CategoryAttribute> createCategoryAttrsGridDataTypeRenderer() {
-        return new ComponentRenderer<>(this::categoryAttrsGridDataTypeComponent,
-                this::categoryAttrsGridDataTypeUpdater);
-    }
-
-    protected Text categoryAttrsGridDataTypeComponent() {
-        return new Text(null);
-    }
-
-    protected void categoryAttrsGridDataTypeUpdater(Text text, CategoryAttribute categoryAttribute) {
-        String dataType;
-        if (BooleanUtils.isTrue(categoryAttribute.getIsEntity())) {
-            Class<?> javaType = categoryAttribute.getJavaType();
-            if (javaType != null) {
-                MetaClass metaClass = metadata.getClass(javaType);
-                dataType = messageTools.getEntityCaption(metaClass);
-            } else {
-                dataType = "";
-            }
-        } else {
-            String key = AttributeType.class.getSimpleName() + "." + categoryAttribute.getDataType().toString();
-            dataType = messages.getMessage(AttributeType.class, key);
-        }
-
-        text.setText(dataType);
-    }
-
-    @Subscribe("categoryAttrsGrid.create")
-    protected void categoryAttrsGridCreateListener(ActionPerformedEvent event) {
-        dialogWindows.detail(this, CategoryAttribute.class)
-                .withViewClass(CategoryAttributesDetailView.class)
-                .newEntity()
-                .withParentDataContext(getViewData().getDataContext())
-                .withInitializer(e -> e.setCategory(categoryDc.getItem()))
-                .withAfterCloseListener(e -> {
-                    if (e.getCloseAction().equals(StandardOutcome.SAVE.getCloseAction())) {
-                        refreshAttributesDc(e.getView().getEditedEntity());
-                    }
-                })
-                .build()
-                .open();
-    }
-
-    @Subscribe("categoryAttrsGrid.edit")
-    protected void categoryAttrsGridEditListener(ActionPerformedEvent event) {
-        CategoryAttribute categoryAttributeSelected = categoryAttrsGrid.getSingleSelectedItem();
-
-        Assert.notNull(categoryAttributeSelected, "Selected attribute has to be not null");
-        dialogWindows.detail(this, CategoryAttribute.class)
-                .withViewClass(CategoryAttributesDetailView.class)
-                .editEntity(categoryAttributeSelected)
-                .withAfterCloseListener(e -> {
-                    if (e.getCloseAction().equals(StandardOutcome.SAVE.getCloseAction())) {
-                        refreshAttributesDc(e.getView().getEditedEntity());
-                    }
-                })
-                .withParentDataContext(getViewData().getDataContext())
-                .build()
-                .open();
-    }
-
-    private void refreshAttributesDc(CategoryAttribute attribute) {
-        if (categoryAttributesDc.getMutableItems().contains(attribute)) {
-            categoryAttributesDc.replaceItem(attribute);
-        } else {
-            categoryAttributesDc.getMutableItems().add(attribute);
-        }
-        categoryAttrsGrid.getDataProvider().refreshAll();
-    }
-
-    @Subscribe("categoryAttrsGrid.remove")
-    protected void categoryAttrsGridRemoveListener(ActionPerformedEvent event) {
-        CategoryAttribute selected = Objects.requireNonNull(categoryAttrsGrid.getSingleSelectedItem());
-        categoryAttributesDc.getMutableItems().remove(selected);
-        getViewData().getDataContext().remove(selected);
-        categoryAttrsGrid.getDataProvider().refreshAll();
-    }
-
-    protected void onCategoryAttrsGridSelection(SelectionEvent<DataGrid<CategoryAttribute>, CategoryAttribute> event) {
-        Set<CategoryAttribute> selected = categoryAttrsGrid.getSelectedItems();
-        if (selected.isEmpty()) {
-            refreshMoveButtonsEnabled(null);
-        } else {
-            refreshMoveButtonsEnabled(selected.iterator().next());
-        }
-    }
-
-    @Subscribe("categoryAttrsGrid")
-    protected void onCategoryAttrsGridSelectionEvent(SelectionEvent<DataGrid<CategoryAttribute>, CategoryAttribute> event) {
-        setGridActionsEnabled(!event.getAllSelectedItems().isEmpty());
-    }
-
-    @Subscribe("categoryAttrsGrid.moveUp")
-    protected void onCategoryAttrsGridMoveUp(ActionPerformedEvent event) {
-        dynAttrUiHelper.moveTableItemUp(categoryAttributesDc, categoryAttrsGrid, () ->
-                categoryAttributesDc.getMutableItems()
-                        .forEach(item -> item.setOrderNo(categoryAttributesDc.getMutableItems().indexOf(item))));
-
-    }
-
-    @Subscribe("categoryAttrsGrid.moveDown")
-    protected void onCategoryAttrsGridMoveDown(ActionPerformedEvent event) {
-        dynAttrUiHelper.moveTableItemDown(categoryAttributesDc, categoryAttrsGrid, () ->
-                categoryAttributesDc.getMutableItems()
-                        .forEach(item -> item.setOrderNo(categoryAttributesDc.getMutableItems().indexOf(item))));
-    }
-
-    protected CategoryAttribute getPrevAttribute(Integer orderNo) {
-        return categoryAttributesDc.getMutableItems()
-                .stream()
-                .filter(categoryAttribute -> orderNo.compareTo(categoryAttribute.getOrderNo()) > 0)
-                .max(Comparator.comparing(CategoryAttribute::getOrderNo))
-                .orElse(null);
-    }
-
-    protected CategoryAttribute getNextAttribute(Integer orderNo) {
-        return categoryAttributesDc.getMutableItems()
-                .stream()
-                .filter(categoryAttribute -> orderNo.compareTo(categoryAttribute.getOrderNo()) < 0)
-                .min(Comparator.comparing(CategoryAttribute::getOrderNo))
-                .orElse(null);
-    }
-
-    protected void sortCategoryAttrsGridByOrderNo() {
-        Objects.requireNonNull(categoryAttributesDc.getSorter())
-                .sort(Sort.by(Sort.Direction.ASC, "orderNo"));
-    }
-
-    protected void refreshMoveButtonsEnabled(@Nullable CategoryAttribute categoryAttribute) {
-        moveUpBtn.setEnabled(categoryAttribute != null && getPrevAttribute(categoryAttribute.getOrderNo()) != null);
-        moveDownBtn.setEnabled(categoryAttribute != null && getNextAttribute(categoryAttribute.getOrderNo()) != null);
-    }
-
-    public void setCategory(Category category) {
-        categoryDc.setItem(category);
-        categoryAttributesDc.setItems(dataManager.load(CategoryAttribute.class)
-                .query("select e from dynat_CategoryAttribute e where e.category = :category")
-                .parameter("category", category)
-                .list());
     }
 
     @Subscribe(target = Target.DATA_CONTEXT)

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/category/CategoryListView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/category/CategoryListView.java
@@ -17,35 +17,60 @@
 package io.jmix.dynattrflowui.view.category;
 
 import com.google.common.io.Files;
+import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.grid.Grid;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.data.renderer.Renderer;
+import com.vaadin.flow.data.selection.SelectionEvent;
+import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.Route;
+import com.vaadin.flow.router.RouteParam;
+import com.vaadin.flow.router.RouteParameters;
 import io.jmix.core.*;
 import io.jmix.core.accesscontext.CrudEntityContext;
+import io.jmix.core.accesscontext.EntityAttributeContext;
+import io.jmix.core.metamodel.datatype.FormatStringsRegistry;
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.security.CurrentAuthentication;
+import io.jmix.dynattr.AttributeType;
 import io.jmix.dynattr.DynAttrMetadata;
 import io.jmix.dynattr.model.Category;
 import io.jmix.dynattr.model.CategoryAttribute;
 import io.jmix.dynattr.model.ReferenceToEntity;
+import io.jmix.dynattrflowui.utils.DynAttrUiHelper;
 import io.jmix.flowui.Notifications;
+import io.jmix.flowui.UiComponents;
 import io.jmix.flowui.component.grid.DataGrid;
 import io.jmix.flowui.component.upload.FileUploadField;
 import io.jmix.flowui.download.DownloadFormat;
 import io.jmix.flowui.download.Downloader;
+import io.jmix.flowui.kit.action.Action;
 import io.jmix.flowui.kit.action.ActionPerformedEvent;
 import io.jmix.flowui.kit.component.upload.event.FileUploadSucceededEvent;
 import io.jmix.flowui.model.CollectionContainer;
 import io.jmix.flowui.model.CollectionLoader;
-import io.jmix.flowui.model.InstanceContainer;
-import io.jmix.flowui.model.InstanceLoader;
+import io.jmix.flowui.model.DataContext;
 import io.jmix.flowui.view.*;
+import io.jmix.flowui.view.navigation.RouteSupport;
+import io.jmix.flowui.view.navigation.UrlParamSerializer;
+import org.apache.commons.lang3.BooleanUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Objects;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 
+import static io.jmix.dynattrflowui.view.categoryattr.CategoryAttributesDetailView.CATEGORY_ID_ROUTE_PARAMETER;
 import static io.jmix.flowui.download.DownloadFormat.JSON;
 import static io.jmix.flowui.download.DownloadFormat.ZIP;
 
@@ -57,12 +82,20 @@ import static io.jmix.flowui.download.DownloadFormat.ZIP;
 @DialogMode(width = "47.5em")
 public class CategoryListView extends StandardListView<Category> {
 
+    public static final String SELECTED_CATEGORY_QUERY_PARAMETER = "selectedCategory";
+
     private static final Logger log = LoggerFactory.getLogger(CategoryListView.class);
 
     @Autowired
     protected Notifications notifications;
     @Autowired
     protected Messages messages;
+    @Autowired
+    protected MessageTools messageTools;
+    @Autowired
+    protected MetadataTools metadataTools;
+    @Autowired
+    protected DataManager dataManager;
     @Autowired
     protected Metadata metadata;
     @Autowired
@@ -77,27 +110,101 @@ public class CategoryListView extends StandardListView<Category> {
     protected Downloader downloader;
     @Autowired
     protected AccessManager accessManager;
+    @Autowired
+    protected UiComponents uiComponents;
+    @Autowired
+    protected UrlParamSerializer urlParamSerializer;
+    @Autowired
+    protected RouteSupport routeSupport;
+    @Autowired
+    protected DynAttrUiHelper dynAttrUiHelper;
+    @Autowired
+    protected CurrentAuthentication currentAuthentication;
+    @Autowired
+    protected ReferenceToEntitySupport referenceToEntitySupport;
+    @Autowired
+    protected FetchPlanRepository fetchPlanRepository;
+    @Autowired
+    protected FormatStringsRegistry formatStringsRegistry;
 
 
     @ViewComponent
     protected DataGrid<Category> categoriesGrid;
     @ViewComponent
-    protected CollectionContainer<CategoryAttribute> attributesDc;
-    @ViewComponent
-    protected InstanceContainer<Category> categoryDc;
-    @ViewComponent
-    protected InstanceLoader<Category> categoryDl;
+    protected CollectionContainer<Category> categoriesDc;
     @ViewComponent
     protected CollectionLoader<Category> categoriesDl;
+
+    @ViewComponent
+    protected DataGrid<CategoryAttribute> attributesTable;
+    @ViewComponent
+    protected CollectionContainer<CategoryAttribute> attributesDc;
+
+    @ViewComponent("attributesTable.create")
+    protected Action createAction;
+    @ViewComponent("attributesTable.moveUp")
+    protected Action moveUpAction;
+    @ViewComponent("attributesTable.moveDown")
+    protected Action moveDownAction;
+
     @ViewComponent
     protected FileUploadField importField;
     @ViewComponent
     protected Button applyChangesBtn;
+    @ViewComponent
+    protected DataContext dataContext;
+
+    protected UUID selectedCategoryId;
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        super.beforeEnter(event);
+
+        Map<String, List<String>> parameters = event.getLocation().getQueryParameters().getParameters();
+
+        if (parameters.containsKey(SELECTED_CATEGORY_QUERY_PARAMETER)) {
+            parameters.get(SELECTED_CATEGORY_QUERY_PARAMETER)
+                    .stream()
+                    .filter(StringUtils::isNotBlank)
+                    .findAny()
+                    .ifPresent(this::setSelectedCategory);
+        }
+    }
+
+    protected void setSelectedCategory(String categoryUUid) {
+        selectedCategoryId = UUID.fromString(categoryUUid);
+    }
 
     @Subscribe
     protected void onBeforeShow(BeforeShowEvent event) {
-        Objects.requireNonNull(attributesDc.getSorter()).sort(Sort.by(Sort.Direction.ASC, "orderNo"));
         setupFieldsLock();
+    }
+
+    @Subscribe
+    protected void onReady(ReadyEvent event) {
+        setupSelectedCategory();
+        categoriesGrid.addSelectionListener(this::onCategoryGridSelectionChange);
+    }
+
+    protected void setupFieldsLock() {
+        CrudEntityContext crudEntityContext = new CrudEntityContext(categoriesDc.getEntityMetaClass());
+        accessManager.applyRegisteredConstraints(crudEntityContext);
+        if (!crudEntityContext.isUpdatePermitted()) {
+            applyChangesBtn.setEnabled(false);
+        }
+    }
+
+    protected void setupSelectedCategory() {
+        if (selectedCategoryId == null || categoriesGrid.getItems() == null) {
+            return;
+        }
+
+        categoriesGrid.getItems()
+                .getItems()
+                .stream()
+                .filter(category -> selectedCategoryId.equals(category.getId()))
+                .findAny()
+                .ifPresent(categoriesGrid::select);
     }
 
     @Subscribe("categoriesGrid.applyChanges")
@@ -108,23 +215,278 @@ public class CategoryListView extends StandardListView<Category> {
                 .show();
     }
 
-    @Subscribe(id = "categoriesDc", target = Target.DATA_CONTAINER)
-    protected void onCategoriesDcItemChange(InstanceContainer.ItemChangeEvent<Category> event) {
-        Category category = event.getItem();
-        if (category != null) {
-            categoryDl.setEntityId(category.getId());
-            categoryDl.load();
-        } else {
-            categoryDc.setItem(null);
-        }
+    @Supply(to = "categoriesGrid.isDefault", subject = "renderer")
+    protected Renderer<Category> categoriesGridIsDefaultRenderer() {
+        return new ComponentRenderer<>(category ->
+                createCheckboxIconByAttributeValue(category.getIsDefault())
+        );
     }
 
-    protected void setupFieldsLock() {
-        CrudEntityContext crudEntityContext = new CrudEntityContext(categoryDc.getEntityMetaClass());
-        accessManager.applyRegisteredConstraints(crudEntityContext);
-        if (!crudEntityContext.isUpdatePermitted()) {
-            applyChangesBtn.setEnabled(false);
+    @Supply(to = "attributesTable.required", subject = "renderer")
+    protected Renderer<CategoryAttribute> categoryAttrsGridRequiredRenderer() {
+        return new ComponentRenderer<>(categoryAttribute ->
+                createCheckboxIconByAttributeValue(categoryAttribute.getRequired())
+        );
+    }
+
+    @Supply(to = "attributesTable.isCollection", subject = "renderer")
+    protected Renderer<CategoryAttribute> categoryAttrsGridIsCollectionRenderer() {
+        return new ComponentRenderer<>(categoryAttribute ->
+                createCheckboxIconByAttributeValue(categoryAttribute.getIsCollection())
+        );
+    }
+
+    protected Icon createCheckboxIconByAttributeValue(Boolean attributeValue) {
+        Icon icon = uiComponents.create(Icon.class);
+
+        if (Boolean.TRUE.equals(attributeValue)) {
+            icon.setIcon(VaadinIcon.CHECK_SQUARE_O);
+        } else {
+            icon.setIcon(VaadinIcon.THIN_SQUARE);
         }
+
+        return icon;
+    }
+
+    @Supply(to = "attributesTable.dataType", subject = "renderer")
+    protected Renderer<CategoryAttribute> createCategoryAttrsGridDataTypeRenderer() {
+        return new ComponentRenderer<>(this::categoryAttrsGridDataTypeComponent,
+                this::categoryAttrsGridDataTypeUpdater);
+    }
+
+    protected Span categoryAttrsGridDataTypeComponent() {
+        return uiComponents.create(Span.class);
+    }
+
+    protected void categoryAttrsGridDataTypeUpdater(Span text, CategoryAttribute categoryAttribute) {
+        String dataType;
+        if (Boolean.TRUE.equals(categoryAttribute.getIsEntity())) {
+            Class<?> javaType = categoryAttribute.getJavaType();
+            if (javaType != null) {
+                MetaClass metaClass = metadata.getClass(javaType);
+                dataType = messageTools.getEntityCaption(metaClass);
+            } else {
+                dataType = "";
+            }
+        } else {
+            String key = AttributeType.class.getSimpleName() + "." + categoryAttribute.getDataType().toString();
+            dataType = messages.getMessage(AttributeType.class, key);
+        }
+
+        text.setText(dataType);
+    }
+
+    @Supply(to = "attributesTable.defaultValue", subject = "renderer")
+    protected Renderer<CategoryAttribute> createCategoryAttrsGridDefaultValueRenderer() {
+        return new ComponentRenderer<>(this::categoryAttrsGridDefaultValueColumnComponent,
+                this::categoryAttrsGridDefaultValueColumnUpdater);
+    }
+
+    protected Span categoryAttrsGridDefaultValueColumnComponent() {
+        return uiComponents.create(Span.class);
+    }
+
+    protected void categoryAttrsGridDefaultValueColumnUpdater(Span defaultValueLabel, CategoryAttribute attribute) {
+        String defaultValue = "";
+
+        AttributeType dataType = attribute.getDataType();
+        switch (dataType) {
+            case BOOLEAN -> {
+                Boolean b = attribute.getDefaultBoolean();
+                if (b != null)
+                    defaultValue = BooleanUtils.isTrue(b)
+                            ? messages.getMessage("trueString")
+                            : messages.getMessage("falseString");
+            }
+            case DATE -> {
+                Date dateTime = attribute.getDefaultDate();
+                if (dateTime != null) {
+                    String dateTimeFormat =
+                            formatStringsRegistry.getFormatStrings(currentAuthentication.getLocale()).getDateTimeFormat();
+                    SimpleDateFormat simpleDateFormat = new SimpleDateFormat(dateTimeFormat);
+                    defaultValue = simpleDateFormat.format(dateTime);
+                } else if (BooleanUtils.isTrue(attribute.getDefaultDateIsCurrent())) {
+                    defaultValue = messages.getMessage(getClass(), "categoryAttrsGrid.currentDate");
+                }
+            }
+            case DATE_WITHOUT_TIME -> {
+                LocalDate dateWoTime = attribute.getDefaultDateWithoutTime();
+                if (dateWoTime != null) {
+                    String dateWoTimeFormat =
+                            formatStringsRegistry.getFormatStrings(currentAuthentication.getLocale()).getDateFormat();
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(dateWoTimeFormat);
+                    defaultValue = dateWoTime.format(formatter);
+                } else if (BooleanUtils.isTrue(attribute.getDefaultDateIsCurrent())) {
+                    defaultValue = messages.getMessage(getClass(), "categoryAttrsGrid.currentDate");
+                }
+            }
+            case DECIMAL -> {
+                BigDecimal defaultDecimal = attribute.getDefaultDecimal();
+                if (defaultDecimal != null) {
+                    defaultValue = defaultDecimal.toString();
+                }
+            }
+            case DOUBLE -> {
+                Double defaultDouble = attribute.getDefaultDouble();
+                if (defaultDouble != null) {
+                    defaultValue = defaultDouble.toString();
+                }
+            }
+            case ENTITY -> {
+                Class<?> entityClass = attribute.getJavaType();
+                if (entityClass != null) {
+                    defaultValue = "";
+                    if (attribute.getObjectDefaultEntityId() != null) {
+                        MetaClass metaClass = metadata.getClass(entityClass);
+                        LoadContext<?> lc = new LoadContext<>(metadata.getClass(attribute.getJavaType()));
+                        FetchPlan fetchPlan = fetchPlanRepository.getFetchPlan(metaClass, FetchPlan.INSTANCE_NAME);
+                        lc.setFetchPlan(fetchPlan);
+                        String pkName = referenceToEntitySupport.getPrimaryKeyForLoadingEntity(metaClass);
+                        lc.setQueryString(String.format("select e from %s e where e.%s = :entityId", metaClass.getName(), pkName))
+                                .setParameter("entityId", attribute.getObjectDefaultEntityId());
+                        Object entity = dataManager.load(lc);
+                        if (entity != null) {
+                            defaultValue = metadataTools.getInstanceName(entity);
+                        }
+                    }
+                } else {
+                    defaultValue = messages.getMessage(getClass(), "categoryAttrsGrid.entityNotFound");
+                }
+            }
+            case ENUMERATION, STRING -> defaultValue = attribute.getDefaultString();
+            case INTEGER -> {
+                Integer defaultInt = attribute.getDefaultInt();
+                if (defaultInt != null) {
+                    defaultValue = defaultInt.toString();
+                }
+            }
+        }
+
+        defaultValueLabel.setText(defaultValue);
+    }
+
+    @Subscribe("attributesTable.moveUp")
+    protected void onCategoryAttrsGridMoveUp(ActionPerformedEvent event) {
+        dynAttrUiHelper.moveTableItemUp(attributesDc, attributesTable, () ->
+                attributesDc.getMutableItems()
+                        .forEach(item -> item.setOrderNo(attributesDc.getMutableItems().indexOf(item))));
+        refreshMoveActionStates();
+        dataContext.save();
+    }
+
+    @Install(to = "attributesTable.moveUp", subject = "enabledRule")
+    protected boolean categoryAttrsGridMoveUpEnabledRule() {
+        CategoryAttribute item = attributesTable.getSingleSelectedItem();
+        if (item == null) {
+            return false;
+        }
+
+        return getPrevAttribute(item.getOrderNo()) != null && checkOrderNoModificationPermissions();
+    }
+
+    @Subscribe("attributesTable.moveDown")
+    protected void onCategoryAttrsGridMoveDown(ActionPerformedEvent event) {
+        dynAttrUiHelper.moveTableItemDown(attributesDc, attributesTable, () ->
+                attributesDc.getMutableItems()
+                        .forEach(item -> item.setOrderNo(attributesDc.getMutableItems().indexOf(item))));
+        refreshMoveActionStates();
+        dataContext.save();
+    }
+
+    @Install(to = "attributesTable.moveDown", subject = "enabledRule")
+    protected boolean categoryAttrsGridMoveDownEnabledRule() {
+        CategoryAttribute item = attributesTable.getSingleSelectedItem();
+        if (item == null) {
+            return false;
+        }
+
+        return getNextAttribute(item.getOrderNo()) != null && checkOrderNoModificationPermissions();
+    }
+
+    protected boolean checkOrderNoModificationPermissions() {
+        EntityAttributeContext context = new EntityAttributeContext(attributesDc.getEntityMetaClass(), "orderNo");
+        accessManager.applyRegisteredConstraints(context);
+        return context.canModify();
+    }
+
+    protected void refreshMoveActionStates() {
+        moveUpAction.refreshState();
+        moveDownAction.refreshState();
+    }
+
+    protected CategoryAttribute getPrevAttribute(Integer orderNo) {
+        return attributesDc.getMutableItems()
+                .stream()
+                .filter(categoryAttribute -> orderNo.compareTo(categoryAttribute.getOrderNo()) > 0)
+                .max(Comparator.comparing(CategoryAttribute::getOrderNo))
+                .orElse(null);
+    }
+
+    protected CategoryAttribute getNextAttribute(Integer orderNo) {
+        return attributesDc.getMutableItems()
+                .stream()
+                .filter(categoryAttribute -> orderNo.compareTo(categoryAttribute.getOrderNo()) < 0)
+                .min(Comparator.comparing(CategoryAttribute::getOrderNo))
+                .orElse(null);
+    }
+
+    @Install(to = "attributesTable.create", subject = "enabledRule")
+    protected boolean categoryAttrsGridCreateEnabledRule() {
+        return categoriesGrid.getSingleSelectedItem() != null;
+    }
+
+    @Subscribe("categoriesGrid")
+    protected void onCategoriesGridSelectionEvent(SelectionEvent<Grid<Category>, Category> event) {
+        createAction.refreshState();
+    }
+
+    protected void onCategoryGridSelectionChange(SelectionEvent<Grid<Category>, Category> event) {
+        Object categoryUuid;
+
+        Category category = categoriesGrid.getSingleSelectedItem();
+        if (category == null) {
+            categoryUuid = StringUtils.EMPTY;
+        } else {
+            categoryUuid = category.getId();
+        }
+
+        UI ui = UI.getCurrent();
+        routeSupport.setQueryParameter(ui, SELECTED_CATEGORY_QUERY_PARAMETER, categoryUuid);
+    }
+
+    @Install(to = "attributesTable.create", subject = "routeParametersProvider")
+    protected RouteParameters attributesTableCreateActionRouteParametersProvider() {
+        Category category = categoriesGrid.getSingleSelectedItem();
+        if (category == null) {
+            return RouteParameters.empty();
+        }
+
+        RouteParam categoryParam = new RouteParam(
+                CATEGORY_ID_ROUTE_PARAMETER, urlParamSerializer.serialize(category.getId())
+        );
+        RouteParam categoryAttributeParam = new RouteParam(
+                StandardDetailView.DEFAULT_ROUTE_PARAM, StandardDetailView.NEW_ENTITY_ID
+        );
+
+        return new RouteParameters(categoryParam, categoryAttributeParam);
+    }
+
+    @Install(to = "attributesTable.edit", subject = "routeParametersProvider")
+    protected RouteParameters attributesTableEditActionRouteParametersProvider() {
+        Category category = categoriesGrid.getSingleSelectedItem();
+        CategoryAttribute categoryAttribute = attributesTable.getSingleSelectedItem();
+        if (category == null || categoryAttribute == null) {
+            return RouteParameters.empty();
+        }
+
+        RouteParam categoryParam = new RouteParam(
+                CATEGORY_ID_ROUTE_PARAMETER, urlParamSerializer.serialize(category.getId())
+        );
+        RouteParam categoryAttributeParam = new RouteParam(
+                StandardDetailView.DEFAULT_ROUTE_PARAM, urlParamSerializer.serialize(categoryAttribute.getId())
+        );
+
+        return new RouteParameters(categoryParam, categoryAttributeParam);
     }
 
     @Subscribe("categoriesGrid.exportJSON")

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/category/CategoryListView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/category/CategoryListView.java
@@ -160,6 +160,17 @@ public class CategoryListView extends StandardListView<Category> {
     public void beforeEnter(BeforeEnterEvent event) {
         super.beforeEnter(event);
 
+        processQueryParameters(event);
+    }
+
+    @Override
+    protected void processBeforeEnterInternal(BeforeEnterEvent event) {
+        super.processBeforeEnterInternal(event);
+
+        processQueryParameters(event);
+    }
+
+    protected void processQueryParameters(BeforeEnterEvent event) {
         Map<String, List<String>> parameters = event.getLocation().getQueryParameters().getParameters();
 
         if (parameters.containsKey(SELECTED_CATEGORY_QUERY_PARAMETER)) {

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/AttributeEnumerationDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/AttributeEnumerationDetailView.java
@@ -22,17 +22,16 @@ import com.google.common.collect.Lists;
 import com.vaadin.flow.component.ClickEvent;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.button.Button;
-import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
+import com.vaadin.flow.data.renderer.Renderer;
 import io.jmix.core.*;
 import io.jmix.core.accesscontext.CrudEntityContext;
 import io.jmix.dynattr.MsgBundleTools;
 import io.jmix.dynattrflowui.impl.model.AttributeLocalizedEnumValue;
 import io.jmix.dynattrflowui.view.localization.AttributeLocalizationComponent;
 import io.jmix.flowui.UiComponents;
-import io.jmix.flowui.component.grid.DataGrid;
 import io.jmix.flowui.component.textfield.TypedTextField;
 import io.jmix.flowui.kit.action.Action;
 import io.jmix.flowui.kit.action.ActionPerformedEvent;
@@ -54,9 +53,8 @@ import java.util.stream.Collectors;
 
 @ViewController("dynat_AttributeEnumerationDetailView")
 @ViewDescriptor("attribute-enumeration-detail-view.xml")
-@DialogMode(width = "55em", height = "45em", resizable = true)
+@DialogMode(width = "65em", resizable = true)
 public class AttributeEnumerationDetailView extends StandardView {
-    public static final String REMOVE_ITEM_COLUMN = "removeItem";
 
     @Autowired
     protected CoreProperties coreProperties;
@@ -83,14 +81,11 @@ public class AttributeEnumerationDetailView extends StandardView {
     protected CollectionLoader<AttributeLocalizedEnumValue> localizedEnumValuesDl;
     @ViewComponent
     protected CollectionContainer<AttributeLocalizedEnumValue> localizedEnumValuesDc;
-    @ViewComponent
-    protected DataGrid<AttributeLocalizedEnumValue> localizedEnumValuesDataGrid;
 
     protected String enumeration;
     protected String enumerationLocales;
     protected AttributeLocalizationComponent localizationFragment;
     protected List<AttributeLocalizedEnumValue> localizedEnumValues = new ArrayList<>();
-
 
     public void setEnumeration(String enumeration) {
         this.enumeration = enumeration;
@@ -116,21 +111,11 @@ public class AttributeEnumerationDetailView extends StandardView {
     }
 
     @Subscribe
-    protected void onInit(InitEvent e) {
-        Grid.Column<AttributeLocalizedEnumValue> removeItemColumn = localizedEnumValuesDataGrid.getColumnByKey(REMOVE_ITEM_COLUMN);
-        if (removeItemColumn == null) {
-            throw new IllegalStateException("No column with key " + REMOVE_ITEM_COLUMN);
-        }
-        removeItemColumn.setRenderer(createRemoveItemColumnRenderer());
-    }
-
-    @Subscribe
     protected void onBeforeShow(BeforeShowEvent event) {
         initLocalizedEnumValuesDataGrid();
         initLocalizationFragment();
         localizedEnumValuesDl.load();
     }
-
 
     @Install(to = "localizedEnumValuesDl", target = Target.DATA_LOADER)
     protected List<AttributeLocalizedEnumValue> localizedEnumValuesDlLoadDelegate(LoadContext<AttributeLocalizedEnumValue> loadContext) {
@@ -157,7 +142,8 @@ public class AttributeEnumerationDetailView extends StandardView {
         }
     }
 
-    protected ComponentRenderer<JmixButton, AttributeLocalizedEnumValue> createRemoveItemColumnRenderer() {
+    @Supply(to = "localizedEnumValuesDataGrid.removeItem", subject = "renderer")
+    protected Renderer<AttributeLocalizedEnumValue> createRemoveItemColumnRenderer() {
         return new ComponentRenderer<>(this::createRemoveItemColumnComponent, this::gradeRemoveItemColumnUpdater);
     }
 
@@ -172,7 +158,7 @@ public class AttributeEnumerationDetailView extends StandardView {
                     localizedEnumValuesDl.load();
                 })
                 .withVariant(ActionVariant.DANGER)
-                .withIcon(VaadinIcon.CLOSE.create());
+                .withIcon(VaadinIcon.TRASH.create());
         button.setAction(removeAction);
     }
 

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/AttributeEnumerationDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/AttributeEnumerationDetailView.java
@@ -20,9 +20,12 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.vaadin.flow.component.ClickEvent;
+import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.icon.VaadinIcon;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
@@ -32,6 +35,8 @@ import io.jmix.dynattr.MsgBundleTools;
 import io.jmix.dynattrflowui.impl.model.AttributeLocalizedEnumValue;
 import io.jmix.dynattrflowui.view.localization.AttributeLocalizationComponent;
 import io.jmix.flowui.UiComponents;
+import io.jmix.flowui.component.grid.DataGrid;
+import io.jmix.flowui.component.grid.editor.DataGridEditor;
 import io.jmix.flowui.component.textfield.TypedTextField;
 import io.jmix.flowui.kit.action.Action;
 import io.jmix.flowui.kit.action.ActionPerformedEvent;
@@ -53,7 +58,7 @@ import java.util.stream.Collectors;
 
 @ViewController("dynat_AttributeEnumerationDetailView")
 @ViewDescriptor("attribute-enumeration-detail-view.xml")
-@DialogMode(width = "65em", resizable = true)
+@DialogMode(width = "30em", resizable = true)
 public class AttributeEnumerationDetailView extends StandardView {
 
     @Autowired
@@ -81,6 +86,8 @@ public class AttributeEnumerationDetailView extends StandardView {
     protected CollectionLoader<AttributeLocalizedEnumValue> localizedEnumValuesDl;
     @ViewComponent
     protected CollectionContainer<AttributeLocalizedEnumValue> localizedEnumValuesDc;
+    @ViewComponent
+    protected DataGrid<AttributeLocalizedEnumValue> localizedEnumValuesDataGrid;
 
     protected String enumeration;
     protected String enumerationLocales;
@@ -142,13 +149,87 @@ public class AttributeEnumerationDetailView extends StandardView {
         }
     }
 
-    @Supply(to = "localizedEnumValuesDataGrid.removeItem", subject = "renderer")
-    protected Renderer<AttributeLocalizedEnumValue> createRemoveItemColumnRenderer() {
-        return new ComponentRenderer<>(this::createRemoveItemColumnComponent, this::gradeRemoveItemColumnUpdater);
+    @Supply(to = "localizedEnumValuesDataGrid.bufferedEditorColumn", subject = "editorComponent")
+    protected Component localizedEnumValuesDataGridEditorComponent() {
+        DataGridEditor<AttributeLocalizedEnumValue> editor = localizedEnumValuesDataGrid.getEditor();
+
+        JmixButton saveButton = createEditorSaveButton(editor);
+        JmixButton cancelButton = createEditorCancelButton(editor);
+
+        HorizontalLayout editorButtonsLayout = createEditorButtonsLayout();
+        editorButtonsLayout.add(saveButton, cancelButton);
+
+        return editorButtonsLayout;
     }
 
-    protected JmixButton createRemoveItemColumnComponent() {
-        return uiComponents.create(JmixButton.class);
+    protected JmixButton createEditorSaveButton(DataGridEditor<AttributeLocalizedEnumValue> editor) {
+        JmixButton saveButton = uiComponents.create(JmixButton.class);
+        saveButton.setIcon(VaadinIcon.CHECK.create());
+        saveButton.addThemeVariants(ButtonVariant.LUMO_SUCCESS);
+        saveButton.addClickListener(__ -> editor.save());
+
+        return saveButton;
+    }
+
+    protected JmixButton createEditorCancelButton(DataGridEditor<AttributeLocalizedEnumValue> editor) {
+        JmixButton cancelButton = uiComponents.create(JmixButton.class);
+        cancelButton.setIcon(VaadinIcon.CLOSE.create());
+        cancelButton.addThemeVariants(ButtonVariant.LUMO_ERROR);
+
+        cancelButton.addClickListener(__ -> editor.cancel());
+
+        return cancelButton;
+    }
+
+    @Supply(to = "localizedEnumValuesDataGrid.bufferedEditorColumn", subject = "renderer")
+    protected Renderer<AttributeLocalizedEnumValue> localizedEnumValuesDataGridEditorRenderer() {
+        return new ComponentRenderer<>(this::createEditorColumnRenderer);
+    }
+
+    protected Component createEditorColumnRenderer(AttributeLocalizedEnumValue currentItem) {
+        DataGridEditor<AttributeLocalizedEnumValue> editor = localizedEnumValuesDataGrid.getEditor();
+
+        JmixButton editButton = createEditorEditButton(editor, currentItem);
+        JmixButton removeButton = createEditorRemoveButton(currentItem);
+
+        HorizontalLayout editorButtonsLayout = createEditorButtonsLayout();
+        editorButtonsLayout.add(editButton, removeButton);
+
+        return editorButtonsLayout;
+    }
+
+    protected JmixButton createEditorEditButton(DataGridEditor<AttributeLocalizedEnumValue> editor,
+                                                AttributeLocalizedEnumValue currentItem) {
+        JmixButton editorButton = uiComponents.create(JmixButton.class);
+        editorButton.setIcon(VaadinIcon.PENCIL.create());
+
+        editorButton.addClickListener(__ -> {
+            if (editor.isOpen()) {
+                editor.cancel();
+            }
+            editor.editItem(currentItem);
+        });
+
+        return editorButton;
+    }
+
+    protected JmixButton createEditorRemoveButton(AttributeLocalizedEnumValue currentItem) {
+        JmixButton removeButton = uiComponents.create(JmixButton.class);
+        removeButton.setIcon(VaadinIcon.TRASH.create());
+        removeButton.addThemeVariants(ButtonVariant.LUMO_ERROR);
+
+        removeButton.addClickListener(__ -> {
+            localizedEnumValues.remove(currentItem);
+            localizedEnumValuesDl.load();
+        });
+
+        return removeButton;
+    }
+
+    protected HorizontalLayout createEditorButtonsLayout() {
+        HorizontalLayout horizontalLayout = uiComponents.create(HorizontalLayout.class);
+        horizontalLayout.setPadding(false);
+        return horizontalLayout;
     }
 
     protected void gradeRemoveItemColumnUpdater(JmixButton button, AttributeLocalizedEnumValue customer) {

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
@@ -480,6 +480,10 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
                 })
                 .build();
 
+        // localizedEnumValuesDataGrid will be shown
+        if (coreProperties.getAvailableLocales().size() > 1) {
+            enumerationScreen.setWidth("65em");
+        }
         enumerationScreen.getView().setEnumeration(getEditedEntity().getEnumeration());
         enumerationScreen.getView().setEnumerationLocales(getEditedEntity().getEnumerationLocales());
         enumerationScreen.open();

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/localization/AttributeLocalizationComponent.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/localization/AttributeLocalizationComponent.java
@@ -22,6 +22,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.component.grid.editor.Editor;
+import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
@@ -95,12 +96,12 @@ public class AttributeLocalizationComponent extends Composite<VerticalLayout> {
     protected VerticalLayout initContent() {
         VerticalLayout content = super.initContent();
         content.add(localizedValuesDataGrid);
-        content.setMargin(false);
         content.setPadding(false);
+        content.setHeightFull();
         return content;
     }
 
-    private void initData() {
+    protected void initData() {
         localizedValuesDc = this.dataComponents.createCollectionContainer(AttributeLocalizedValue.class);
         localizedValuesDl = this.dataComponents.createCollectionLoader();
         localizedValuesDc.addItemChangeListener(e -> Optional.ofNullable(e.getItem()).ifPresent(val -> dataContext.setModified(val, true)));
@@ -108,19 +109,25 @@ public class AttributeLocalizationComponent extends Composite<VerticalLayout> {
         localizedValuesDl.setContainer(localizedValuesDc);
     }
 
-    private void initComponentUi() {
+    protected void initComponentUi() {
         localizedValuesDataGrid = new Grid<>(AttributeLocalizedValue.class, false);
+        localizedValuesDataGrid.setHeightFull();
         localizedValuesDataGrid.setDataProvider(new ContainerDataGridItems<>(localizedValuesDc));
 
-        Grid.Column<AttributeLocalizedValue> languageColumn = localizedValuesDataGrid.addColumn(LANG_PROPERTY);
-        languageColumn.setHeader(messageTools.getPropertyCaption(metadata.getClass(AttributeLocalizedValue.class), LANG_PROPERTY));
-        languageColumn.setRenderer(new ComponentRenderer<>(item -> new Text(item.getLanguage() + "|" + item.getLocale())));
+        localizedValuesDataGrid.addColumn(LANG_PROPERTY)
+                .setSortable(false)
+                .setHeader(messageTools.getPropertyCaption(metadata.getClass(AttributeLocalizedValue.class), LANG_PROPERTY))
+                .setRenderer(new ComponentRenderer<>(item -> new Text(item.getLanguage() + "|" + item.getLocale())))
+                .setFlexGrow(0)
+                .setAutoWidth(true);
 
-        Grid.Column<AttributeLocalizedValue> nameCol = localizedValuesDataGrid.addColumn(NAME_PROPERTY);
-        nameCol.setHeader(messageTools.getPropertyCaption(metadata.getClass(AttributeLocalizedValue.class), NAME_PROPERTY));
+        Grid.Column<AttributeLocalizedValue> nameCol = localizedValuesDataGrid.addColumn(NAME_PROPERTY)
+                .setSortable(false)
+                .setHeader(messageTools.getPropertyCaption(metadata.getClass(AttributeLocalizedValue.class), NAME_PROPERTY));
 
-        Grid.Column<AttributeLocalizedValue> descriptionCol = localizedValuesDataGrid.addColumn(DESCRIPTION_PROPERTY);
-        descriptionCol.setHeader(messageTools.getPropertyCaption(metadata.getClass(AttributeLocalizedValue.class), DESCRIPTION_PROPERTY));
+        Grid.Column<AttributeLocalizedValue> descriptionCol = localizedValuesDataGrid.addColumn(DESCRIPTION_PROPERTY)
+                .setSortable(false)
+                .setHeader(messageTools.getPropertyCaption(metadata.getClass(AttributeLocalizedValue.class), DESCRIPTION_PROPERTY));
 
         Editor<AttributeLocalizedValue> editor = localizedValuesDataGrid.getEditor();
         editor.addSaveListener(e -> {
@@ -128,7 +135,7 @@ public class AttributeLocalizationComponent extends Composite<VerticalLayout> {
         });
 
         Grid.Column<AttributeLocalizedValue> editColumn = localizedValuesDataGrid.addComponentColumn(attributeLocalizedValue -> {
-                    Button editButton = new Button(messages.getMessage("actions.Edit"));
+                    Button editButton = new Button(new Icon(VaadinIcon.PENCIL));
                     editButton.setEnabled(true);
                     editButton.addClickListener(e -> {
                         if (editor.isOpen()) {
@@ -139,7 +146,7 @@ public class AttributeLocalizationComponent extends Composite<VerticalLayout> {
                     editButton.setEnabled(true);
                     return editButton;
                 })
-                .setWidth("16em")
+                .setWidth("8em")
                 .setFlexGrow(0);
 
         Binder<AttributeLocalizedValue> binder = new Binder<>(AttributeLocalizedValue.class);

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/META-INF/resources/styles/dynattr-styles.css
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/META-INF/resources/styles/dynattr-styles.css
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+jmix-tabsheet.category-attributes-detail-main-tab-sheet::part(content) {
+    padding: unset;
+}
+
+.category-list-view-wrapper {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(40rem, 1fr));
+}

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/messages.properties
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/messages.properties
@@ -59,7 +59,7 @@ io.jmix.dynattrflowui.view.categoryattr/entityClassField.required=Entity type re
 io.jmix.dynattrflowui.view.categoryattr/viewField.required=Entity view required
 io.jmix.dynattrflowui.view.categoryattr/widthField.validationMessage=Width is incorrect
 io.jmix.dynattrflowui.view.categoryattr/rowsCountField.validationMessage=Rows count should be a number between 1 and 40
-io.jmix.dynattrflowui.view.categoryattr/calculatedValuesAndOptionsTab.title=Calculated values and options
+io.jmix.dynattrflowui.view.categoryattr/advancedTab.label=Advanced
 io.jmix.dynattrflowui.view.categoryattr/constraintWizardField.title=Constraint wizard
 io.jmix.dynattrflowui.view.categoryattr/selectEntityType=Select entity type
 io.jmix.dynattrflowui.view.categoryattr/minGreaterThanMax=Minimum value can't be greater than maximum
@@ -75,10 +75,8 @@ io.jmix.dynattrflowui.view.categoryattr/dependsOnAttributes.validationMsg=At lea
 io.jmix.dynattrflowui.view.categoryattr/uniqueName=Attribute with same name already exists
 io.jmix.dynattrflowui.view.categoryattr/uniqueCode=Attribute with same code already exists
 io.jmix.dynattrflowui.view.categoryattr/localizationTab.title=Localization
-io.jmix.dynattrflowui.view.categoryattr/visibilityTab.title=Visibility
 io.jmix.dynattrflowui.view.categoryattr/visibilityTab.help=<div>Сonfigure <b>dynamicAttributes</b> facet for views that will display dynamic attributes.</div>
-io.jmix.dynattrflowui.view.categoryattr/targetViewsTable.create=Add target view
-io.jmix.dynattrflowui.view.categoryattr/targetViewsTable.remove=Remove target view
+io.jmix.dynattrflowui.view.categoryattr/targetScreensTable.addAllViews.text=Add all known views
 io.jmix.dynattrflowui.view.categoryattr/optionsLoaderGroovyScript=Options loader groovy script
 io.jmix.dynattrflowui.view.categoryattr/optionsLoaderGroovyScriptHelp=<div>Allows you to load dynamic attribute options by a Groovy script.\
   <br/>A script should return options list. The entity with dynamic attributes is available \
@@ -151,8 +149,6 @@ io.jmix.dynattrflowui.view.categoryattr/targetViews=Target views
 # AttributeEnumerationView
 io.jmix.dynattrflowui.view.categoryattr/enumerationView.title=Enumeration details
 io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.action=Action
-io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.edit=Editing
-io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.remove=Remove
 io.jmix.dynattrflowui.view.categoryattr/localizationBox.title=Localization
 io.jmix.dynattrflowui.view.categoryattr/localizedEnumValuesDataGrid.add=Add
 

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/messages.properties
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/messages.properties
@@ -17,10 +17,9 @@ menu-config.dynamicattributes.title=Dynamic attributes
 
 # Category List
 io.jmix.dynattrflowui.view.category/categoryListView.title=Dynamic attributes
-io.jmix.dynattrflowui.view.category/categoriesGrid.create=Create category
 io.jmix.dynattrflowui.view.category/categoriesGrid.applyChanges=Apply changes
 io.jmix.dynattrflowui.view.category/notification.changesApplied=Changes have been applied
-io.jmix.dynattrflowui.view.category/categoriesGrid.name=Category
+io.jmix.dynattrflowui.view.category/categoryHeader.text=Categories
 io.jmix.dynattrflowui.view.category/categoryAttributes.text=Category attributes
 
 # Category Detail

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/module.properties
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/module.properties
@@ -15,3 +15,4 @@
 #
 
 jmix.ui.menu-config = io/jmix/dynattrflowui/menu.xml
+jmix.ui.export-styles=styles/dynattr-styles.css

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/category/category-detail-view.xml
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/category/category-detail-view.xml
@@ -20,16 +20,9 @@
     <data>
         <instance id="categoryDc"
                   class="io.jmix.dynattr.model.Category">
-            <fetchPlan extends="_local">
-                <property name="categoryAttrs" fetchPlan="_local">
-                    <property name="defaultEntity" fetchPlan="_local"/>
-                    <property name="category" fetchPlan="_local"/>
-                </property>
-            </fetchPlan>
+            <fetchPlan extends="_local"/>
             <loader id="categoryDl"/>
-            <collection id="categoryAttributesDc" property="categoryAttrs"/>
         </instance>
-        <collection id="categoryAttributesLocationDc" class="io.jmix.dynattr.model.CategoryAttribute"/>
     </data>
     <facets>
         <settings auto="true"/>
@@ -42,48 +35,20 @@
     <layout spacing="true" expand="tabSheet">
         <tabSheet id="tabSheet" height="AUTO" width="100%">
             <tab id="mainTab" label="msg://mainTab.title">
-                <vbox padding="false" margin="false">
-                    <formLayout id="form" dataContainer="categoryDc">
-                        <responsiveSteps>
-                            <responsiveStep minWidth="0" columns="1"/>
-                            <responsiveStep minWidth="28em" columns="2"/>
-                            <responsiveStep minWidth="42em" columns="3"/>
-                        </responsiveSteps>
-                        <textField id="nameField" property="name"
-                                   required="true" requiredMessage="msg://nameField.required"/>
-                        <comboBox id="entityTypeField"
-                                  label="msg://io.jmix.dynattr.model/Category.entityType"
-                                  required="true"
-                                  requiredMessage="msg://entityTypeField.required"/>
-                        <checkbox id="isDefaultField" property="isDefault"/>
-                    </formLayout>
-                    <h4 text="msg://io.jmix.dynattr.model/Category.categoryAttrs"/>
-                    <hbox id="buttonsPanel" classNames="buttons-panel">
-                        <button id="createBtn" action="categoryAttrsGrid.create"/>
-                        <button id="editBtn" action="categoryAttrsGrid.edit"/>
-                        <button id="removeBtn" action="categoryAttrsGrid.remove"/>
-                        <button id="moveUpBtn" action="categoryAttrsGrid.moveUp"/>
-                        <button id="moveDownBtn" action="categoryAttrsGrid.moveDown"/>
-                    </hbox>
-                    <dataGrid id="categoryAttrsGrid" dataContainer="categoryAttributesDc"
-                              width="100%" minHeight="20em" height="100%"
-                              columnReorderingAllowed="true">
-                        <actions>
-                            <action id="create" icon="PLUS" text="msg:///actions.Create" actionVariant="PRIMARY"/>
-                            <action id="edit" icon="PENCIL" text="msg:///actions.Edit"/>
-                            <action id="remove" icon="TRASH" text="msg:///actions.Remove" actionVariant="DANGER"/>
-                            <action id="moveUp" icon="ARROW_UP"/>
-                            <action id="moveDown" icon="ARROW_DOWN"/>
-                        </actions>
-                        <columns resizable="true">
-                            <column property="name"/>
-                            <column property="code"/>
-                            <column property="required"/>
-                            <column key="dataType" header="msg://io.jmix.dynattr.model/CategoryAttribute.dataType"/>
-                            <column key="defaultValue" header="msg://categoryAttrsGrid.defaultValue"/>
-                        </columns>
-                    </dataGrid>
-                </vbox>
+                <formLayout id="form" dataContainer="categoryDc">
+                    <responsiveSteps>
+                        <responsiveStep minWidth="0" columns="1"/>
+                        <responsiveStep minWidth="28em" columns="2"/>
+                        <responsiveStep minWidth="42em" columns="3"/>
+                    </responsiveSteps>
+                    <comboBox id="entityTypeField"
+                              label="msg://io.jmix.dynattr.model/Category.entityType"
+                              required="true"
+                              requiredMessage="msg://entityTypeField.required"/>
+                    <textField id="nameField" property="name"
+                               required="true" requiredMessage="msg://nameField.required"/>
+                    <checkbox id="isDefaultField" property="isDefault"/>
+                </formLayout>
             </tab>
             <tab id="localizationTab" label="msg://localizationTab.title" visible="false">
                 <vbox id="localizationTabContainer" padding="false" margin="false">

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/category/category-detail-view.xml
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/category/category-detail-view.xml
@@ -32,7 +32,7 @@
         <action id="windowCommitAndClose" type="detail_saveClose"/>
         <action id="windowClose" type="detail_close"/>
     </actions>
-    <layout spacing="true" expand="tabSheet">
+    <layout expand="tabSheet">
         <tabSheet id="tabSheet" height="AUTO" width="100%">
             <tab id="mainTab" label="msg://mainTab.title">
                 <formLayout id="form" dataContainer="categoryDc">
@@ -58,7 +58,7 @@
                 </vbox>
             </tab>
         </tabSheet>
-        <hbox id="detailButtonsBox" spacing="true">
+        <hbox id="detailButtonsBox">
             <button action="windowCommitAndClose"/>
             <button action="windowClose"/>
         </hbox>

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/category/category-list-view.xml
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/category/category-list-view.xml
@@ -41,84 +41,85 @@
         <settings auto="true"/>
         <dataLoadCoordinator auto="true"/>
     </facets>
-    <layout>
-        <split id="split" orientation="HORIZONTAL" width="100%" minHeight="25em"
-               height="100%" themeNames="splitter-spacing">
-            <vbox id="categoryBox" padding="false" height="100%" expand="categoriesGrid">
-                <h2 id="categoryHeader" text="msg://categoryHeader.text"/>
-                <hbox id="buttonsPanel" classNames="buttons-panel">
-                    <button id="createBtn" action="categoriesGrid.create"/>
-                    <button id="editBtn" action="categoriesGrid.edit"/>
-                    <button id="removeBtn" action="categoriesGrid.remove"/>
-                    <button id="applyChangesBtn" action="categoriesGrid.applyChanges"/>
-                    <dropdownButton id="exportBtn" icon="DOWNLOAD" text="msg://export">
-                        <items>
-                            <actionItem id="exportJSONButtonAction" ref="categoriesGrid.exportJSON"/>
-                            <actionItem id="exportZIPButtonAction" ref="categoriesGrid.exportZIP"/>
-                        </items>
-                    </dropdownButton>
-                    <fileUploadField id="importField" uploadIcon="UPLOAD" uploadText="msg://import"
-                                     acceptedFileTypes=".json,.zip"/>
-                </hbox>
-                <dataGrid id="categoriesGrid"
-                          width="100%"
-                          minHeight="20em"
-                          columnReorderingAllowed="true"
-                          dataContainer="categoriesDc">
-                    <actions>
-                        <action id="create" type="list_create">
-                            <properties>
-                                <property name="openMode" value="DIALOG"/>
-                            </properties>
-                        </action>
-                        <action id="edit" type="list_edit">
-                            <properties>
-                                <property name="openMode" value="DIALOG"/>
-                            </properties>
-                        </action>
-                        <action id="remove" type="list_remove"/>
-                        <action id="applyChanges" text="msg://categoriesGrid.applyChanges" icon="CHECK"/>
-                        <action id="exportJSON" text="msg://exportJSON"/>
-                        <action id="exportZIP" text="msg://exportZIP"/>
-                    </actions>
-                    <columns resizable="true">
-                        <column property="name"/>
-                        <column property="entityType"/>
-                        <column property="isDefault"/>
-                    </columns>
-                </dataGrid>
-            </vbox>
-            <vbox id="attributesBox" padding="false"
-                  height="100%" expand="attributesTable">
-                <h2 text="msg://categoryAttributes.text"/>
-                <hbox id="attributesButtonsPanel" classNames="buttons-panel">
-                    <button id="createBtn" action="attributesTable.create"/>
-                    <button id="editBtn" action="attributesTable.edit"/>
-                    <button id="removeBtn" action="attributesTable.remove"/>
-                    <button id="moveUpBtn" action="attributesTable.moveUp"/>
-                    <button id="moveDownBtn" action="attributesTable.moveDown"/>
-                </hbox>
-                <dataGrid id="attributesTable"
-                          width="100%"
-                          columnReorderingAllowed="true"
-                          dataContainer="attributesDc">
-                    <actions>
-                        <action id="create" type="list_create"/>
-                        <action id="edit" type="list_edit"/>
-                        <action id="remove" type="list_remove"/>
-                        <action id="moveUp" icon="ARROW_UP" type="list_itemTracking"/>
-                        <action id="moveDown" icon="ARROW_DOWN" type="list_itemTracking"/>
-                    </actions>
-                    <columns resizable="true" sortable="false">
-                        <column property="name"/>
-                        <column property="code"/>
-                        <column property="dataType"/>
-                        <column key="defaultValue" header="msg://categoryAttrsGrid.defaultValue"/>
-                        <column property="required"/>
-                        <column property="isCollection"/>
-                    </columns>
-                </dataGrid>
-            </vbox>
-        </split>
+    <layout classNames="category-list-view-wrapper">
+        <vbox id="categoryBox" padding="false" height="100%" expand="categoriesGrid">
+            <h2 id="categoryHeader" text="msg://categoryHeader.text"/>
+            <hbox id="buttonsPanel" classNames="buttons-panel">
+                <button id="createBtn" action="categoriesGrid.create"/>
+                <button id="editBtn" action="categoriesGrid.edit"/>
+                <button id="removeBtn" action="categoriesGrid.remove"/>
+                <button id="applyChangesBtn" action="categoriesGrid.applyChanges"/>
+                <dropdownButton id="exportBtn" icon="DOWNLOAD" text="msg://export">
+                    <items>
+                        <actionItem id="exportJSONButtonAction" ref="categoriesGrid.exportJSON"/>
+                        <actionItem id="exportZIPButtonAction" ref="categoriesGrid.exportZIP"/>
+                    </items>
+                </dropdownButton>
+                <fileUploadField id="importField" uploadIcon="UPLOAD" uploadText="msg://import"
+                                 acceptedFileTypes=".json,.zip"/>
+            </hbox>
+            <dataGrid id="categoriesGrid"
+                      width="100%"
+                      height="100%"
+                      minHeight="20em"
+                      columnReorderingAllowed="true"
+                      dataContainer="categoriesDc">
+                <actions>
+                    <action id="create" type="list_create">
+                        <properties>
+                            <property name="openMode" value="DIALOG"/>
+                        </properties>
+                    </action>
+                    <action id="edit" type="list_edit">
+                        <properties>
+                            <property name="openMode" value="DIALOG"/>
+                        </properties>
+                    </action>
+                    <action id="remove" type="list_remove"/>
+                    <action id="applyChanges" text="msg://categoriesGrid.applyChanges"
+                            icon="CHECK" actionVariant="SUCCESS"/>
+                    <action id="exportJSON" text="msg://exportJSON"/>
+                    <action id="exportZIP" text="msg://exportZIP"/>
+                </actions>
+                <columns resizable="true">
+                    <column property="name"/>
+                    <column property="entityType"/>
+                    <column property="isDefault"/>
+                </columns>
+            </dataGrid>
+        </vbox>
+        <vbox id="attributesBox" padding="false"
+              height="100%" expand="attributesTable">
+            <h2 text="msg://categoryAttributes.text"/>
+            <hbox id="attributesButtonsPanel" classNames="buttons-panel">
+                <button id="createBtn" action="attributesTable.create"/>
+                <button id="editBtn" action="attributesTable.edit"/>
+                <button id="removeBtn" action="attributesTable.remove"/>
+                <button id="moveUpBtn" action="attributesTable.moveUp"/>
+                <button id="moveDownBtn" action="attributesTable.moveDown"/>
+            </hbox>
+            <dataGrid id="attributesTable"
+                      width="100%"
+                      height="100%"
+                      minHeight="20em"
+                      columnReorderingAllowed="true"
+                      dataContainer="attributesDc">
+                <actions>
+                    <action id="create" type="list_create"/>
+                    <action id="edit" type="list_edit"/>
+                    <action id="remove" type="list_remove"/>
+                    <action id="moveUp" icon="ARROW_UP" type="list_itemTracking"/>
+                    <action id="moveDown" icon="ARROW_DOWN" type="list_itemTracking"/>
+                </actions>
+                <columns resizable="true" sortable="false">
+                    <column property="name"/>
+                    <column property="code"/>
+                    <column property="dataType"/>
+                    <column key="defaultValue" header="msg://categoryAttrsGrid.defaultValue"/>
+                    <column property="required" autoWidth="true"/>
+                    <column property="isCollection" autoWidth="true"/>
+                </columns>
+            </dataGrid>
+        </vbox>
     </layout>
 </view>

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/category/category-list-view.xml
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/category/category-list-view.xml
@@ -16,34 +16,36 @@
 <view xmlns="http://jmix.io/schema/flowui/view"
       title="msg://categoryListView.title"
       focusComponent="categoriesGrid">
-    <data readOnly="true">
+    <data>
         <collection id="categoriesDc"
                     class="io.jmix.dynattr.model.Category"
                     fetchPlan="_local">
-            <loader id="categoriesDl">
+            <loader id="categoriesDl" readOnly="true">
                 <query>
                     <![CDATA[select c from dynat_Category c where c.special is null order by c.createTs]]>
                 </query>
             </loader>
         </collection>
-        <instance id="categoryDc"
-                  class="io.jmix.dynattr.model.Category">
-            <fetchPlan extends="_local">
-                <property name="categoryAttrs" fetchPlan="_local"/>
-            </fetchPlan>
-            <loader id="categoryDl"/>
-            <collection id="attributesDc" property="categoryAttrs"/>
-        </instance>
+        <collection id="attributesDc" class="io.jmix.dynattr.model.CategoryAttribute">
+            <fetchPlan extends="_base"/>
+            <loader id="attributesDl">
+                <query>
+                    <![CDATA[select a from dynat_CategoryAttribute a where a.category = :container_categoriesDc
+                    order by a.orderNo asc]]>
+                </query>
+            </loader>
+        </collection>
     </data>
 
     <facets>
         <settings auto="true"/>
         <dataLoadCoordinator auto="true"/>
     </facets>
-    <layout spacing="true">
+    <layout>
         <split id="split" orientation="HORIZONTAL" width="100%" minHeight="25em"
                height="100%" themeNames="splitter-spacing">
             <vbox id="categoryBox" padding="false" height="100%" expand="categoriesGrid">
+                <h2 id="categoryHeader" text="msg://categoryHeader.text"/>
                 <hbox id="buttonsPanel" classNames="buttons-panel">
                     <button id="createBtn" action="categoriesGrid.create"/>
                     <button id="editBtn" action="categoriesGrid.edit"/>
@@ -64,30 +66,54 @@
                           columnReorderingAllowed="true"
                           dataContainer="categoriesDc">
                     <actions>
-                        <action id="create" type="list_create" text="msg://categoriesGrid.create"/>
-                        <action id="edit" type="list_edit"/>
+                        <action id="create" type="list_create">
+                            <properties>
+                                <property name="openMode" value="DIALOG"/>
+                            </properties>
+                        </action>
+                        <action id="edit" type="list_edit">
+                            <properties>
+                                <property name="openMode" value="DIALOG"/>
+                            </properties>
+                        </action>
                         <action id="remove" type="list_remove"/>
                         <action id="applyChanges" text="msg://categoriesGrid.applyChanges" icon="CHECK"/>
                         <action id="exportJSON" text="msg://exportJSON"/>
                         <action id="exportZIP" text="msg://exportZIP"/>
                     </actions>
                     <columns resizable="true">
-                        <column property="name" header="msg://categoriesGrid.name"/>
+                        <column property="name"/>
                         <column property="entityType"/>
                         <column property="isDefault"/>
                     </columns>
                 </dataGrid>
             </vbox>
-            <vbox id="attributesBox" padding="false" height="100%" expand="attributesTable">
-                <h3 text="msg://categoryAttributes.text"/>
+            <vbox id="attributesBox" padding="false"
+                  height="100%" expand="attributesTable">
+                <h2 text="msg://categoryAttributes.text"/>
+                <hbox id="attributesButtonsPanel" classNames="buttons-panel">
+                    <button id="createBtn" action="attributesTable.create"/>
+                    <button id="editBtn" action="attributesTable.edit"/>
+                    <button id="removeBtn" action="attributesTable.remove"/>
+                    <button id="moveUpBtn" action="attributesTable.moveUp"/>
+                    <button id="moveDownBtn" action="attributesTable.moveDown"/>
+                </hbox>
                 <dataGrid id="attributesTable"
                           width="100%"
                           columnReorderingAllowed="true"
                           dataContainer="attributesDc">
-                    <columns resizable="true">
+                    <actions>
+                        <action id="create" type="list_create"/>
+                        <action id="edit" type="list_edit"/>
+                        <action id="remove" type="list_remove"/>
+                        <action id="moveUp" icon="ARROW_UP" type="list_itemTracking"/>
+                        <action id="moveDown" icon="ARROW_DOWN" type="list_itemTracking"/>
+                    </actions>
+                    <columns resizable="true" sortable="false">
                         <column property="name"/>
                         <column property="code"/>
                         <column property="dataType"/>
+                        <column key="defaultValue" header="msg://categoryAttrsGrid.defaultValue"/>
                         <column property="required"/>
                         <column property="isCollection"/>
                     </columns>

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/categoryattr/attribute-enumeration-detail-view.xml
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/categoryattr/attribute-enumeration-detail-view.xml
@@ -28,7 +28,7 @@
     </facets>
     <layout expand="detailButtonsBox">
         <hbox id="editorBox" width="100%">
-            <vbox width="55em" height="100%" padding="false">
+            <vbox height="100%" padding="false">
                 <hbox width="100%" expand="valueField">
                     <textField id="valueField" datatype="string"/>
                     <button id="addBtn" action="localizedEnumValuesDataGrid.add"/>

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/categoryattr/attribute-enumeration-detail-view.xml
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/categoryattr/attribute-enumeration-detail-view.xml
@@ -26,10 +26,10 @@
     <facets>
         <settings auto="true"/>
     </facets>
-    <layout spacing="true" expand="detailButtonsBox">
-        <hbox id="editorBox" margin="false" width="100%">
-            <vbox spacing="true" width="100%" height="100%">
-                <hbox spacing="true" width="100%" expand="valueField">
+    <layout expand="detailButtonsBox">
+        <hbox id="editorBox" width="100%">
+            <vbox width="55em" height="100%" padding="false">
+                <hbox width="100%" expand="valueField">
                     <textField id="valueField" datatype="string"/>
                     <button id="addBtn" action="localizedEnumValuesDataGrid.add"/>
                 </hbox>
@@ -39,22 +39,23 @@
                     <actions>
                         <action id="add" text="msg:///actions.Add"/>
                     </actions>
-                    <columns resizable="true">
-                        <column key="value" property="value" editable="true"/>
-                        <editorActionsColumn key="bufferedEditorColumn" width="7em" header="msg://AttributeLocalizedEnumValue.edit">
-                            <editButton text="Edit" icon="PENCIL"/>
-                            <saveButton icon="CHECK" themeNames="success"/>
-                            <cancelButton icon="CLOSE" themeNames="error"/>
+                    <columns resizable="true" sortable="false">
+                        <column key="value" property="value" editable="true" sortable="true"/>
+                        <editorActionsColumn key="bufferedEditorColumn" width="8em" flexGrow="0">
+                            <editButton text=""/>
+
+                            <saveButton themeNames="success"/>
+                            <cancelButton icon="CLOSE" themeNames="error" text=""/>
                         </editorActionsColumn>
-                        <column key="removeItem" editable="false" header="msg://AttributeLocalizedEnumValue.remove"/>
+                        <column key="removeItem" editable="false" autoWidth="true" flexGrow="0"/>
                     </columns>
                 </dataGrid>
             </vbox>
-            <vbox id="localizationBox" spacing="true" margin="false" width="100%" height="100%" visible="false">
+            <vbox id="localizationBox" width="100%" height="100%" visible="false" padding="false">
                 <h3 text="msg://localizationBox.title"/>
             </vbox>
         </hbox>
-        <hbox id="detailButtonsBox" spacing="true">
+        <hbox id="detailButtonsBox">
             <button id="commitBtn" icon="CHECK" text="msg:///actions.Ok" themeNames="primary"/>
             <button id="cancelBtn" icon="BAN" text="msg:///actions.Cancel"/>
         </hbox>

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/categoryattr/attribute-enumeration-detail-view.xml
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/categoryattr/attribute-enumeration-detail-view.xml
@@ -28,7 +28,7 @@
     </facets>
     <layout expand="detailButtonsBox">
         <hbox id="editorBox" width="100%">
-            <vbox height="100%" padding="false">
+            <vbox height="100%" padding="false" css="flex-grow: 1; width: unset;">
                 <hbox width="100%" expand="valueField">
                     <textField id="valueField" datatype="string"/>
                     <button id="addBtn" action="localizedEnumValuesDataGrid.add"/>
@@ -41,17 +41,11 @@
                     </actions>
                     <columns resizable="true" sortable="false">
                         <column key="value" property="value" editable="true" sortable="true"/>
-                        <editorActionsColumn key="bufferedEditorColumn" width="8em" flexGrow="0">
-                            <editButton text=""/>
-
-                            <saveButton themeNames="success"/>
-                            <cancelButton icon="CLOSE" themeNames="error" text=""/>
-                        </editorActionsColumn>
-                        <column key="removeItem" editable="false" autoWidth="true" flexGrow="0"/>
+                        <column key="bufferedEditorColumn" autoWidth="true" flexGrow="0"/>
                     </columns>
                 </dataGrid>
             </vbox>
-            <vbox id="localizationBox" width="100%" height="100%" visible="false" padding="false">
+            <vbox id="localizationBox" height="100%" visible="false" padding="false" css="flex-grow: 4; width: unset;">
                 <h3 text="msg://localizationBox.title"/>
             </vbox>
         </hbox>

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/categoryattr/category-attributes-detail-view.xml
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/view/categoryattr/category-attributes-detail-view.xml
@@ -45,198 +45,211 @@
         <settings auto="true"/>
         <dataLoadCoordinator auto="true"/>
     </facets>
-    <layout expand="detailButtonsBox" spacing="true">
-        <tabSheet id="tabSheet" width="100%">
-            <tab id="mainTab" label="msg://mainTab.title">
-                <vbox margin="false" padding="false">
-                    <hbox id="attributeBox" width="100%" spacing="true">
-                        <formLayout id="attributeForm" dataContainer="categoryAttributeDc" width="100%">
-                            <responsiveSteps>
-                                <responsiveStep minWidth="0px" columns="1"/>
-                            </responsiveSteps>
-                            <textField id="nameField" property="name" required="true"
-                                       requiredMessage="msg://nameField.required"/>
-                            <textField id="codeField" property="code" required="true"
-                                       requiredMessage="msg://codeField.required"/>
+    <layout expand="contentBox" alignItems="STRETCH" padding="false" spacing="false">
+        <vbox id="contentBox" expand="tabSheet" classNames="overflow-auto" padding="false">
+            <tabSheet id="tabSheet" width="100%" height="100%"
+                      classNames="category-attributes-detail-main-tab-sheet">
+                <tab id="mainTab" label="msg://mainTab.title">
+                    <vbox height="100%" padding="false"
+                          css="padding: var(--lumo-space-m) var(--lumo-space-m) 0 var(--lumo-space-m);">
+                        <hbox id="attributeBox" width="100%">
+                            <formLayout id="attributeForm" dataContainer="categoryAttributeDc" width="100%">
+                                <responsiveSteps>
+                                    <responsiveStep minWidth="0" columns="1"/>
+                                    <responsiveStep minWidth="60em" columns="2"/>
+                                </responsiveSteps>
+                                <textField id="nameField" property="name" required="true"
+                                           requiredMessage="msg://nameField.required"/>
+                                <textField id="codeField" property="code" required="true"
+                                           requiredMessage="msg://codeField.required"/>
 
-                            <comboBox id="dataTypeField" property="dataType" required="true"
-                                      requiredMessage="msg://dataTypeField.required"/>
-                            <textArea id="descriptionField" property="description" minHeight="7em"/>
-                            <checkbox id="isRequiredField" property="required"/>
-                        </formLayout>
-                        <formLayout id="optionalAttributeForm" dataContainer="categoryAttributeDc"
-                                    width="100%"
-                                    visible="false">
-                            <responsiveSteps>
-                                <responsiveStep minWidth="0px" columns="1"/>
-                            </responsiveSteps>
-                            <comboBox id="entityClassField" required="true"
-                                      label="msg://io.jmix.dynattr.model/CategoryAttribute.entityClass"
-                                      requiredMessage="msg://entityClassField.required"/>
-                            <comboBox id="screenField" label="msg://io.jmix.dynattr.model/CategoryAttribute.screen"
-                                      required="true"
-                                      requiredMessage="msg://viewField.required"/>
-                            <textField id="rowsCountField" property="rowsCount">
-                                <validators>
-                                    <min value="1" message="msg://rowsCountField.validationMessage"/>
-                                    <max value="40" message="msg://rowsCountField.validationMessage"/>
-                                </validators>
-                            </textField>
-                            <valuePicker id="defaultEntityIdField"
-                                         label="msg://io.jmix.dynattr.model/CategoryAttribute.defaultEntityId">
-                                <actions>
-                                    <action id="lookup" icon="ELLIPSIS_DOTS_H"/>
-                                    <action id="clear" type="value_clear" icon="BAN"/>
-                                </actions>
-                            </valuePicker>
-                            <hbox id="enumerationBox" expand="enumerationField" margin="false" classNames="items-end">
-                                <textField id="enumerationField"
-                                           label="msg://io.jmix.dynattr.model/CategoryAttribute.enumeration"
-                                           dataContainer="categoryAttributeDc"
-                                           property="enumeration" required="true"
-                                           requiredMessage="msg://enumerationField.required" readOnly="true"/>
-                                <button id="editEnumerationBtn" text="msg:///actions.Edit"/>
+                                <comboBox id="dataTypeField" property="dataType" required="true"
+                                          requiredMessage="msg://dataTypeField.required"/>
+                                <textArea id="descriptionField" property="description" minHeight="7em"/>
+                                <checkbox id="isRequiredField" property="required"/>
+                            </formLayout>
+                            <formLayout id="optionalAttributeForm" dataContainer="categoryAttributeDc"
+                                        width="100%">
+                                <responsiveSteps>
+                                    <responsiveStep minWidth="0" columns="1"/>
+                                    <responsiveStep minWidth="60em" columns="2"/>
+                                </responsiveSteps>
+                                <comboBox id="entityClassField" required="true"
+                                          label="msg://io.jmix.dynattr.model/CategoryAttribute.entityClass"
+                                          requiredMessage="msg://entityClassField.required"/>
+                                <comboBox id="screenField"
+                                          label="msg://io.jmix.dynattr.model/CategoryAttribute.screen"
+                                          required="true"
+                                          requiredMessage="msg://viewField.required"/>
+                                <textField id="rowsCountField" property="rowsCount">
+                                    <validators>
+                                        <min value="1" message="msg://rowsCountField.validationMessage"/>
+                                        <max value="40" message="msg://rowsCountField.validationMessage"/>
+                                    </validators>
+                                </textField>
+                                <valuePicker id="defaultEntityIdField"
+                                             label="msg://io.jmix.dynattr.model/CategoryAttribute.defaultEntityId">
+                                    <actions>
+                                        <action id="lookup" icon="ELLIPSIS_DOTS_H"/>
+                                        <action id="clear" type="value_clear" icon="BAN"/>
+                                    </actions>
+                                </valuePicker>
+                                <hbox id="enumerationBox" expand="enumerationField" margin="false"
+                                      classNames="items-end">
+                                    <textField id="enumerationField"
+                                               label="msg://io.jmix.dynattr.model/CategoryAttribute.enumeration"
+                                               dataContainer="categoryAttributeDc"
+                                               property="enumeration" required="true"
+                                               requiredMessage="msg://enumerationField.required" readOnly="true"/>
+                                    <button id="editEnumerationBtn" text="msg:///actions.Edit"/>
+                                </hbox>
+                                <textField id="defaultStringField" property="defaultString"/>
+                                <textField id="defaultIntField" property="defaultInt"/>
+                                <textField id="defaultDoubleField" property="defaultDouble"/>
+                                <textField id="defaultDecimalField" property="defaultDecimal"/>
+                                <comboBox id="defaultBooleanField" property="defaultBoolean"/>
+                                <comboBox id="defaultEnumField"
+                                          label="msg://io.jmix.dynattr.model/CategoryAttribute.defaultString"/>
+                                <dateTimePicker id="defaultDateField" property="defaultDate"/>
+                                <datePicker id="defaultDateWithoutTimeField" property="defaultDateWithoutTime"/>
+                                <textField id="numberFormatPatternField"
+                                           property="configuration.numberFormatPattern"/>
+                                <textField id="minIntField" property="configuration.minInt"/>
+                                <textField id="maxIntField" property="configuration.maxInt"/>
+                                <textField id="minDoubleField" property="configuration.minDouble"/>
+                                <textField id="maxDoubleField" property="configuration.maxDouble"/>
+                                <textField id="minDecimalField" property="configuration.minDecimal"/>
+                                <textField id="maxDecimalField" property="configuration.maxDecimal"/>
+                                <checkbox id="defaultDateIsCurrentField" property="defaultDateIsCurrent"/>
+                                <checkbox id="isCollectionField" property="isCollection" visible="false"/>
+                            </formLayout>
+                        </hbox>
+                        <vbox padding="false" height="100%" css="padding-bottom: var(--lumo-space-m)">
+                            <h3 text="msg://targetViews"/>
+                            <html content="msg://visibilityTab.help"/>
+                            <hbox classNames="buttons-panel">
+                                <button id="createBtn" action="targetScreensTable.create"/>
+                                <button id="removeBtn" action="targetScreensTable.remove"/>
+                                <button id="addAllViewsBtn" action="targetScreensTable.addAllViews"/>
                             </hbox>
-                            <textField id="defaultStringField" property="defaultString"/>
-                            <textField id="defaultIntField" property="defaultInt"/>
-                            <textField id="defaultDoubleField" property="defaultDouble"/>
-                            <textField id="defaultDecimalField" property="defaultDecimal"/>
-                            <comboBox id="defaultBooleanField" property="defaultBoolean"/>
-                            <comboBox id="defaultEnumField"
-                                      label="msg://io.jmix.dynattr.model/CategoryAttribute.defaultString"/>
-                            <dateTimePicker id="defaultDateField" property="defaultDate"/>
-                            <datePicker id="defaultDateWithoutTimeField" property="defaultDateWithoutTime"/>
-                            <textField id="numberFormatPatternField" property="configuration.numberFormatPattern"/>
-                            <textField id="minIntField" property="configuration.minInt"/>
-                            <textField id="maxIntField" property="configuration.maxInt"/>
-                            <textField id="minDoubleField" property="configuration.minDouble"/>
-                            <textField id="maxDoubleField" property="configuration.maxDouble"/>
-                            <textField id="minDecimalField" property="configuration.minDecimal"/>
-                            <textField id="maxDecimalField" property="configuration.maxDecimal"/>
-                            <checkbox id="defaultDateIsCurrentField" property="defaultDateIsCurrent"/>
+                            <dataGrid id="targetScreensTable" dataContainer="targetScreensDc"
+                                      width="100%"
+                                      height="100%"
+                                      columnReorderingAllowed="true"
+                                      allRowsVisible="true"
+                                      editorBuffered="true">
+                                <actions>
+                                    <action id="create" type="list_create"/>
+                                    <action id="remove" type="list_remove"/>
+                                    <action id="addAllViews" icon="LINES_LIST"
+                                            text="msg://targetScreensTable.addAllViews.text"/>
+                                </actions>
+                                <columns resizable="true" sortable="false">
+                                    <column key="view"
+                                            header="msg://io.jmix.dynattrflowui.impl.model/TargetViewComponent.view"/>
+                                    <column key="component"
+                                            header="msg://io.jmix.dynattrflowui.impl.model/TargetViewComponent.component"/>
+                                </columns>
+                            </dataGrid>
+                        </vbox>
+                    </vbox>
+                </tab>
+                <tab id="advancedTab" label="msg://advancedTab.label">
+                    <vbox height="100%" css="padding-bottom: unset">
+                        <formLayout id="calculatedValuesAndOptionsForm" dataContainer="categoryAttributeDc"
+                                    width="100%">
+                            <multiSelectComboBoxPicker id="dependsOnAttributesField"
+                                                       label="msg://io.jmix.dynattr.model/CategoryAttributeConfiguration.dependsOnAttributes"
+                                                       allowCustomValue="true">
+                                <actions>
+                                    <action id="select" type="multi_value_select" icon="ELLIPSIS_DOTS_H"/>
+                                    <action id="clear" type="value_clear"/>
+                                </actions>
+                            </multiSelectComboBoxPicker>
                             <checkbox id="lookupField" property="lookup" visible="false">
                                 <tooltip text="msg://lookupField.contextHelp"/>
                             </checkbox>
-                            <checkbox id="isCollectionField" property="isCollection" visible="false"/>
+                            <comboBox id="optionsLoaderTypeField" property="configuration.optionsLoaderType"/>
                         </formLayout>
-                    </hbox>
-                    <div width="100%" classNames="flex items-start">
-                        <codeEditor id="validationScriptField"
-                                    label="msg://io.jmix.dynattr.model/CategoryAttributeConfiguration.validatorGroovyScript"
-                                    dataContainer="categoryAttributeDc" property="configuration.validatorGroovyScript"
-                                    mode="GROOVY"
-                                    width="100%"
-                                    showLineNumbers="true"
-                                    highlightActiveLine="false"
-                                    colspan="2"
-                                    showGutter="true"
-                                    highlightGutterLine="false"
-                                    height="9em"/>
-                    </div>
-                </vbox>
-            </tab>
-            <tab id="calculatedValuesAndOptionsTab" label="msg://calculatedValuesAndOptionsTab.title">
-                <vbox margin="false" padding="false">
-                    <formLayout id="calculatedValuesAndOptionsForm" dataContainer="categoryAttributeDc" width="100%">
-                        <multiSelectComboBoxPicker id="dependsOnAttributesField"
-                                                   label="msg://io.jmix.dynattr.model/CategoryAttributeConfiguration.dependsOnAttributes"
-                                                   allowCustomValue="true">
-                            <actions>
-                                <action id="select" type="multi_value_select" icon="ELLIPSIS_DOTS_H"/>
-                                <action id="clear" type="value_clear"/>
-                            </actions>
-                        </multiSelectComboBoxPicker>
-                        <comboBox id="optionsLoaderTypeField" property="configuration.optionsLoaderType"/>
-                    </formLayout>
-                    <div width="100%" classNames="flex items-start">
-                        <codeEditor id="optionsLoaderScriptField"
-                                    label="msg://io.jmix.dynattr.model/CategoryAttributeConfiguration.optionsLoaderScript"
-                                    dataContainer="categoryAttributeDc" property="configuration.optionsLoaderScript"
-                                    width="100%"
-                                    showLineNumbers="true"
-                                    highlightGutterLine="false"
-                                    highlightActiveLine="false"
-                                    mode="GROOVY"
-                                    height="12em"
-                                    colspan="2"
-                                    showGutter="true"/>
-                    </div>
-                    <div width="100%" classNames="flex items-start">
-                        <codeEditor id="joinClauseField"
-                                    label="msg://io.jmix.dynattr.model/CategoryAttribute.joinClause"
-                                    dataContainer="categoryAttributeDc" property="joinClause"
-                                    width="100%"
-                                    showLineNumbers="true"
-                                    highlightGutterLine="false"
-                                    highlightActiveLine="false"
-                                    mode="SQL"
-                                    colspan="2"
-                                    showGutter="true"
-                                    height="12em"/>
-                    </div>
-                    <div width="100%" classNames="flex items-start">
-                        <codeEditor id="whereClauseField"
-                                    label="msg://io.jmix.dynattr.model/CategoryAttribute.whereClause"
-                                    dataContainer="categoryAttributeDc" property="whereClause"
-                                    width="100%"
-                                    showLineNumbers="true"
-                                    highlightGutterLine="false"
-                                    highlightActiveLine="false"
-                                    colspan="2"
-                                    mode="SQL"
-                                    showGutter="true"
-                                    height="12em"/>
-                    </div>
-                    <div width="100%" classNames="flex items-start">
-                        <codeEditor id="recalculationScriptField"
-                                    label="msg://io.jmix.dynattr.model/CategoryAttributeConfiguration.recalculationScript"
-                                    dataContainer="categoryAttributeDc" property="configuration.recalculationScript"
-                                    showLineNumbers="true"
-                                    width="100%"
-                                    highlightGutterLine="false"
-                                    highlightActiveLine="false"
-                                    colspan="2"
-                                    showGutter="true"
-                                    mode="GROOVY"
-                                    height="12em"/>
-                    </div>
-                </vbox>
-            </tab>
-            <tab id="localizationTab" label="msg://localizationTab.title"
-                 visible="false">
-                <vbox id="localizationContainer" padding="false" margin="false">
-                    <formLayout id="categoryAttrLocalizationForm" dataContainer="categoryAttributeDc" width="100%">
-                        <textField id="localizedNameField" property="name" readOnly="true"/>
-                        <textField id="localizedDescriptionField" property="description" readOnly="true"/>
-                    </formLayout>
-                </vbox>
-            </tab>
-            <tab id="visibilityTab" label="msg://visibilityTab.title">
-                <vbox padding="false" margin="false">
-                    <h3 text="msg://targetViews"/>
-                    <html content="msg://visibilityTab.help"/>
-                    <hbox classNames="buttons-panel">
-                        <button id="createBtn" action="targetScreensTable.create"/>
-                        <button id="removeBtn" action="targetScreensTable.remove"/>
-                    </hbox>
-                    <dataGrid id="targetScreensTable" dataContainer="targetScreensDc" width="100%" height="250px"
-                              columnReorderingAllowed="true"
-                              editorBuffered="true" minWidth="55em">
-                        <actions>
-                            <action id="create" type="list_create" text="msg:///actions.Create"/>
-                            <action id="remove" type="list_remove" text="msg:///actions.Remove" actionVariant="DANGER"/>
-                        </actions>
-                        <columns resizable="true">
-                            <column key="view"
-                                    header="msg://io.jmix.dynattrflowui.impl.model/TargetViewComponent.view"/>
-                            <column key="component"
-                                    header="msg://io.jmix.dynattrflowui.impl.model/TargetViewComponent.component"/>
-                        </columns>
-                    </dataGrid>
-                </vbox>
-            </tab>
-        </tabSheet>
-        <hbox id="detailButtonsBox">
+                        <formLayout width="100%" css="padding-bottom: var(--lumo-space-m)">
+                            <div width="100%" classNames="flex items-start">
+                                <codeEditor id="validationScriptField"
+                                            label="msg://io.jmix.dynattr.model/CategoryAttributeConfiguration.validatorGroovyScript"
+                                            dataContainer="categoryAttributeDc"
+                                            property="configuration.validatorGroovyScript"
+                                            mode="GROOVY"
+                                            width="100%"
+                                            showLineNumbers="true"
+                                            highlightActiveLine="false"
+                                            showGutter="true"
+                                            highlightGutterLine="false"
+                                            showPrintMargin="false"/>
+                            </div>
+                            <div width="100%" classNames="flex items-start">
+                                <codeEditor id="recalculationScriptField"
+                                            label="msg://io.jmix.dynattr.model/CategoryAttributeConfiguration.recalculationScript"
+                                            dataContainer="categoryAttributeDc"
+                                            property="configuration.recalculationScript"
+                                            showLineNumbers="true"
+                                            width="100%"
+                                            highlightGutterLine="false"
+                                            showPrintMargin="false"
+                                            highlightActiveLine="false"
+                                            showGutter="true"
+                                            mode="GROOVY"/>
+                            </div>
+                            <div width="100%" classNames="flex items-start">
+                                <codeEditor id="optionsLoaderScriptField"
+                                            label="msg://io.jmix.dynattr.model/CategoryAttributeConfiguration.optionsLoaderScript"
+                                            dataContainer="categoryAttributeDc"
+                                            property="configuration.optionsLoaderScript"
+                                            width="100%"
+                                            showLineNumbers="true"
+                                            highlightGutterLine="false"
+                                            showPrintMargin="false"
+                                            highlightActiveLine="false"
+                                            mode="GROOVY"
+                                            showGutter="true"/>
+                            </div>
+                            <div width="100%" classNames="flex items-start">
+                                <codeEditor id="joinClauseField"
+                                            label="msg://io.jmix.dynattr.model/CategoryAttribute.joinClause"
+                                            dataContainer="categoryAttributeDc" property="joinClause"
+                                            width="100%"
+                                            showLineNumbers="true"
+                                            highlightGutterLine="false"
+                                            showPrintMargin="false"
+                                            highlightActiveLine="false"
+                                            mode="SQL"
+                                            showGutter="true"/>
+                            </div>
+                            <div width="100%" classNames="flex items-start">
+                                <codeEditor id="whereClauseField"
+                                            label="msg://io.jmix.dynattr.model/CategoryAttribute.whereClause"
+                                            dataContainer="categoryAttributeDc" property="whereClause"
+                                            width="100%"
+                                            showLineNumbers="true"
+                                            highlightGutterLine="false"
+                                            showPrintMargin="false"
+                                            highlightActiveLine="false"
+                                            mode="SQL"
+                                            showGutter="true"/>
+                            </div>
+                        </formLayout>
+                    </vbox>
+                </tab>
+                <tab id="localizationTab" label="msg://localizationTab.title"
+                     visible="false">
+                    <vbox id="localizationContainer" height="100%">
+                        <formLayout id="categoryAttrLocalizationForm" dataContainer="categoryAttributeDc" width="100%">
+                            <textField id="localizedNameField" property="name" readOnly="true"/>
+                            <textField id="localizedDescriptionField" property="description" readOnly="true"/>
+                        </formLayout>
+                    </vbox>
+                </tab>
+            </tabSheet>
+        </vbox>
+        <hbox id="detailButtonsBox" classNames="px-m py-s bg-contrast-5">
             <button action="windowCommitAndClose"/>
             <button action="windowClose"/>
         </hbox>

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/component/AbstractGridLoader.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/component/AbstractGridLoader.java
@@ -298,7 +298,7 @@ public abstract class AbstractGridLoader<T extends Grid & EnhancedDataGrid & Has
         if (buttonElement != null) {
             JmixButton button = factory.create(JmixButton.class);
 
-            loadResourceString(buttonElement, "text", context.getMessageGroup())
+            loadResourceString(buttonElement, "text", context.getMessageGroup(), false)
                     .ifPresentOrElse(button::setText, () -> button.setText(loadMessage(defaultMessage)));
             componentLoader().loadIcon(buttonElement)
                     .ifPresentOrElse(button::setIcon, () -> button.setIcon(defaultIcon));

--- a/jmix-translations/content/io/jmix/dynattrflowui/messages.properties
+++ b/jmix-translations/content/io/jmix/dynattrflowui/messages.properties
@@ -59,7 +59,7 @@ io.jmix.dynattrflowui.view.categoryattr/entityClassField.required=Entity type re
 io.jmix.dynattrflowui.view.categoryattr/viewField.required=Entity view required
 io.jmix.dynattrflowui.view.categoryattr/widthField.validationMessage=Width is incorrect
 io.jmix.dynattrflowui.view.categoryattr/rowsCountField.validationMessage=Rows count should be a number between 1 and 40
-io.jmix.dynattrflowui.view.categoryattr/calculatedValuesAndOptionsTab.title=Calculated values and options
+io.jmix.dynattrflowui.view.categoryattr/advancedTab.label=Advanced
 io.jmix.dynattrflowui.view.categoryattr/constraintWizardField.title=Constraint wizard
 io.jmix.dynattrflowui.view.categoryattr/selectEntityType=Select entity type
 io.jmix.dynattrflowui.view.categoryattr/minGreaterThanMax=Minimum value can't be greater than maximum
@@ -75,10 +75,8 @@ io.jmix.dynattrflowui.view.categoryattr/dependsOnAttributes.validationMsg=At lea
 io.jmix.dynattrflowui.view.categoryattr/uniqueName=Attribute with same name already exists
 io.jmix.dynattrflowui.view.categoryattr/uniqueCode=Attribute with same code already exists
 io.jmix.dynattrflowui.view.categoryattr/localizationTab.title=Localization
-io.jmix.dynattrflowui.view.categoryattr/visibilityTab.title=Visibility
 io.jmix.dynattrflowui.view.categoryattr/visibilityTab.help=<div>Сonfigure <b>dynamicAttributes</b> facet for views that will display dynamic attributes.</div>
-io.jmix.dynattrflowui.view.categoryattr/targetViewsTable.create=Add target view
-io.jmix.dynattrflowui.view.categoryattr/targetViewsTable.remove=Remove target view
+io.jmix.dynattrflowui.view.categoryattr/targetScreensTable.addAllViews.text=Add all known views
 io.jmix.dynattrflowui.view.categoryattr/optionsLoaderGroovyScript=Options loader groovy script
 io.jmix.dynattrflowui.view.categoryattr/optionsLoaderGroovyScriptHelp=<div>Allows you to load dynamic attribute options by a Groovy script.\
   <br/>A script should return options list. The entity with dynamic attributes is available \
@@ -151,8 +149,6 @@ io.jmix.dynattrflowui.view.categoryattr/targetViews=Target views
 # AttributeEnumerationView
 io.jmix.dynattrflowui.view.categoryattr/enumerationView.title=Enumeration details
 io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.action=Action
-io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.edit=Editing
-io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.remove=Remove
 io.jmix.dynattrflowui.view.categoryattr/localizationBox.title=Localization
 io.jmix.dynattrflowui.view.categoryattr/localizedEnumValuesDataGrid.add=Add
 

--- a/jmix-translations/content/io/jmix/dynattrflowui/messages.properties
+++ b/jmix-translations/content/io/jmix/dynattrflowui/messages.properties
@@ -17,10 +17,9 @@ menu-config.dynamicattributes.title=Dynamic attributes
 
 # Category List
 io.jmix.dynattrflowui.view.category/categoryListView.title=Dynamic attributes
-io.jmix.dynattrflowui.view.category/categoriesGrid.create=Create category
 io.jmix.dynattrflowui.view.category/categoriesGrid.applyChanges=Apply changes
 io.jmix.dynattrflowui.view.category/notification.changesApplied=Changes have been applied
-io.jmix.dynattrflowui.view.category/categoriesGrid.name=Category
+io.jmix.dynattrflowui.view.category/categoryHeader.text=Categories
 io.jmix.dynattrflowui.view.category/categoryAttributes.text=Category attributes
 
 # Category Detail

--- a/jmix-translations/content/io/jmix/dynattrflowui/messages_ru.properties
+++ b/jmix-translations/content/io/jmix/dynattrflowui/messages_ru.properties
@@ -17,10 +17,9 @@ menu-config.dynamicattributes.title=Динамические атрибуты
 
 # Category List
 io.jmix.dynattrflowui.view.category/categoryListView.title=Динамические атрибуты
-io.jmix.dynattrflowui.view.category/categoriesGrid.create=Создать категорию
 io.jmix.dynattrflowui.view.category/categoriesGrid.applyChanges=Применить изменения
 io.jmix.dynattrflowui.view.category/notification.changesApplied=Изменения были применены
-io.jmix.dynattrflowui.view.category/categoriesGrid.name=Категория
+io.jmix.dynattrflowui.view.category/categoryHeader.text=Категории
 io.jmix.dynattrflowui.view.category/categoryAttributes.text=Атрибуты категории
 
 # Category Detail

--- a/jmix-translations/content/io/jmix/dynattrflowui/messages_ru.properties
+++ b/jmix-translations/content/io/jmix/dynattrflowui/messages_ru.properties
@@ -58,7 +58,7 @@ io.jmix.dynattrflowui.view.categoryattr/entityClassField.required=Тип сущ�
 io.jmix.dynattrflowui.view.categoryattr/viewField.required=Экран сущности обязательна
 io.jmix.dynattrflowui.view.categoryattr/widthField.validationMessage=Ширина некорректна
 io.jmix.dynattrflowui.view.categoryattr/rowsCountField.validationMessage=Количество строк должно быть в диапазоне от 1 до 40
-io.jmix.dynattrflowui.view.categoryattr/calculatedValuesAndOptionsTab.title=Вычисляемые значения и опции
+io.jmix.dynattrflowui.view.categoryattr/advancedTab.label=Дополнительно
 io.jmix.dynattrflowui.view.categoryattr/constraintWizardField.title=Мастер ограничения
 io.jmix.dynattrflowui.view.categoryattr/selectEntityType=Выберите тип сущности
 io.jmix.dynattrflowui.view.categoryattr/minGreaterThanMax=Минимальное значение не может быть больше максимального
@@ -74,10 +74,8 @@ io.jmix.dynattrflowui.view.categoryattr/dependsOnAttributes.validationMsg=По �
 io.jmix.dynattrflowui.view.categoryattr/uniqueName=Атрибут с таким же именем уже существует
 io.jmix.dynattrflowui.view.categoryattr/uniqueCode=Атрибут с таким же кодом уже существует
 io.jmix.dynattrflowui.view.categoryattr/localizationTab.title=Локализация
-io.jmix.dynattrflowui.view.categoryattr/visibilityTab.title=Видимость
 io.jmix.dynattrflowui.view.categoryattr/visibilityTab.help=<div>Настройте <b>фасет динамических атрибутов</b>  для экранов, которые будут отображать динамические атрибуты.</div>
-io.jmix.dynattrflowui.view.categoryattr/targetViewsTable.create=Добавить целевой экран
-io.jmix.dynattrflowui.view.categoryattr/targetViewsTable.remove=Удалить целевой экран
+io.jmix.dynattrflowui.view.categoryattr/targetScreensTable.addAllViews.text=Добавить все известные экраны
 io.jmix.dynattrflowui.view.categoryattr/optionsLoaderGroovyScript=Параметры загрузчика groovy script
 io.jmix.dynattrflowui.view.categoryattr/optionsLoaderGroovyScriptHelp=<div> Позволяет загружать параметры динамических атрибутов с помощью скрипта Groovy.\
 <br/>Скрипт должен возвращать список опций. Доступ к сущности с динамическими атрибутами \
@@ -150,8 +148,6 @@ io.jmix.dynattrflowui.view.categoryattr/targetViews=Целевые экраны 
 # AttributeEnumerationView
 io.jmix.dynattrflowui.view.categoryattr/enumerationView.title=Редактор перечислении
 io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.action=Действия
-io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.edit=Редактировать
-io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.remove=Удалить
 io.jmix.dynattrflowui.view.categoryattr/localizationBox.title=Локализация
 io.jmix.dynattrflowui.view.categoryattr/localizedEnumValuesDataGrid.add=Добавить
 

--- a/jmix-translations/content/io/jmix/dynattrflowui/messages_ru.properties
+++ b/jmix-translations/content/io/jmix/dynattrflowui/messages_ru.properties
@@ -58,7 +58,7 @@ io.jmix.dynattrflowui.view.categoryattr/entityClassField.required=Тип сущ�
 io.jmix.dynattrflowui.view.categoryattr/viewField.required=Экран сущности обязательна
 io.jmix.dynattrflowui.view.categoryattr/widthField.validationMessage=Ширина некорректна
 io.jmix.dynattrflowui.view.categoryattr/rowsCountField.validationMessage=Количество строк должно быть в диапазоне от 1 до 40
-io.jmix.dynattrflowui.view.categoryattr/advancedTab.label=Дополнительно
+io.jmix.dynattrflowui.view.categoryattr/advancedTab.label=Продвинутые настройки
 io.jmix.dynattrflowui.view.categoryattr/constraintWizardField.title=Мастер ограничения
 io.jmix.dynattrflowui.view.categoryattr/selectEntityType=Выберите тип сущности
 io.jmix.dynattrflowui.view.categoryattr/minGreaterThanMax=Минимальное значение не может быть больше максимального
@@ -146,7 +146,7 @@ io.jmix.dynattrflowui.view.categoryattr/entityViewAccessDeniedMessage=Досту
 io.jmix.dynattrflowui.view.categoryattr/targetViews=Целевые экраны динамических атрибутов
 
 # AttributeEnumerationView
-io.jmix.dynattrflowui.view.categoryattr/enumerationView.title=Редактор перечислении
+io.jmix.dynattrflowui.view.categoryattr/enumerationView.title=Редактор перечислений
 io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.action=Действия
 io.jmix.dynattrflowui.view.categoryattr/localizationBox.title=Локализация
 io.jmix.dynattrflowui.view.categoryattr/localizedEnumValuesDataGrid.add=Добавить


### PR DESCRIPTION
See: #2653 & #2660

Contains braking changes: 
* the layout of the view has been changed
* public variable `REMOVE_ITEM_COLUMN` was removed from `AttributeEnumerationDetailView`
* `CategoryAttributesDetailView` view changed its ID from `dynat_CategoryAttribute.edit` to `dynat_CategoryAttribute.detail`
* `CategoryAttributesDetailView` view changed its `@Route` signature from `dynat/category/:id/attributes/:id` to `dynat/category/:categoryId/attributes/:id`
* The following localized keys have been removed from EU & RU localization files:
   * `io.jmix.dynattrflowui.view.category/categoriesGrid.create`
   * `io.jmix.dynattrflowui.view.category/categoriesGrid.name`
   * `io.jmix.dynattrflowui.view.categoryattr/calculatedValuesAndOptionsTab.title`
   * `io.jmix.dynattrflowui.view.categoryattr/visibilityTab.title`
   * `io.jmix.dynattrflowui.view.categoryattr/targetViewsTable.create`
   * `io.jmix.dynattrflowui.view.categoryattr/targetViewsTable.remove`
   * `io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.edit`
   * `io.jmix.dynattrflowui.view.categoryattr/AttributeLocalizedEnumValue.remove`