### PR TITLE
UUID fields are not generated in AppSettingsEntity editor screen #671

### DIFF
--- a/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/AppSettingsFlowUiConfiguration.java
+++ b/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/AppSettingsFlowUiConfiguration.java
@@ -21,6 +21,7 @@ import io.jmix.core.annotation.JmixModule;
 import io.jmix.core.impl.scanning.AnnotationScanMetadataReaderFactory;
 import io.jmix.flowui.FlowuiConfiguration;
 import io.jmix.flowui.sys.ViewControllersConfiguration;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
@@ -31,6 +32,7 @@ import java.util.Collections;
 
 @Configuration
 @ComponentScan
+@ConfigurationPropertiesScan
 @JmixModule(dependsOn = {
         FlowuiConfiguration.class,
         AppSettingsConfiguration.class

--- a/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/AppSettingsUiProperties.java
+++ b/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/AppSettingsUiProperties.java
@@ -1,0 +1,37 @@
+///*
+// * Copyright 2025 Haulmont.
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+
+package io.jmix.appsettingsflowui;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties(prefix = "jmix.appsettings.ui")
+public class AppSettingsUiProperties {
+    /**
+     * Property for displaying the uuid field in the Application settings
+     */
+    final Boolean showUuidFields;
+
+    public AppSettingsUiProperties(@DefaultValue("true") Boolean showUuidFields) {
+        this.showUuidFields = showUuidFields;
+    }
+
+    /**
+     * @see #showUuidFields
+     */
+    public Boolean isShowUuidFields() { return showUuidFields; }
+ }

--- a/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/AppSettingsUiProperties.java
+++ b/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/AppSettingsUiProperties.java
@@ -24,14 +24,14 @@ public class AppSettingsUiProperties {
     /**
      * Defines whether uuid fields are displayed in the Application Settings view
      */
-    final Boolean showUuidFields;
+    final boolean showUuidFields;
 
-    public AppSettingsUiProperties(@DefaultValue("true") Boolean showUuidFields) {
+    public AppSettingsUiProperties(@DefaultValue("true") boolean showUuidFields) {
         this.showUuidFields = showUuidFields;
     }
 
     /**
      * @see #showUuidFields
      */
-    public Boolean isShowUuidFields() { return showUuidFields; }
+    public boolean isShowUuidFields() { return showUuidFields; }
  }

--- a/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/AppSettingsUiProperties.java
+++ b/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/AppSettingsUiProperties.java
@@ -1,18 +1,18 @@
-///*
-// * Copyright 2025 Haulmont.
-// *
-// * Licensed under the Apache License, Version 2.0 (the "License");
-// * you may not use this file except in compliance with the License.
-// * You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package io.jmix.appsettingsflowui;
 
@@ -22,7 +22,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
 @ConfigurationProperties(prefix = "jmix.appsettings.ui")
 public class AppSettingsUiProperties {
     /**
-     * Property for displaying the uuid field in the Application settings
+     * Defines whether uuid fields are displayed in the Application Settings view
      */
     final Boolean showUuidFields;
 

--- a/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/view/appsettings/AppSettingsEntityView.java
+++ b/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/view/appsettings/AppSettingsEntityView.java
@@ -30,6 +30,7 @@ import com.vaadin.flow.router.*;
 import io.jmix.appsettings.AppSettings;
 import io.jmix.appsettings.AppSettingsTools;
 import io.jmix.appsettings.entity.AppSettingsEntity;
+import io.jmix.appsettingsflowui.AppSettingsUiProperties;
 import io.jmix.core.*;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
@@ -81,6 +82,8 @@ public class AppSettingsEntityView extends StandardView {
 
     @Autowired
     protected AppSettings appSettings;
+    @Autowired
+    protected AppSettingsUiProperties appSettingsUiProperties;
     @Autowired
     protected EntityStates entityStates;
     @Autowired
@@ -309,7 +312,9 @@ public class AppSettingsEntityView extends StandardView {
                         continue;
                     }
                     if (metaProperty.getType() != MetaProperty.Type.ENUM
-                            && metaProperty.getRange().asDatatype().getJavaClass().equals(byte[].class)) {
+                            && (metaProperty.getRange().asDatatype().getJavaClass().equals(byte[].class) ||
+                            metaProperty.getRange().asDatatype().getJavaClass().equals(UUID.class) &&
+                            !appSettingsUiProperties.isShowUuidFields())) {
                         continue;
                     }
                     if (metadataTools.isAnnotationPresent(item, metaProperty.getName(), Convert.class)) {

--- a/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/view/appsettings/AppSettingsEntityView.java
+++ b/jmix-appsettings/appsettings-flowui/src/main/java/io/jmix/appsettingsflowui/view/appsettings/AppSettingsEntityView.java
@@ -309,8 +309,7 @@ public class AppSettingsEntityView extends StandardView {
                         continue;
                     }
                     if (metaProperty.getType() != MetaProperty.Type.ENUM
-                            && (metaProperty.getRange().asDatatype().getJavaClass().equals(byte[].class) ||
-                            metaProperty.getRange().asDatatype().getJavaClass().equals(UUID.class))) {
+                            && metaProperty.getRange().asDatatype().getJavaClass().equals(byte[].class)) {
                         continue;
                     }
                     if (metadataTools.isAnnotationPresent(item, metaProperty.getName(), Convert.class)) {


### PR DESCRIPTION
Fixes: #671 

The UUID type has been removed from the skipping if condition in AppSettingsEntityView class