### PR TITLE
Add the way to determine that entity uses database view #4333

### DIFF
--- a/jmix-data/data/src/main/java/io/jmix/data/DbView.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/DbView.java
@@ -26,6 +26,6 @@ import java.lang.annotation.Target;
  * Development tools do not generate database migration scripts for such entities.
  */
 @Target({ElementType.TYPE})
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface DbView {
 }


### PR DESCRIPTION
In accordance with the recommendations, the RetentionPolicy for DbView annotation was replaced with Runtime.