### PR TITLE
Use a bean for MessageTemplatesGeneratorImpl.defaultConfiguration jmix-framework/jmix#4334

### DIFF
--- a/jmix-messagetemplates/messagetemplates-starter/src/main/java/io/jmix/autoconfigure/messagetemplates/MessageTemplatesAutoConfiguration.java
+++ b/jmix-messagetemplates/messagetemplates-starter/src/main/java/io/jmix/autoconfigure/messagetemplates/MessageTemplatesAutoConfiguration.java
@@ -16,11 +16,27 @@
 
 package io.jmix.autoconfigure.messagetemplates;
 
+import io.jmix.messagetemplates.MessageTemplateConfigurer;
+import io.jmix.messagetemplates.MessageTemplateProperties;
 import io.jmix.messagetemplates.MessageTemplatesConfiguration;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.freemarker.FreeMarkerProperties;
+import org.springframework.boot.autoconfigure.freemarker.FreeMarkerVariablesCustomizer;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.web.servlet.view.freemarker.FreeMarkerConfig;
 
 @AutoConfiguration
 @Import({MessageTemplatesConfiguration.class})
 public class MessageTemplatesAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean(FreeMarkerConfig.class)
+    public MessageTemplateConfigurer configuration(MessageTemplateProperties messageTemplateProperties,
+                                                   FreeMarkerProperties freeMarkerProperties,
+                                                   ObjectProvider<FreeMarkerVariablesCustomizer> variablesCustomizers) {
+        return new MessageTemplateConfigurer(messageTemplateProperties, freeMarkerProperties, variablesCustomizers);
+    }
 }

--- a/jmix-messagetemplates/messagetemplates/src/main/java/io/jmix/messagetemplates/MessageTemplateConfigurer.java
+++ b/jmix-messagetemplates/messagetemplates/src/main/java/io/jmix/messagetemplates/MessageTemplateConfigurer.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.messagetemplates;
+
+import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.freemarker.FreeMarkerProperties;
+import org.springframework.boot.autoconfigure.freemarker.FreeMarkerVariablesCustomizer;
+import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Factory that configures a FreeMarker {@link Configuration}.
+ */
+public class MessageTemplateConfigurer extends FreeMarkerConfigurer {
+
+    protected MessageTemplateProperties messageTemplateProperties;
+    protected FreeMarkerProperties freeMarkerProperties;
+    protected List<FreeMarkerVariablesCustomizer> variablesCustomizers;
+
+    public MessageTemplateConfigurer(MessageTemplateProperties messageTemplateProperties,
+                                     FreeMarkerProperties freeMarkerProperties,
+                                     ObjectProvider<FreeMarkerVariablesCustomizer> variablesCustomizers) {
+        this.messageTemplateProperties = messageTemplateProperties;
+        this.freeMarkerProperties = freeMarkerProperties;
+        this.variablesCustomizers = variablesCustomizers.orderedStream().toList();
+    }
+
+    @Override
+    public void afterPropertiesSet() throws IOException, TemplateException {
+        applyProperties();
+
+        super.afterPropertiesSet();
+    }
+
+    protected void applyProperties() {
+        setTemplateLoaderPaths(freeMarkerProperties.getTemplateLoaderPath());
+        setPreferFileSystemAccess(freeMarkerProperties.isPreferFileSystemAccess());
+        setDefaultEncoding(freeMarkerProperties.getCharsetName());
+
+        setFreemarkerSettings(createFreeMarkerSettings());
+        setFreemarkerVariables(createFreeMarkerVariables());
+    }
+
+    protected Properties createFreeMarkerSettings() {
+        Properties settings = new Properties();
+        settings.put("recognize_standard_file_extensions", "true");
+        settings.putAll(freeMarkerProperties.getSettings());
+        return settings;
+    }
+
+    protected Map<String, Object> createFreeMarkerVariables() {
+        Map<String, Object> variables = new HashMap<>();
+        for (FreeMarkerVariablesCustomizer customizer : variablesCustomizers) {
+            customizer.customizeFreeMarkerVariables(variables);
+        }
+        return variables;
+    }
+
+    @Override
+    protected Configuration newConfiguration() {
+        return new Configuration(messageTemplateProperties.getFreemarkerVersion());
+    }
+}

--- a/jmix-messagetemplates/messagetemplates/src/main/java/io/jmix/messagetemplates/MessageTemplatesConfiguration.java
+++ b/jmix-messagetemplates/messagetemplates/src/main/java/io/jmix/messagetemplates/MessageTemplatesConfiguration.java
@@ -20,7 +20,6 @@ import io.jmix.core.CoreConfiguration;
 import io.jmix.core.annotation.JmixModule;
 import io.jmix.data.DataConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -29,12 +28,4 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationPropertiesScan
 @JmixModule(dependsOn = {CoreConfiguration.class, DataConfiguration.class})
 public class MessageTemplatesConfiguration {
-
-    @Bean("msgtmp_Configuration")
-    public freemarker.template.Configuration configuration(MessageTemplateProperties messageTemplateProperties) {
-        freemarker.template.Configuration configuration
-                = new freemarker.template.Configuration(messageTemplateProperties.getFreemarkerVersion());
-        configuration.setDefaultEncoding("UTF-8");
-        return configuration;
-    }
 }

--- a/jmix-messagetemplates/messagetemplates/src/main/java/io/jmix/messagetemplates/MessageTemplatesConfiguration.java
+++ b/jmix-messagetemplates/messagetemplates/src/main/java/io/jmix/messagetemplates/MessageTemplatesConfiguration.java
@@ -20,6 +20,7 @@ import io.jmix.core.CoreConfiguration;
 import io.jmix.core.annotation.JmixModule;
 import io.jmix.data.DataConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
@@ -28,4 +29,12 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationPropertiesScan
 @JmixModule(dependsOn = {CoreConfiguration.class, DataConfiguration.class})
 public class MessageTemplatesConfiguration {
+
+    @Bean("msgtmp_Configuration")
+    public freemarker.template.Configuration configuration(MessageTemplateProperties messageTemplateProperties) {
+        freemarker.template.Configuration configuration
+                = new freemarker.template.Configuration(messageTemplateProperties.getFreemarkerVersion());
+        configuration.setDefaultEncoding("UTF-8");
+        return configuration;
+    }
 }

--- a/jmix-messagetemplates/messagetemplates/src/main/java/io/jmix/messagetemplates/impl/MessageTemplatesGeneratorImpl.java
+++ b/jmix-messagetemplates/messagetemplates/src/main/java/io/jmix/messagetemplates/impl/MessageTemplatesGeneratorImpl.java
@@ -48,9 +48,11 @@ public class MessageTemplatesGeneratorImpl implements MessageTemplatesGenerator,
     protected Configuration defaultConfiguration;
 
     public MessageTemplatesGeneratorImpl(DataManager dataManager,
-                                         MessageTemplateProperties messageTemplateProperties) {
+                                         MessageTemplateProperties messageTemplateProperties,
+                                         Configuration configuration) {
         this.dataManager = dataManager;
         this.version = messageTemplateProperties.getFreemarkerVersion();
+        this.defaultConfiguration = configuration;
     }
 
     @Override
@@ -68,9 +70,6 @@ public class MessageTemplatesGeneratorImpl implements MessageTemplatesGenerator,
                 return super.wrap(obj);
             }
         };
-
-        defaultConfiguration = new Configuration(version);
-        defaultConfiguration.setDefaultEncoding("UTF-8");
     }
 
     @Override


### PR DESCRIPTION
See: #4334

Now you can override the default configuration by using the following code in your project:
```java
// ...

    @Bean
    public MessageTemplateConfigurer configuration(MessageTemplateProperties messageTemplateProperties,
                                                   FreeMarkerProperties freeMarkerProperties,
                                                   ObjectProvider<FreeMarkerVariablesCustomizer> variablesCustomizers) {
        MessageTemplateConfigurer messageTemplateConfigurer =
                new MessageTemplateConfigurer(messageTemplateProperties, freeMarkerProperties, variablesCustomizers);
        // configurer changes
        return messageTemplateConfigurer;
    }
```
