### PR TITLE
Wrong value of sequences.createNextValue method in MS SQL DB #4500

### DIFF
--- a/jmix-data/data/src/main/java/io/jmix/data/Sequences.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/Sequences.java
@@ -33,13 +33,15 @@ public interface Sequences {
     long createNextValue(Sequence sequence);
 
     /**
+     * @deprecated as unused
+     *
      * Returns the current value of the sequence. For some implementations
      * {@link #createNextValue(Sequence)} must be called at least once beforehand.
      *
      * @param sequence object {@link Sequence}
      * @return          current value
      */
-    @Deprecated
+    @Deprecated(forRemoval = true, since = "2.7")
     long getCurrentValue(Sequence sequence);
 
     /**

--- a/jmix-data/data/src/main/java/io/jmix/data/Sequences.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/Sequences.java
@@ -39,6 +39,7 @@ public interface Sequences {
      * @param sequence object {@link Sequence}
      * @return          current value
      */
+    @Deprecated
     long getCurrentValue(Sequence sequence);
 
     /**


### PR DESCRIPTION
Fixes: #4500 