### PR TITLE
Open API detailed docs call produces NPE #4474

### DIFF
--- a/jmix-rest/rest/src/main/java/io/jmix/rest/impl/config/RestServicesConfiguration.java
+++ b/jmix-rest/rest/src/main/java/io/jmix/rest/impl/config/RestServicesConfiguration.java
@@ -394,6 +394,7 @@ public class RestServicesConfiguration {
             this.name = name;
         }
 
+        @Nullable
         public String getHttpMethod() {
             return httpMethod;
         }

--- a/jmix-rest/rest/src/main/java/io/jmix/rest/impl/openapi/OpenAPIGeneratorImpl.java
+++ b/jmix-rest/rest/src/main/java/io/jmix/rest/impl/openapi/OpenAPIGeneratorImpl.java
@@ -484,9 +484,14 @@ public class OpenAPIGeneratorImpl implements OpenAPIGenerator {
                 String path = String.format(SERVICE_PATH, serviceName, methodInfo.getName());
                 PathItem pathItem = openAPI.getPaths().getOrDefault(path, new PathItem());
 
-                switch (RestHttpMethod.valueOf(methodInfo.getHttpMethod())) {
-                    case GET -> pathItem.get(createServiceMethodOp(serviceName, methodInfo, RequestMethod.GET));
-                    case POST -> pathItem.post(createServiceMethodOp(serviceName, methodInfo, RequestMethod.POST));
+                if (methodInfo.getHttpMethod() == null) {
+                    pathItem.get(createServiceMethodOp(serviceName, methodInfo, RequestMethod.GET))
+                            .post(createServiceMethodOp(serviceName, methodInfo, RequestMethod.POST));
+                } else {
+                    switch (RestHttpMethod.valueOf(methodInfo.getHttpMethod())) {
+                        case GET -> pathItem.get(createServiceMethodOp(serviceName, methodInfo, RequestMethod.GET));
+                        case POST -> pathItem.post(createServiceMethodOp(serviceName, methodInfo, RequestMethod.POST));
+                    }
                 }
 
                 openAPI.path(path, pathItem);


### PR DESCRIPTION
Fixes: #4474 

If httpMethod property in rest-services.xml is not set for controller method, both types of GET and POST requests will be processed simultaneously. They will be processed separately otherwise.

Added Nullable annotation for RestServicesConfiguration.getHttpMethod()