### PR TITLE
OffsetTime datatype does not consider user's TimeZone jmix-framework/jmix#3414

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/DateTimeTransformations.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/DateTimeTransformations.java
@@ -17,9 +17,9 @@
 package io.jmix.core;
 
 import com.google.common.base.Preconditions;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
-import org.springframework.lang.Nullable;
 import java.time.*;
 import java.util.Date;
 
@@ -46,6 +46,7 @@ public class DateTimeTransformations {
      * Obtains an instance of ZonedDateTime
      * from Date or LocalDate or LocalDateTime or OffsetDateTime
      * ZonedDateTime is created for LocalDate, LocalDateTime with default system timezone
+     *
      * @param date date object, not null
      * @return the ZonedDateTime, not null
      */
@@ -74,8 +75,9 @@ public class DateTimeTransformations {
      * Obtains an instance of specified by type date object from
      * from ZonedDateTime
      * LocalDate, LocalDateTime is created for default system timezone
+     *
      * @param zonedDateTime date object, not null
-     * @param javaType date type to transformation from ZonedDateTime
+     * @param javaType      date type to transformation from ZonedDateTime
      * @return the date object, not null
      */
     public Object transformFromZDT(ZonedDateTime zonedDateTime, Class<?> javaType) {
@@ -106,6 +108,7 @@ public class DateTimeTransformations {
     /**
      * Obtains an instance of LocalTime
      * from Time or Date or LocalTime or OffsetTime
+     *
      * @param date date object, not null
      * @return the LocalTime, not null
      */
@@ -128,8 +131,9 @@ public class DateTimeTransformations {
     /**
      * Obtains an instance of specified by type date object from
      * from LocalTime
+     *
      * @param localTime date object, not null
-     * @param javaType date type to transformation from LocalTime
+     * @param javaType  date type to transformation from LocalTime
      * @return the date object, not null
      */
     public Object transformFromLocalTime(LocalTime localTime, Class<?> javaType) {
@@ -150,12 +154,15 @@ public class DateTimeTransformations {
     }
 
     /**
-     * Check if date type supports time zone conversation
+     * Check if a date type supports time zone conversation
+     *
      * @param javaType - date type
      * @return true - if date type supports timezones
      */
     public boolean isDateTypeSupportsTimeZones(Class<?> javaType) {
-        return Date.class.equals(javaType) || OffsetDateTime.class.equals(javaType);
+        return Date.class.equals(javaType)
+                || OffsetDateTime.class.equals(javaType)
+                || OffsetTime.class.equals(javaType);
     }
 
     private static RuntimeException newUnsupportedTypeException(Class<?> javaType) {

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/OffsetTimeDatatype.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/datatype/impl/OffsetTimeDatatype.java
@@ -18,18 +18,37 @@ package io.jmix.core.metamodel.datatype.impl;
 
 import io.jmix.core.metamodel.annotation.DatatypeDef;
 import io.jmix.core.metamodel.datatype.FormatStrings;
+import io.jmix.core.metamodel.datatype.TimeZoneAwareDatatype;
+import org.springframework.lang.Nullable;
 
+import java.time.LocalDate;
 import java.time.OffsetTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.time.temporal.TemporalQuery;
 import java.util.Locale;
+import java.util.TimeZone;
 
 @DatatypeDef(id = "offsetTime", javaClass = OffsetTime.class, defaultForClass = true, value = "core_OffsetTimeDatatype")
-public class OffsetTimeDatatype extends AbstractTemporalDatatype<OffsetTime> {
+public class OffsetTimeDatatype extends AbstractTemporalDatatype<OffsetTime>
+        implements TimeZoneAwareDatatype {
 
     public OffsetTimeDatatype() {
         super(DateTimeFormatter.ISO_OFFSET_TIME);
+    }
+
+    @Override
+    public String format(@Nullable Object value, Locale locale, @Nullable TimeZone timeZone) {
+        if (timeZone == null || value == null) {
+            return format(value, locale);
+        }
+
+        OffsetTime offsetTime = (OffsetTime) value;
+        ZonedDateTime zonedDateTime = offsetTime.atDate(LocalDate.now()).atZoneSameInstant(timeZone.toZoneId());
+        OffsetTime result = zonedDateTime.toOffsetDateTime().toOffsetTime();
+
+        return format(result, locale);
     }
 
     @Override


### PR DESCRIPTION
See: #3414 

The offset time data type now supports time zone-aware formatting.

For example:
12:00 UTC+4 will be formatted as 08:00 for UTC time zone. 

Similar formatting will also occur when this data type is used for display in the UI, such as in `dataGrid` cells or in the `timePicker` in entity details.

<img width="1462" height="390" alt="Screenshot 2025-12-09 at 11 59 04" src="https://github.com/user-attachments/assets/2dbdd50b-ccec-4a92-bdd8-928063ecd753" />

<img width="1460" height="419" alt="Screenshot 2025-12-09 at 12 00 45" src="https://github.com/user-attachments/assets/8717a1a8-27f5-42f2-a787-acf38bc8aab6" />


Test project:
[test.zip](https://github.com/user-attachments/files/24049716/test.zip)

