### PR TITLE
Download document button is permanently inactive in dialog window of report executions #4751

### DIFF
--- a/jmix-reports/reports-flowui/src/main/resources/io/jmix/reportsflowui/view/history/report-execution-list-view.xml
+++ b/jmix-reports/reports-flowui/src/main/resources/io/jmix/reportsflowui/view/history/report-execution-list-view.xml
@@ -52,7 +52,7 @@
         <dataGrid id="executionsDataGrid" dataContainer="executionsDc" width="100%" selectionMode="MULTI"
                   columnReorderingAllowed="true">
             <actions>
-                <action id="download" text="msg://action.download.text" icon="DOWNLOAD"/>
+                <action id="download" text="msg://action.download.text" icon="DOWNLOAD" type="list_itemTracking"/>
             </actions>
             <columns resizable="true">
                 <column property="startTime"/>


### PR DESCRIPTION
Fixes: #4751 