### PR TITLE
Jmix blames its own generated code for using internal APIs jmix-framework/jmix#3826

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/AbstractClasspathScanner.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/AbstractClasspathScanner.java
@@ -16,6 +16,7 @@
 
 package io.jmix.core.impl.scanning;
 
+import io.jmix.core.annotation.Internal;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
@@ -29,6 +30,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.stream.Stream;
 
+@Internal
 public abstract class AbstractClasspathScanner {
     public static final String DEFAULT_CLASS_RESOURCE_PATTERN = "**/*.class";
 

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/ClasspathScanCandidateDetector.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/ClasspathScanCandidateDetector.java
@@ -16,8 +16,10 @@
 
 package io.jmix.core.impl.scanning;
 
+import io.jmix.core.annotation.Internal;
 import org.springframework.core.type.classreading.MetadataReader;
 
+@Internal
 public interface ClasspathScanCandidateDetector {
 
     boolean isCandidate(MetadataReader metadataReader);

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/EntityDetector.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/EntityDetector.java
@@ -16,10 +16,12 @@
 
 package io.jmix.core.impl.scanning;
 
+import io.jmix.core.annotation.Internal;
 import io.jmix.core.metamodel.annotation.JmixEntity;
 import org.springframework.core.type.classreading.MetadataReader;
 import org.springframework.stereotype.Component;
 
+@Internal
 @Component("core_EntityDetector")
 public class EntityDetector implements ClasspathScanCandidateDetector {
 

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/EnumDetector.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/EnumDetector.java
@@ -16,12 +16,14 @@
 
 package io.jmix.core.impl.scanning;
 
+import io.jmix.core.annotation.Internal;
 import io.jmix.core.metamodel.datatype.EnumClass;
 import org.springframework.core.type.classreading.MetadataReader;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 
+@Internal
 @Component("core_EnumDetector")
 public class EnumDetector implements ClasspathScanCandidateDetector {
 

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/JmixModulesClasspathScanner.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/JmixModulesClasspathScanner.java
@@ -18,6 +18,7 @@ package io.jmix.core.impl.scanning;
 
 import io.jmix.core.JmixModuleDescriptor;
 import io.jmix.core.JmixModules;
+import io.jmix.core.annotation.Internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,6 +39,7 @@ import java.util.stream.Collectors;
  * Detected class names are stored and available through the {@link #getClassNames(Class)} method. This method
  * accepts a {@code ClasspathScanCandidateDetector} type and returns names of classes selected by this detector.
  */
+@Internal
 @Component("core_JmixModulesClasspathScanner")
 public class JmixModulesClasspathScanner extends AbstractClasspathScanner {
 

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/JpaConverterDetector.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/JpaConverterDetector.java
@@ -16,11 +16,13 @@
 
 package io.jmix.core.impl.scanning;
 
+import io.jmix.core.annotation.Internal;
 import org.springframework.core.type.classreading.MetadataReader;
 import org.springframework.stereotype.Component;
 
 import jakarta.persistence.Converter;
 
+@Internal
 @Component("core_JpaConverterDetector")
 public class JpaConverterDetector implements ClasspathScanCandidateDetector {
 

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/package-info.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/scanning/package-info.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-@Internal
 @NonNullApi
 package io.jmix.core.impl.scanning;
 
-import io.jmix.core.annotation.Internal;
 import org.springframework.lang.NonNullApi;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/registration/package-info.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/registration/package-info.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-@Internal
 @NonNullApi
 package io.jmix.flowui.component.genericfilter.registration;
 
-import io.jmix.core.annotation.Internal;
 import org.springframework.lang.NonNullApi;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/AbstractBasePackageConfigurationSorter.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/AbstractBasePackageConfigurationSorter.java
@@ -18,6 +18,7 @@ package io.jmix.flowui.sys;
 
 import io.jmix.core.JmixModuleDescriptor;
 import io.jmix.core.JmixModules;
+import io.jmix.core.annotation.Internal;
 import org.springframework.lang.Nullable;
 
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import java.util.regex.Pattern;
  * using configuration base packages.
  * @param <T> type of specific scan configuration
  */
+@Internal
 public abstract class AbstractBasePackageConfigurationSorter<T extends AbstractScanConfiguration> {
 
     protected JmixModules jmixModules;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ActionDefinition.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ActionDefinition.java
@@ -16,6 +16,9 @@
 
 package io.jmix.flowui.sys;
 
+import io.jmix.core.annotation.Internal;
+
+@Internal
 public final class ActionDefinition {
 
     private final String id;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ActionsConfigurationSorter.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ActionsConfigurationSorter.java
@@ -17,6 +17,7 @@
 package io.jmix.flowui.sys;
 
 import io.jmix.core.JmixModules;
+import io.jmix.core.annotation.Internal;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.List;
  * have been sorted.
  * @see AbstractBasePackageConfigurationSorter
  */
+@Internal
 @Component("flowui_ActionsConfigurationSorter")
 public class ActionsConfigurationSorter extends AbstractBasePackageConfigurationSorter<ActionsConfiguration> {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/AppCookies.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/AppCookies.java
@@ -15,6 +15,7 @@
  */
 package io.jmix.flowui.sys;
 
+import io.jmix.core.annotation.Internal;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -27,6 +28,7 @@ import java.util.Map;
 
 import static java.lang.System.identityHashCode;
 
+@Internal
 public class AppCookies {
 
     public static final String COOKIE_LOCALE = "LAST_LOCALE";

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/BeanUtil.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/BeanUtil.java
@@ -16,11 +16,13 @@
 
 package io.jmix.flowui.sys;
 
+import io.jmix.core.annotation.Internal;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
+@Internal
 public final class BeanUtil {
 
     private BeanUtil() {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ExtendedClientDetailsProvider.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ExtendedClientDetailsProvider.java
@@ -19,10 +19,12 @@ package io.jmix.flowui.sys;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.page.ExtendedClientDetails;
 import com.vaadin.flow.component.page.Page.ExtendedClientDetailsReceiver;
+import io.jmix.core.annotation.Internal;
 import org.springframework.stereotype.Component;
 
 import org.springframework.lang.Nullable;
 
+@Internal
 @Component("flowui_ExtendedClientDetailsProvider")
 public class ExtendedClientDetailsProvider {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/JmixI18NProvider.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/JmixI18NProvider.java
@@ -19,11 +19,13 @@ package io.jmix.flowui.sys;
 import com.vaadin.flow.i18n.I18NProvider;
 import io.jmix.core.CoreProperties;
 import io.jmix.core.Messages;
+import io.jmix.core.annotation.Internal;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Locale;
 
+@Internal
 @Component("flowui_JmixI18NProvider")
 public class JmixI18NProvider implements I18NProvider {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/JmixServiceInitListener.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/JmixServiceInitListener.java
@@ -28,6 +28,7 @@ import io.jmix.core.CoreProperties;
 import io.jmix.core.JmixModules;
 import io.jmix.core.LocaleResolver;
 import io.jmix.core.Resources;
+import io.jmix.core.annotation.Internal;
 import io.jmix.flowui.backgroundtask.BackgroundTaskManager;
 import io.jmix.flowui.component.error.JmixInternalServerError;
 import io.jmix.flowui.exception.UiExceptionHandlers;
@@ -52,6 +53,7 @@ import java.util.Locale;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Internal
 @Component("flowui_JmixServiceInitListener")
 public class JmixServiceInitListener implements VaadinServiceInitListener, ApplicationContextAware {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/JmixTempJarManifestUtils.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/JmixTempJarManifestUtils.java
@@ -1,5 +1,6 @@
 package io.jmix.flowui.sys;
 
+import io.jmix.core.annotation.Internal;
 import org.apache.commons.lang3.SystemUtils;
 import org.springframework.core.io.UrlResource;
 import org.springframework.util.ResourceUtils;
@@ -18,6 +19,7 @@ import java.nio.charset.StandardCharsets;
  * Also see issue and comments:
  * <a href="https://github.com/jmix-framework/jmix/issues/1571">jmix-framework/jmix#1571</a>
  */
+@Internal
 public class JmixTempJarManifestUtils {
 
     public static boolean isGradleTempJarClassPathUsed() {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/JmixVaadinServletContextInitializer.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/JmixVaadinServletContextInitializer.java
@@ -17,6 +17,7 @@
 package io.jmix.flowui.sys;
 
 import com.vaadin.flow.spring.VaadinServletContextInitializer;
+import io.jmix.core.annotation.Internal;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletContextEvent;
 import jakarta.servlet.ServletContextListener;
@@ -31,6 +32,7 @@ import org.springframework.context.ApplicationContext;
  * Also see issue and comments:
  * <a href="https://github.com/jmix-framework/jmix/issues/1571">jmix-framework/jmix#1571</a>
  */
+@Internal
 public class JmixVaadinServletContextInitializer extends VaadinServletContextInitializer {
 
     protected ApplicationContext applicationContext;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/LogoutSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/LogoutSupport.java
@@ -19,6 +19,7 @@ package io.jmix.flowui.sys;
 import com.google.common.base.Strings;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.spring.security.AuthenticationContext;
+import io.jmix.core.annotation.Internal;
 import io.jmix.flowui.util.WebBrowserTools;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -26,6 +27,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.lang.Nullable;
 import jakarta.servlet.ServletContext;
 
+@Internal
 @Component("flowui_LogoutSupport")
 public class LogoutSupport {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/SessionHolder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/SessionHolder.java
@@ -18,6 +18,7 @@ package io.jmix.flowui.sys;
 
 import com.google.common.base.Strings;
 import com.vaadin.flow.server.*;
+import io.jmix.core.annotation.Internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.lang.Nullable;
@@ -35,6 +36,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 /**
  * Holds vaadin sessions for all users
  */
+@Internal
 @Component("flowui_SessionHolder")
 public class SessionHolder implements VaadinServiceInitListener {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/UiAccessChecker.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/UiAccessChecker.java
@@ -18,6 +18,7 @@ package io.jmix.flowui.sys;
 
 import com.vaadin.flow.server.auth.AccessAnnotationChecker;
 import io.jmix.core.AccessManager;
+import io.jmix.core.annotation.Internal;
 import io.jmix.core.security.AccessDeniedException;
 import io.jmix.flowui.accesscontext.UiMenuContext;
 import io.jmix.flowui.accesscontext.UiShowViewContext;
@@ -35,6 +36,7 @@ import java.util.function.Function;
 /**
  * Class checks UI access permission.
  */
+@Internal
 @Component("flowui_UiAccessChecker")
 public class UiAccessChecker {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ValuePathHelper.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ValuePathHelper.java
@@ -15,6 +15,7 @@
  */
 package io.jmix.flowui.sys;
 
+import io.jmix.core.annotation.Internal;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -24,6 +25,7 @@ import java.util.List;
 /**
  * Utility class to format and parse component paths.
  */
+@Internal
 public final class ValuePathHelper {
 
     private ValuePathHelper() {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewControllerDefinition.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewControllerDefinition.java
@@ -16,10 +16,12 @@
 
 package io.jmix.flowui.sys;
 
+import io.jmix.core.annotation.Internal;
 import org.springframework.core.io.Resource;
 
 import org.springframework.lang.Nullable;
 
+@Internal
 public final class ViewControllerDefinition {
 
     private final String id;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewControllerMeta.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewControllerMeta.java
@@ -16,6 +16,7 @@
 
 package io.jmix.flowui.sys;
 
+import io.jmix.core.annotation.Internal;
 import io.jmix.flowui.view.View;
 import io.jmix.flowui.view.ViewController;
 import org.slf4j.Logger;
@@ -34,6 +35,7 @@ import java.util.Map;
 /**
  * Class provides information about view controller.
  */
+@Internal
 public class ViewControllerMeta {
 
     private static final Logger log = LoggerFactory.getLogger(ViewControllerMeta.class);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewControllersConfigurationSorter.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewControllersConfigurationSorter.java
@@ -17,6 +17,7 @@
 package io.jmix.flowui.sys;
 
 import io.jmix.core.JmixModules;
+import io.jmix.core.annotation.Internal;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.List;
  * have been sorted.
  * @see AbstractBasePackageConfigurationSorter
  */
+@Internal
 @Component("flowui_ViewControllersConfigurationSorter")
 public class ViewControllersConfigurationSorter
         extends AbstractBasePackageConfigurationSorter<ViewControllersConfiguration> {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewDescriptorUtils.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewDescriptorUtils.java
@@ -18,6 +18,7 @@ package io.jmix.flowui.sys;
 
 import com.google.common.base.Strings;
 import io.jmix.core.DevelopmentException;
+import io.jmix.core.annotation.Internal;
 import io.jmix.flowui.view.*;
 import org.apache.commons.lang3.StringUtils;
 
@@ -25,6 +26,7 @@ import org.springframework.lang.Nullable;
 
 import static io.jmix.core.common.util.Preconditions.checkNotNullArgument;
 
+@Internal
 public final class ViewDescriptorUtils {
 
     private ViewDescriptorUtils() {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewSupport.java
@@ -23,6 +23,7 @@ import com.vaadin.flow.internal.Pair;
 import com.vaadin.flow.router.*;
 import com.vaadin.flow.server.VaadinSession;
 import io.jmix.core.MessageTools;
+import io.jmix.core.annotation.Internal;
 import io.jmix.core.security.CurrentAuthentication;
 import io.jmix.flowui.model.ViewData;
 import io.jmix.flowui.monitoring.ViewLifeCycle;
@@ -53,7 +54,7 @@ import static io.jmix.flowui.monitoring.UiMonitoring.startTimerSample;
 import static io.jmix.flowui.monitoring.UiMonitoring.stopViewTimerSample;
 import static io.jmix.flowui.view.ViewControllerUtils.getPackage;
 
-
+@Internal
 @Component("flowui_ViewSupport")
 public class ViewSupport {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewXmlDocumentCache.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewXmlDocumentCache.java
@@ -18,11 +18,13 @@ package io.jmix.flowui.sys;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import io.jmix.core.annotation.Internal;
 import org.dom4j.Document;
 import org.springframework.stereotype.Component;
 
 import org.springframework.lang.Nullable;
 
+@Internal
 @Component("flowui_ViewXmlDocumentCache")
 public class ViewXmlDocumentCache {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewXmlLoader.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewXmlLoader.java
@@ -18,6 +18,7 @@ package io.jmix.flowui.sys;
 
 import io.jmix.core.DevelopmentException;
 import io.jmix.core.Resources;
+import io.jmix.core.annotation.Internal;
 import io.jmix.flowui.view.View;
 import org.apache.commons.io.IOUtils;
 import org.dom4j.Document;
@@ -33,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * Loads view XML descriptors.
  */
+@Internal
 @Component("flowui_ViewXmlLoader")
 public class ViewXmlLoader {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewXmlParser.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ViewXmlParser.java
@@ -16,6 +16,7 @@
 
 package io.jmix.flowui.sys;
 
+import io.jmix.core.annotation.Internal;
 import io.jmix.core.common.util.Dom4j;
 import org.apache.commons.io.IOUtils;
 import org.dom4j.Document;
@@ -30,6 +31,7 @@ import static io.jmix.core.common.util.Preconditions.checkNotNullArgument;
 /**
  * Parses view XML taking into account 'assign' elements.
  */
+@Internal
 @Component("flowui_ViewXmlParser")
 public class ViewXmlParser {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/XmlInheritanceProcessor.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/XmlInheritanceProcessor.java
@@ -18,6 +18,7 @@ package io.jmix.flowui.sys;
 
 import io.jmix.core.DevelopmentException;
 import io.jmix.core.Resources;
+import io.jmix.core.annotation.Internal;
 import io.jmix.core.common.util.Dom4j;
 import io.jmix.core.common.util.ParamsMap;
 import org.apache.commons.lang3.StringUtils;
@@ -39,6 +40,7 @@ import java.util.*;
 /**
  * Provides inheritance of screen XML descriptors.
  */
+@Internal
 @Component("flowui_XmlInheritanceProcessor")
 @Scope(BeanDefinition.SCOPE_PROTOTYPE)
 public class XmlInheritanceProcessor {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/package-info.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/package-info.java
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-@Internal
 @NonNullApi
 package io.jmix.flowui.sys;
 
-import io.jmix.core.annotation.Internal;
 import org.springframework.lang.NonNullApi;


### PR DESCRIPTION
Classes that are no longer `@Internal`:

* Core:
   * `AnnotationScanMetadataReaderFactory`
* FlowUI:
   * `AbstractScanConfiguration`
   * `ActionsConfiguration`
   * `ActionViewInitializer`
   * `BeforeNavigationInitializer`
   * `ViewControllersConfiguration`