### PR TITLE
Remove HTML from default list of extensions downloaded with Content-Disposition: inline #4364

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/UiProperties.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/UiProperties.java
@@ -108,7 +108,7 @@ public class UiProperties {
                         @Nullable Map<String, Integer> entityMaxFetchSize,
                         @DefaultValue("50") Integer defaultPageSize,
                         @Nullable Map<String, Integer> entityPageSize,
-                        @DefaultValue({"htm", "html", "jpg", "png", "jpeg", "pdf"}) List<String> viewFileExtensions,
+                        @DefaultValue({"jpg", "png", "jpeg", "pdf"}) List<String> viewFileExtensions,
                         @DefaultValue("3600") int fileDownloaderCacheMaxAgeSec,
                         @DefaultValue("102400") int saveExportedByteArrayDataThresholdBytes,
                         @DefaultValue("true") boolean useSessionFixationProtection,

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/download/Downloader.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/download/Downloader.java
@@ -21,6 +21,8 @@ import io.jmix.core.FileStorage;
 
 import org.springframework.lang.Nullable;
 
+import java.util.function.Function;
+
 /**
  * Generic interface to download data from the system.
  */
@@ -45,6 +47,15 @@ public interface Downloader {
      * @param showNewWindow {@code true} if downloader opens new window, otherwise {@code false}
      */
     void setShowNewWindow(boolean showNewWindow);
+
+    /**
+     * Sets a delegate that checks if file should be opened or downloaded.
+     * It takes file extension as an input parameter and returns {@code true} if file is allowed to be opened or
+     * {@code false} if file should be downloaded.
+     *
+     * @param viewFileAllowanceDelegate delegate
+     */
+    void setViewFileAllowanceDelegate(Function<String, Boolean> viewFileAllowanceDelegate);
 
     /**
      * Downloads an arbitrary resource defined by a DownloadDataProvider.

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/runner/impl/RunMultipleReportsBackgroundTask.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/runner/impl/RunMultipleReportsBackgroundTask.java
@@ -21,6 +21,7 @@ import io.jmix.flowui.backgroundtask.TaskLifeCycle;
 import io.jmix.flowui.download.DownloadFormat;
 import io.jmix.flowui.download.Downloader;
 import io.jmix.flowui.view.View;
+import io.jmix.reports.ReportsProperties;
 import io.jmix.reports.entity.Report;
 import io.jmix.reports.runner.ReportRunContext;
 import io.jmix.reports.runner.ReportRunner;
@@ -28,6 +29,7 @@ import io.jmix.reports.util.ReportZipUtils;
 import io.jmix.reports.yarg.reporting.ReportOutputDocument;
 import io.jmix.reportsflowui.runner.UiReportRunContext;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.*;
@@ -38,6 +40,7 @@ public class RunMultipleReportsBackgroundTask extends BackgroundTask<Integer, Li
     protected ReportRunner reportRunner;
     protected ReportZipUtils reportZipUtils;
     protected Downloader downloader;
+    protected ReportsProperties reportsProperties;
 
     protected final UiReportRunContext context;
     protected final Report targetReport;
@@ -55,6 +58,9 @@ public class RunMultipleReportsBackgroundTask extends BackgroundTask<Integer, Li
     }
 
     @Autowired
+    public void setReportsProperties(ReportsProperties reportsProperties) { this.reportsProperties = reportsProperties; }
+
+    @Autowired
     public void setReportZipUtils(ReportZipUtils reportZipUtils) {
         this.reportZipUtils = reportZipUtils;
     }
@@ -62,6 +68,18 @@ public class RunMultipleReportsBackgroundTask extends BackgroundTask<Integer, Li
     @Autowired
     public void setDownloader(Downloader downloader) {
         this.downloader = downloader;
+
+        setDownloaderViewFileAllowanceDelegate();
+    }
+
+    protected void setDownloaderViewFileAllowanceDelegate() {
+        downloader.setViewFileAllowanceDelegate((fileExtension) -> {
+            if (StringUtils.isEmpty(fileExtension)) {
+                return false;
+            }
+
+            return reportsProperties.getViewFileExtensions().contains(StringUtils.lowerCase(fileExtension));
+        });
     }
 
     @Autowired

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/runner/impl/UiReportRunnerImpl.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/runner/impl/UiReportRunnerImpl.java
@@ -27,6 +27,7 @@ import io.jmix.flowui.download.DownloadFormat;
 import io.jmix.flowui.download.Downloader;
 import io.jmix.flowui.view.DialogWindow;
 import io.jmix.flowui.view.View;
+import io.jmix.reports.ReportsProperties;
 import io.jmix.reports.entity.*;
 import io.jmix.reports.exception.FailedToConnectToOpenOfficeException;
 import io.jmix.reports.exception.MissingDefaultTemplateException;
@@ -71,6 +72,7 @@ public class UiReportRunnerImpl implements UiReportRunner {
     protected final ObjectProvider<FluentUiReportRunner> fluentUiReportRunners;
     protected final Notifications notifications;
     protected final ReportsClientProperties reportsClientProperties;
+    protected final ReportsProperties reportsProperties;
 
     public UiReportRunnerImpl(ReportRunner reportRunner,
                               DialogWindows dialogWindows,
@@ -82,7 +84,8 @@ public class UiReportRunnerImpl implements UiReportRunner {
                               ReportsUtils reportsUtils,
                               ObjectProvider<FluentUiReportRunner> fluentUiReportRunners,
                               Notifications notifications,
-                              ReportsClientProperties reportsClientProperties) {
+                              ReportsClientProperties reportsClientProperties,
+                              ReportsProperties reportsProperties) {
         this.reportRunner = reportRunner;
         this.dialogWindows = dialogWindows;
         this.downloader = downloader;
@@ -94,6 +97,19 @@ public class UiReportRunnerImpl implements UiReportRunner {
         this.fluentUiReportRunners = fluentUiReportRunners;
         this.notifications = notifications;
         this.reportsClientProperties = reportsClientProperties;
+        this.reportsProperties = reportsProperties;
+
+        setDownloaderViewFileAllowanceDelegate();
+    }
+
+    protected void setDownloaderViewFileAllowanceDelegate() {
+        downloader.setViewFileAllowanceDelegate((fileExtension) -> {
+            if (StringUtils.isEmpty(fileExtension)) {
+                return false;
+            }
+
+            return reportsProperties.getViewFileExtensions().contains(StringUtils.lowerCase(fileExtension));
+        });
     }
 
     @Override

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/runner/impl/UiReportRunnerSupport.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/runner/impl/UiReportRunnerSupport.java
@@ -20,12 +20,14 @@ import io.jmix.flowui.DialogWindows;
 import io.jmix.flowui.download.DownloadFormat;
 import io.jmix.flowui.download.Downloader;
 import io.jmix.flowui.view.DialogWindow;
+import io.jmix.reports.ReportsProperties;
 import io.jmix.reports.entity.JmixReportOutputType;
 import io.jmix.reports.entity.ReportOutputType;
 import io.jmix.reports.entity.ReportTemplate;
 import io.jmix.reports.yarg.reporting.ReportOutputDocument;
 import io.jmix.reportsflowui.runner.UiReportRunContext;
 import io.jmix.reportsflowui.view.run.ReportTableView;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.lang.Nullable;
 
@@ -38,10 +40,24 @@ public class UiReportRunnerSupport {
 
     protected final DialogWindows dialogWindows;
     protected final Downloader downloader;
+    protected final ReportsProperties reportsProperties;
 
-    public UiReportRunnerSupport(DialogWindows dialogWindows, Downloader downloader) {
+    public UiReportRunnerSupport(DialogWindows dialogWindows, Downloader downloader, ReportsProperties reportsProperties) {
         this.dialogWindows = dialogWindows;
         this.downloader = downloader;
+        this.reportsProperties = reportsProperties;
+
+        setDownloaderViewFileAllowanceDelegate();
+    }
+
+    protected void setDownloaderViewFileAllowanceDelegate() {
+        downloader.setViewFileAllowanceDelegate((fileExtension) -> {
+            if (StringUtils.isEmpty(fileExtension)) {
+                return false;
+            }
+
+            return reportsProperties.getViewFileExtensions().contains(StringUtils.lowerCase(fileExtension));
+        });
     }
 
     protected void showResult(ReportOutputDocument document, UiReportRunContext context) {

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/history/ReportExecutionListView.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/history/ReportExecutionListView.java
@@ -26,6 +26,7 @@ import io.jmix.flowui.download.Downloader;
 import io.jmix.flowui.kit.action.ActionPerformedEvent;
 import io.jmix.flowui.model.CollectionLoader;
 import io.jmix.flowui.view.*;
+import io.jmix.reports.ReportsProperties;
 import io.jmix.reports.entity.Report;
 import io.jmix.reports.entity.ReportExecution;
 import org.apache.commons.collections4.CollectionUtils;
@@ -52,9 +53,26 @@ public class ReportExecutionListView extends StandardListView<ReportExecution> {
     @Autowired
     protected Downloader downloader;
     @Autowired
+    protected ReportsProperties reportsProperties;
+    @Autowired
     protected SecondsToTextFormatter durationFormatter;
 
     protected List<Report> filterByReports;
+
+    @Subscribe
+    protected void onInit(InitEvent event) {
+        setDownloaderViewFileAllowanceDelegate();
+    }
+
+    protected void setDownloaderViewFileAllowanceDelegate() {
+        downloader.setViewFileAllowanceDelegate((fileExtension) -> {
+            if (StringUtils.isEmpty(fileExtension)) {
+                return false;
+            }
+
+            return reportsProperties.getViewFileExtensions().contains(StringUtils.lowerCase(fileExtension));
+        });
+    }
 
     @Supply(to = "executionsDataGrid.executionTimeSec", subject = "renderer")
     protected Renderer<ReportExecution> executionsDataGridExecutionTimeRenderer() {

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/report/ReportDetailView.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/report/ReportDetailView.java
@@ -65,6 +65,7 @@ import io.jmix.flowui.util.RemoveOperation;
 import io.jmix.flowui.view.*;
 import io.jmix.reports.ReportPrintHelper;
 import io.jmix.reports.ReportsPersistence;
+import io.jmix.reports.ReportsProperties;
 import io.jmix.reports.ReportsSerialization;
 import io.jmix.reports.app.EntityTree;
 import io.jmix.reports.entity.*;
@@ -217,6 +218,8 @@ public class ReportDetailView extends StandardDetailView<Report> {
     @Autowired
     protected UiProperties uiProperties;
     @Autowired
+    protected ReportsProperties reportsProperties;
+    @Autowired
     protected CoreProperties coreProperties;
     @Autowired
     protected EntityStates entityStates;
@@ -255,6 +258,8 @@ public class ReportDetailView extends StandardDetailView<Report> {
 
     @Subscribe
     public void onInit(InitEvent event) {
+        setDownloaderViewFileAllowanceDelegate();
+
         dataSetsDataGridLayout.setWidth(null);
 
         hideAllDataSetEditComponents();
@@ -274,6 +279,16 @@ public class ReportDetailView extends StandardDetailView<Report> {
         initLocaleDetailReportTextField();
         initRoleField();
         initScreenIdField();
+    }
+
+    protected void setDownloaderViewFileAllowanceDelegate() {
+        downloader.setViewFileAllowanceDelegate((fileExtension) -> {
+            if (StringUtils.isEmpty(fileExtension)) {
+                return false;
+            }
+
+            return reportsProperties.getViewFileExtensions().contains(StringUtils.lowerCase(fileExtension));
+        });
     }
 
     @Supply(to = "templatesDataGrid.alterable", subject = "renderer")

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/report/ReportListView.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/report/ReportListView.java
@@ -37,6 +37,7 @@ import io.jmix.flowui.model.CollectionLoader;
 import io.jmix.flowui.view.*;
 import io.jmix.reports.ReportImportExport;
 import io.jmix.reports.ReportsPersistence;
+import io.jmix.reports.ReportsProperties;
 import io.jmix.reports.entity.Report;
 import io.jmix.reports.entity.ReportTemplate;
 import io.jmix.reports.exception.MissingDefaultTemplateException;
@@ -49,6 +50,7 @@ import io.jmix.reportsflowui.view.importdialog.ReportImportDialogView;
 import io.jmix.reportsflowui.view.reportwizard.ReportWizardCreatorView;
 import io.jmix.reportsflowui.view.run.InputParametersDialog;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
@@ -97,6 +99,8 @@ public class ReportListView extends StandardListView<Report> {
     @Autowired
     protected UiProperties uiProperties;
     @Autowired
+    protected ReportsProperties reportsProperties;
+    @Autowired
     protected CoreProperties coreProperties;
     @Autowired
     protected FetchPlanRepository fetchPlanRepository;
@@ -115,7 +119,19 @@ public class ReportListView extends StandardListView<Report> {
 
     @Subscribe
     protected void onInit(InitEvent event) {
+        setDownloaderViewFileAllowanceDelegate();
+
         initReportsDataGridCreate();
+    }
+
+    protected void setDownloaderViewFileAllowanceDelegate() {
+        downloader.setViewFileAllowanceDelegate((fileExtension) -> {
+            if (StringUtils.isEmpty(fileExtension)) {
+                return false;
+            }
+
+            return reportsProperties.getViewFileExtensions().contains(StringUtils.lowerCase(fileExtension));
+        });
     }
 
     private void initReportsDataGridCreate() {

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/reportwizard/ReportWizardCreatorView.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/reportwizard/ReportWizardCreatorView.java
@@ -41,6 +41,7 @@ import io.jmix.flowui.kit.component.button.JmixButton;
 import io.jmix.flowui.kit.component.codeeditor.CodeEditorMode;
 import io.jmix.flowui.model.*;
 import io.jmix.flowui.view.*;
+import io.jmix.reports.ReportsProperties;
 import io.jmix.reports.app.EntityTree;
 import io.jmix.reports.entity.ParameterType;
 import io.jmix.reports.entity.Report;
@@ -152,6 +153,8 @@ public class ReportWizardCreatorView extends StandardView {
     @Autowired
     protected UiProperties uiProperties;
     @Autowired
+    protected ReportsProperties reportsProperties;
+    @Autowired
     protected CoreProperties coreProperties;
     @Autowired
     protected QueryTransformerFactory queryTransformerFactory;
@@ -191,6 +194,8 @@ public class ReportWizardCreatorView extends StandardView {
 
     @Subscribe
     public void onInit(InitEvent event) {
+        setDownloaderViewFileAllowanceDelegate();
+
         initItem();
         initFragments();
         initFragmentDescription();
@@ -199,6 +204,16 @@ public class ReportWizardCreatorView extends StandardView {
         initEntityLookupField();
         initReportParameterDataGrid();
         updateWizardDescription();
+    }
+
+    protected void setDownloaderViewFileAllowanceDelegate() {
+        downloader.setViewFileAllowanceDelegate((fileExtension) -> {
+            if (StringUtils.isEmpty(fileExtension)) {
+                return false;
+            }
+
+            return reportsProperties.getViewFileExtensions().contains(StringUtils.lowerCase(fileExtension));
+        });
     }
 
     protected void initItem() {

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/ReportsProperties.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/ReportsProperties.java
@@ -94,6 +94,11 @@ public class ReportsProperties {
     List<String> wizardPropertiesExcludedBlackList;
 
     /**
+     * File extensions that can be opened for viewing in a browser.
+     */
+    List<String> viewFileExtensions;
+
+    /**
      * Maximum depth of entity model that is used in report wizard and report dataset fetchPlan editor.
      */
     int entityTreeModelMaxDepth;
@@ -172,7 +177,8 @@ public class ReportsProperties {
                              @DefaultValue("3") int countOfRetry,
                              @DefaultValue("false") boolean useOfficeForDocumentConversion,
                              @DefaultValue("false") boolean formulasPostProcessingEvaluationEnabled,
-                             @DefaultValue("false") boolean multilineStringsProcessingEnabled) {
+                             @DefaultValue("false") boolean multilineStringsProcessingEnabled,
+                             @DefaultValue({"htm", "html", "jpg", "png", "jpeg", "pdf"}) List<String> viewFileExtensions) {
         this.officePath = officePath;
         this.officePorts = officePorts;
         this.docFormatterTimeout = docFormatterTimeout;
@@ -197,7 +203,13 @@ public class ReportsProperties {
         this.useOfficeForDocumentConversion = useOfficeForDocumentConversion;
         this.formulasPostProcessingEvaluationEnabled = formulasPostProcessingEvaluationEnabled;
         this.multilineStringsProcessingEnabled = multilineStringsProcessingEnabled;
+        this.viewFileExtensions = viewFileExtensions;
     }
+
+    /**
+     * @see #viewFileExtensions
+     */
+    public List<String> getViewFileExtensions() { return viewFileExtensions; }
 
     /**
      * @see #officePath


### PR DESCRIPTION
Necessary file extensions (htm, html) have been removed from UiProperties.java (and jmix.ui.view-file-extensions propety). 
Similar property (jmix.reports.view-file-extensions) has been added that allows you to separately configure the display of uploaded documents in the browser window for working with reports. By default, htm and html files is allowed for display inline while reports configuring.
A delegate has been added to all related classes in the reports and reports-flowui to configure the required behavior of the Downloader.
In addition, the Downloader interface and its implementation class - DownloaderImpl, were affected.