### PR TITLE
Enter hotkey to apply grid column filter jmix-framework/jmix#3832

### DIFF
--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/elementsgroup/StudioElementsGroups.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/elementsgroup/StudioElementsGroups.java
@@ -42,6 +42,7 @@ interface StudioElementsGroups {
                             defaultValue = "false"),
                     @StudioProperty(xmlAttribute = "filterable", type = StudioPropertyType.BOOLEAN,
                             defaultValue = "false"),
+                    @StudioProperty(xmlAttribute = "headerFilterApplyShortcut", type = StudioPropertyType.SHORTCUT_COMBINATION),
                     @StudioProperty(xmlAttribute = "includeAll", type = StudioPropertyType.BOOLEAN, defaultValue = "false")
             }
     )

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/UiComponentProperties.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/UiComponentProperties.java
@@ -24,6 +24,7 @@ import io.jmix.flowui.component.factory.EntityFieldCreationSupport;
 import io.jmix.flowui.component.genericfilter.GenericFilter;
 import io.jmix.flowui.component.genericfilter.configuration.FilterConfigurationDetail;
 import io.jmix.flowui.component.grid.DataGrid;
+import io.jmix.flowui.component.grid.headerfilter.DataGridHeaderFilter;
 import io.jmix.flowui.component.sidedialog.SideDialog;
 import io.jmix.flowui.component.sidepanellayout.SidePanelLayout;
 import io.jmix.flowui.kit.component.sidedialog.SideDialogPosition;
@@ -108,6 +109,11 @@ public class UiComponentProperties {
     String filterApplyShortcut;
 
     /**
+     * Shortcut for applying {@link DataGridHeaderFilter}
+     */
+    String dataGridHeaderFilterApplyShortcut;
+
+    /**
      * Number of nested properties in the {@link AddConditionView}. I.e. if the depth is 2, then you'll be able to
      * select a property "contractor.city.country", if the value is 3, then "contractor.city.country.name", etc.
      */
@@ -184,6 +190,7 @@ public class UiComponentProperties {
             @Nullable Map<String, List<String>> entityFieldActions,
             @DefaultValue("true") boolean filterAutoApply,
             String filterApplyShortcut,
+            String dataGridHeaderFilterApplyShortcut,
             @DefaultValue("2") int filterPropertiesHierarchyDepth,
             @DefaultValue("false") boolean filterShowConfigurationIdField,
             @DefaultValue("true") boolean filterShowNonJpaProperties,
@@ -219,6 +226,7 @@ public class UiComponentProperties {
 
         this.filterAutoApply = filterAutoApply;
         this.filterApplyShortcut = filterApplyShortcut;
+        this.dataGridHeaderFilterApplyShortcut = dataGridHeaderFilterApplyShortcut;
         this.filterPropertiesHierarchyDepth = filterPropertiesHierarchyDepth;
         this.filterShowConfigurationIdField = filterShowConfigurationIdField;
         this.filterShowNonJpaProperties = filterShowNonJpaProperties;
@@ -338,6 +346,13 @@ public class UiComponentProperties {
      */
     public String getFilterApplyShortcut() {
         return filterApplyShortcut;
+    }
+
+    /**
+     * @see #dataGridHeaderFilterApplyShortcut
+     */
+    public String getDataGridHeaderFilterApplyShortcut() {
+        return dataGridHeaderFilterApplyShortcut;
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/delegate/AbstractGridDelegate.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/delegate/AbstractGridDelegate.java
@@ -115,6 +115,8 @@ public abstract class AbstractGridDelegate<C extends Grid<E> & ListDataComponent
     protected Consumer<Component> componentEmptyStateComponentDelegate;
     protected Registration emptyStateByPermissionRegistration;
 
+    protected String headerFilterApplyShortcut;
+
     protected boolean aggregatable;
     protected EnhancedDataGrid.AggregationPosition aggregationPosition = EnhancedDataGrid.AggregationPosition.BOTTOM;
     protected Map<Grid.Column<E>, AggregationInfo> aggregationMap = new LinkedHashMap<>();
@@ -980,6 +982,15 @@ public abstract class AbstractGridDelegate<C extends Grid<E> & ListDataComponent
 
     protected void onGridEditorClose(EditorCloseEvent<E> eEditorCloseEvent) {
         updateAggregationRow();
+    }
+
+    public void setHeaderFilterApplyShortcut(@Nullable String headerFilterApplyShortcut) {
+        this.headerFilterApplyShortcut = headerFilterApplyShortcut;
+    }
+
+    @Nullable
+    public String getHeaderFilterApplyShortcut() {
+        return headerFilterApplyShortcut;
     }
 
     public static class ColumnSecurityContext<E> {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/DataGrid.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/DataGrid.java
@@ -447,6 +447,16 @@ public class DataGrid<E> extends JmixGrid<E> implements ListDataComponent<E>, Mu
 
     @Nullable
     @Override
+    public String getHeaderFilterApplyShortcut() {
+        return gridDelegate.getHeaderFilterApplyShortcut();
+    }
+
+    @Override
+    public void setHeaderFilterApplyShortcut(@Nullable String headerFilterApplyShortcut) {
+        gridDelegate.setHeaderFilterApplyShortcut(headerFilterApplyShortcut);
+    }
+
+    @Override
     public Object getSubPart(String name) {
         Object column = super.getSubPart(name);
         if (column != null) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/EnhancedDataGrid.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/EnhancedDataGrid.java
@@ -19,6 +19,7 @@ package io.jmix.flowui.component.grid;
 import com.vaadin.flow.component.grid.Grid;
 import io.jmix.core.metamodel.model.MetaPropertyPath;
 import io.jmix.flowui.component.AggregationInfo;
+import io.jmix.flowui.component.grid.headerfilter.DataGridHeaderFilter;
 import io.jmix.flowui.kit.component.grid.JmixGridContextMenu;
 import org.springframework.lang.Nullable;
 
@@ -84,6 +85,19 @@ public interface EnhancedDataGrid<T> {
      * @return context menu instance attached to the grid
      */
     JmixGridContextMenu<T> getContextMenu();
+
+    /**
+     * @return a shortcut combination for applying {@link DataGridHeaderFilter}
+     */
+    @Nullable
+    String getHeaderFilterApplyShortcut();
+
+    /**
+     * Sets a shortcut combination for applying {@link DataGridHeaderFilter}.
+     *
+     * @param shortcut shortcut combination (e.g. {@code "CONTROL-ENTER"})
+     */
+    void setHeaderFilterApplyShortcut(@Nullable String shortcut);
 
     /**
      * Defines the position of aggregation row.

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/TreeDataGrid.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/TreeDataGrid.java
@@ -472,6 +472,16 @@ public class TreeDataGrid<E> extends JmixTreeGrid<E> implements ListDataComponen
 
     @Nullable
     @Override
+    public String getHeaderFilterApplyShortcut() {
+        return gridDelegate.getHeaderFilterApplyShortcut();
+    }
+
+    @Override
+    public void setHeaderFilterApplyShortcut(@Nullable String headerFilterApplyShortcut) {
+        gridDelegate.setHeaderFilterApplyShortcut(headerFilterApplyShortcut);
+    }
+
+    @Override
     public Object getSubPart(String name) {
         Object column = super.getSubPart(name);
         if (column != null) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/headerfilter/DataGridHeaderFilter.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/headerfilter/DataGridHeaderFilter.java
@@ -30,6 +30,7 @@ import io.jmix.core.common.util.Preconditions;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaPropertyPath;
 import io.jmix.core.querycondition.PropertyConditionUtils;
+import io.jmix.flowui.UiComponentProperties;
 import io.jmix.flowui.UiComponents;
 import io.jmix.flowui.app.datagrid.HeaderPropertyFilterLayout;
 import io.jmix.flowui.component.grid.DataGridColumn;
@@ -38,6 +39,7 @@ import io.jmix.flowui.component.propertyfilter.PropertyFilter;
 import io.jmix.flowui.component.propertyfilter.PropertyFilterSupport;
 import io.jmix.flowui.data.grid.ContainerDataGridItems;
 import io.jmix.flowui.icon.Icons;
+import io.jmix.flowui.kit.component.KeyCombination;
 import io.jmix.flowui.kit.component.button.JmixButton;
 import io.jmix.flowui.kit.icon.JmixFontIcon;
 import io.jmix.flowui.model.DataLoader;
@@ -66,6 +68,7 @@ public class DataGridHeaderFilter extends Composite<HorizontalLayout>
     protected Messages messages;
     protected PropertyFilterSupport propertyFilterSupport;
     protected Icons icons;
+    protected UiComponentProperties uiComponentProperties;
 
     protected HeaderFilterContext context;
 
@@ -98,6 +101,7 @@ public class DataGridHeaderFilter extends Composite<HorizontalLayout>
         messages = applicationContext.getBean(Messages.class);
         propertyFilterSupport = applicationContext.getBean(PropertyFilterSupport.class);
         icons = applicationContext.getBean(Icons.class);
+        uiComponentProperties = applicationContext.getBean(UiComponentProperties.class);
     }
 
     protected void initComponent() {
@@ -246,9 +250,24 @@ public class DataGridHeaderFilter extends Composite<HorizontalLayout>
 
         applyButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
         applyButton.addClickListener(this::onApplyButtonClick);
+        applyShortcutCombination(applyButton);
         setupButtonFlexGrowStyle(applyButton);
 
         return applyButton;
+    }
+
+    protected void applyShortcutCombination(JmixButton applyButton) {
+        String shortcut = context.getHeaderFilterApplyShortcut();
+
+        if (shortcut == null) {
+            shortcut = uiComponentProperties.getDataGridHeaderFilterApplyShortcut();
+        }
+
+        KeyCombination shortcutCombination = KeyCombination.create(shortcut);
+        if (shortcutCombination != null) {
+            shortcutCombination.setResetFocusOnActiveElement(true);
+            applyButton.setShortcutCombination(shortcutCombination);
+        }
     }
 
     protected void onApplyButtonClick(ClickEvent<Button> event) {
@@ -358,6 +377,7 @@ public class DataGridHeaderFilter extends Composite<HorizontalLayout>
         protected DataLoader dataLoader;
         protected MetaClass metaClass;
         protected String property;
+        protected String headerFilterApplyShortcut;
 
         protected Component headerComponent;
 
@@ -379,6 +399,7 @@ public class DataGridHeaderFilter extends Composite<HorizontalLayout>
 
                 metaClass = propertyPath.getMetaClass();
                 property = propertyPath.toPathString();
+                headerFilterApplyShortcut = enhancedDataGrid.getHeaderFilterApplyShortcut();
             }
 
             if (column.getHeaderText() != null) {
@@ -398,6 +419,11 @@ public class DataGridHeaderFilter extends Composite<HorizontalLayout>
 
         public String getProperty() {
             return property;
+        }
+
+        @Nullable
+        public String getHeaderFilterApplyShortcut() {
+            return headerFilterApplyShortcut;
         }
 
         public Component getHeaderComponent() {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/component/AbstractGridLoader.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/component/AbstractGridLoader.java
@@ -195,6 +195,9 @@ public abstract class AbstractGridLoader<T extends Grid & EnhancedDataGrid & Has
         boolean filterable = loadBoolean(columnsElement, "filterable")
                 .orElse(false);
 
+        loadString(columnsElement, "headerFilterApplyShortcut",
+                resultComponent::setHeaderFilterApplyShortcut);
+
         if (columnsElement.elements(EDITOR_ACTIONS_COLUMN_ELEMENT_NAME).size() > 1) {
             throw new GuiDevelopmentException("DataGrid can contain only one editorActionsColumn",
                     context, "Component ID", resultComponent.getId());

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
@@ -3372,6 +3372,7 @@
                             <xs:attribute name="sortable" type="xs:boolean"/>
                             <xs:attribute name="resizable" type="xs:boolean"/>
                             <xs:attribute name="filterable" type="xs:boolean"/>
+                            <xs:attribute name="headerFilterApplyShortcut" type="shortcutCombination"/>
                         </xs:complexType>
                     </xs:element>
                     <xs:element name="contextMenu" minOccurs="0" type="contextMenuType"/>

--- a/jmix-flowui/flowui/src/test/groovy/component_xml_load/GridXmlLoadTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component_xml_load/GridXmlLoadTest.groovy
@@ -390,6 +390,7 @@ class GridXmlLoadTest extends FlowuiTestSpecification {
         def columnsAttributesDataGrid = gridView.columnsAttributesDataGrid
 
         then: "dataGrid columns' attributes are loaded"
+        columnsAttributesDataGrid.headerFilterApplyShortcut == "CONTROL-ENTER"
         verifyAll(columnsAttributesDataGrid.getColumnByKey("number") as DataGridColumn) {
             sortable
             resizable

--- a/jmix-flowui/flowui/src/test/resources/component_xml_load/screen/grid-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component_xml_load/screen/grid-view.xml
@@ -134,7 +134,8 @@
         </dataGrid>
 
         <dataGrid id="columnsAttributesDataGrid" dataContainer="ordersDc">
-            <columns filterable="true" sortable="false" resizable="true">
+            <columns filterable="true" sortable="false" resizable="true"
+                     headerFilterApplyShortcut="CONTROL-ENTER">
                 <column property="number" sortable="true"/>
                 <column property="amount" resizable="false"/>
                 <column property="date" filterable="false"/>


### PR DESCRIPTION
See: #3832

Implemented the ability to customize the `DataGridHeaderFilter` apply shortcut for each `DataGrid` separately, providing both a global application property and local XML configuration via the `columns` tag.

Added:
* `jmix.ui.component.data-grid-header-filter-apply-shortcut` (no default value)
* `String getHeaderFilterApplyShortcut()` and `setHeaderFilterApplyShortcut(String)` API for the all `grid`'s

HeaderFilter logic updated to check for a component-level shortcut first. If not set, it falls back to the global application property.

<hr/>

Docs issue will be created after merging.