### PR TITLE
Ability to turn off unsafe runtime features

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/CoreProperties.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/CoreProperties.java
@@ -81,6 +81,16 @@ public class CoreProperties {
     String entitySerializationTokenEncryptionKey;
 
     /**
+     * Whether potentially dangerous runtime features are enabled.
+     */
+    boolean unsafeRuntimeFeaturesEnabled;
+
+    /**
+     * Whether loading of classes from the file system is enabled.
+     */
+    boolean hotDeployEnabled;
+
+    /**
      * Whether the processing of bean invocation trigger files is enabled. Default value: true The trigger file is a
      * file that is placed in the triggers subdirectory of the application's temporary directory. The file name consists
      * of two parts separated with a #: the first part is the bean class, the second part is the method name of the bean
@@ -148,6 +158,8 @@ public class CoreProperties {
             String defaultFileStorage,
             @DefaultValue("false") boolean entitySerializationTokenRequired,
             @DefaultValue("KEY") String entitySerializationTokenEncryptionKey,
+            @DefaultValue("true") boolean unsafeRuntimeFeaturesEnabled,
+            @DefaultValue("true") boolean hotDeployEnabled,
             @DefaultValue("false") boolean legacyFetchPlanSerializationAttributeName,
             @DefaultValue("true") boolean triggerFilesEnabled,
             @DefaultValue("5000") Duration triggerFilesProcessInterval,
@@ -180,6 +192,8 @@ public class CoreProperties {
 
         this.entitySerializationTokenRequired = entitySerializationTokenRequired;
         this.entitySerializationTokenEncryptionKey = entitySerializationTokenEncryptionKey;
+        this.unsafeRuntimeFeaturesEnabled = unsafeRuntimeFeaturesEnabled;
+        this.hotDeployEnabled = hotDeployEnabled;
         this.triggerFilesEnabled = triggerFilesEnabled;
         this.triggerFilesProcessInterval = triggerFilesProcessInterval;
         this.roundDecimalValueByFormat = roundDecimalValueByFormat;
@@ -265,11 +279,19 @@ public class CoreProperties {
         return entitySerializationTokenEncryptionKey;
     }
 
+    public boolean isUnsafeRuntimeFeaturesEnabled() {
+        return unsafeRuntimeFeaturesEnabled;
+    }
+
+    public boolean isHotDeployEnabled() {
+        return unsafeRuntimeFeaturesEnabled && hotDeployEnabled;
+    }
+
     /**
      * @see #triggerFilesEnabled
      */
     public boolean isTriggerFilesEnabled() {
-        return triggerFilesEnabled;
+        return unsafeRuntimeFeaturesEnabled && triggerFilesEnabled;
     }
 
     /**

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/JavaClassLoader.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/JavaClassLoader.java
@@ -50,6 +50,7 @@ public class JavaClassLoader extends URLClassLoader {
     private static final Logger log = LoggerFactory.getLogger(JavaClassLoader.class);
 
     protected final Set<String> rootDirs;
+    protected final boolean hotDeployEnabled;
 
     protected final Map<String, TimestampClass> loaded = new ConcurrentHashMap<>();
     protected final Map<String, byte[]> generatedClassBytes = new ConcurrentHashMap<>();
@@ -70,6 +71,7 @@ public class JavaClassLoader extends URLClassLoader {
         super(new URL[0], Thread.currentThread().getContextClassLoader());
 
         this.proxyClassLoader = new ProxyClassLoader(Thread.currentThread().getContextClassLoader(), loaded);
+        this.hotDeployEnabled = coreProperties.isHotDeployEnabled();
         this.rootDirs = Sets.newHashSet(coreProperties.getConfDir()); //getRootPaths(); ToDo: multiple root paths
         this.classFilesProviders = new HashMap<>();
         for (String dir : this.rootDirs) {
@@ -79,13 +81,15 @@ public class JavaClassLoader extends URLClassLoader {
     }
 
     //Please use this constructor only in tests
-    JavaClassLoader(ClassLoader parent, String rootDir, Set<String> rootDirs, SpringBeanLoader springBeanLoader) {
+    JavaClassLoader(ClassLoader parent, String rootDir, Set<String> rootDirs, SpringBeanLoader springBeanLoader,
+                    boolean hotDeployEnabled) {
         super(new URL[0], parent);
 
         Preconditions.checkNotNull(rootDir);
 
         this.proxyClassLoader = new ProxyClassLoader(parent, loaded);
         this.springBeanLoader = springBeanLoader;
+        this.hotDeployEnabled = hotDeployEnabled;
         this.rootDirs = rootDirs;
         this.classFilesProviders = new HashMap<>();
         for (String dir : this.rootDirs) {
@@ -118,15 +122,17 @@ public class JavaClassLoader extends URLClassLoader {
                 return loadedClass.clazz;
             }
 
-            //first check if there is a ".class" file in the root directories
-            for (ClassFilesProvider classFilesProvider : classFilesProviders.values()) {
-                File classFile = classFilesProvider.getClassFile(containerClassName);
-                if (classFile.exists()) {
-                    TimestampClass timestampClass = loaded.get(containerClassName);
-                    if (timestampClass != null && classFile.lastModified() <= timestampClass.timestamp.getTime()) {
-                        return timestampClass.clazz;
+            if (hotDeployEnabled) {
+                //first check if there is a ".class" file in the root directories
+                for (ClassFilesProvider classFilesProvider : classFilesProviders.values()) {
+                    File classFile = classFilesProvider.getClassFile(containerClassName);
+                    if (classFile.exists()) {
+                        TimestampClass timestampClass = loaded.get(containerClassName);
+                        if (timestampClass != null && classFile.lastModified() <= timestampClass.timestamp.getTime()) {
+                            return timestampClass.clazz;
+                        }
+                        return loadClassFromClassFile(fullClassName, containerClassName, classFile);
                     }
-                    return loadClassFromClassFile(fullClassName, containerClassName, classFile);
                 }
             }
 

--- a/jmix-core/core/src/test/java/io/jmix/core/impl/JavaClassLoaderTest.java
+++ b/jmix-core/core/src/test/java/io/jmix/core/impl/JavaClassLoaderTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core.impl;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JavaClassLoaderTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testDisabledHotDeploySkipsFilesystemClassLoading() throws Exception {
+        writeInvalidClassFile();
+
+        JavaClassLoader classLoader = createClassLoader(false);
+        try {
+            assertThat(classLoader.loadClass(String.class.getName(), false)).isSameAs(String.class);
+        } finally {
+            classLoader.destroy();
+        }
+    }
+
+    @Test
+    void testEnabledHotDeployLoadsFilesystemClassLoading() throws Exception {
+        writeInvalidClassFile();
+
+        JavaClassLoader classLoader = createClassLoader(true);
+        try {
+            assertThatThrownBy(() -> classLoader.loadClass(String.class.getName(), false))
+                    .isInstanceOf(SecurityException.class)
+                    .hasMessageContaining("Prohibited package name");
+        } finally {
+            classLoader.destroy();
+        }
+    }
+
+    private JavaClassLoader createClassLoader(boolean hotDeployEnabled) {
+        JavaClassLoader classLoader = new JavaClassLoader(
+                Thread.currentThread().getContextClassLoader(),
+                tempDir.toString(),
+                Set.of(tempDir.toString()),
+                new SpringBeanLoader(),
+                hotDeployEnabled
+        );
+        classLoader.meterRegistry = new SimpleMeterRegistry();
+        return classLoader;
+    }
+
+    private void writeInvalidClassFile() throws Exception {
+        Path classFile = tempDir.resolve("java/lang/String.class");
+        Files.createDirectories(classFile.getParent());
+        Files.write(classFile, new byte[]{0x00, 0x01, 0x02});
+    }
+}

--- a/jmix-core/core/src/test/java/io/jmix/core/impl/TriggerFileProcessorScheduleConfigurerTest.java
+++ b/jmix-core/core/src/test/java/io/jmix/core/impl/TriggerFileProcessorScheduleConfigurerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core.impl;
+
+import io.jmix.core.CoreProperties;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.Trigger;
+import test_support.TestCoreProperties;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ScheduledFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TriggerFileProcessorScheduleConfigurerTest {
+
+    @Test
+    void testDoesNotScheduleTriggerProcessingWhenFeatureIsDisabled() {
+        TrackingTaskScheduler taskScheduler = new TrackingTaskScheduler();
+        CoreProperties properties = TestCoreProperties.builder()
+                .setUnsafeRuntimeFeaturesEnabled(false)
+                .setTriggerFilesEnabled(true)
+                .build();
+
+        TriggerFileProcessorScheduleConfigurer configurer =
+                new TriggerFileProcessorScheduleConfigurer(taskScheduler, properties, new TriggerFilesProcessor());
+
+        configurer.onContextRefreshedEvent(null);
+
+        assertThat(taskScheduler.scheduleWithFixedDelayCallCount).isZero();
+    }
+
+    @Test
+    void testSchedulesTriggerProcessingWhenFeatureIsEnabled() {
+        TrackingTaskScheduler taskScheduler = new TrackingTaskScheduler();
+        CoreProperties properties = TestCoreProperties.builder()
+                .setUnsafeRuntimeFeaturesEnabled(true)
+                .setTriggerFilesEnabled(true)
+                .setTriggerFilesProcessInterval(Duration.ofSeconds(7))
+                .build();
+
+        TriggerFileProcessorScheduleConfigurer configurer =
+                new TriggerFileProcessorScheduleConfigurer(taskScheduler, properties, new TriggerFilesProcessor());
+
+        configurer.onContextRefreshedEvent(null);
+
+        assertThat(taskScheduler.scheduleWithFixedDelayCallCount).isEqualTo(1);
+        assertThat(taskScheduler.lastDelay).isEqualTo(Duration.ofSeconds(7));
+    }
+
+    private static class TrackingTaskScheduler implements TaskScheduler {
+
+        private int scheduleWithFixedDelayCallCount;
+        private Duration lastDelay;
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable task, Trigger trigger) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable task, Instant startTime) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Instant startTime, Duration period) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Duration period) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Instant startTime, Duration delay) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Duration delay) {
+            scheduleWithFixedDelayCallCount++;
+            lastDelay = delay;
+            return null;
+        }
+    }
+}

--- a/jmix-core/core/src/test/java/test_support/TestCoreProperties.java
+++ b/jmix-core/core/src/test/java/test_support/TestCoreProperties.java
@@ -38,6 +38,8 @@ public class TestCoreProperties extends CoreProperties {
                               String defaultFileStorage,
                               boolean entitySerializationTokenRequired,
                               String entitySerializationTokenEncryptionKey,
+                              boolean unsafeRuntimeFeaturesEnabled,
+                              boolean hotDeployEnabled,
                               boolean legacyFetchPlanSerializationAttributeName,
                               boolean triggerFilesEnabled,
                               Duration triggerFilesProcessInterval,
@@ -50,7 +52,8 @@ public class TestCoreProperties extends CoreProperties {
                 crossDataStoreReferenceLoadingBatchSize, idGenerationForEntitiesInAdditionalDataStoresEnabled,
                 dom4jMaxPoolSize, dom4jMaxBorrowWaitMillis, anonymousAuthenticationTokenKey, defaultFileStorage,
                 entitySerializationTokenRequired, entitySerializationTokenEncryptionKey,
-                legacyFetchPlanSerializationAttributeName, triggerFilesEnabled, triggerFilesProcessInterval,
+                unsafeRuntimeFeaturesEnabled, hotDeployEnabled, legacyFetchPlanSerializationAttributeName,
+                triggerFilesEnabled, triggerFilesProcessInterval,
                 roundDecimalValueByFormat, skipNullOrEmptyConditionsByDefault, instanceNameFallbackEnabled,
                 dataObservationEnabled, useUserInfoForObservation);
     }
@@ -75,6 +78,8 @@ public class TestCoreProperties extends CoreProperties {
         String defaultFileStorage;
         boolean entitySerializationTokenRequired = false;
         String entitySerializationTokenEncryptionKey = "KEY";
+        boolean unsafeRuntimeFeaturesEnabled = true;
+        boolean hotDeployEnabled = true;
         boolean legacyFetchPlanSerializationAttributeName = false;
         boolean triggerFilesEnabled = true;
         Duration triggerFilesProcessInterval = Duration.ofSeconds(5000);
@@ -164,6 +169,16 @@ public class TestCoreProperties extends CoreProperties {
             return this;
         }
 
+        public Builder setUnsafeRuntimeFeaturesEnabled(boolean unsafeRuntimeFeaturesEnabled) {
+            this.unsafeRuntimeFeaturesEnabled = unsafeRuntimeFeaturesEnabled;
+            return this;
+        }
+
+        public Builder setHotDeployEnabled(boolean hotDeployEnabled) {
+            this.hotDeployEnabled = hotDeployEnabled;
+            return this;
+        }
+
         public Builder setTriggerFilesEnabled(boolean triggerFilesEnabled) {
             this.triggerFilesEnabled = triggerFilesEnabled;
             return this;
@@ -211,6 +226,8 @@ public class TestCoreProperties extends CoreProperties {
                     this.defaultFileStorage,
                     this.entitySerializationTokenRequired,
                     this.entitySerializationTokenEncryptionKey,
+                    this.unsafeRuntimeFeaturesEnabled,
+                    this.hotDeployEnabled,
                     this.legacyFetchPlanSerializationAttributeName,
                     this.triggerFilesEnabled,
                     this.triggerFilesProcessInterval,

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/DynAttrUiProperties.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/DynAttrUiProperties.java
@@ -33,11 +33,18 @@ public class DynAttrUiProperties {
      */
     int maxRecalculationLevel;
 
+    /**
+     * Whether Groovy-based dynamic attribute behavior is enabled.
+     */
+    boolean groovyEnabled;
+
     @ConstructorBinding
     public DynAttrUiProperties(@DefaultValue("4") int dynamicAttributesPanelMaxCount,
-                               @DefaultValue("10") int maxRecalculationLevel) {
+                               @DefaultValue("10") int maxRecalculationLevel,
+                               @DefaultValue("true") boolean groovyEnabled) {
         this.dynamicAttributesPanelMaxColumnsCount = dynamicAttributesPanelMaxCount;
         this.maxRecalculationLevel = maxRecalculationLevel;
+        this.groovyEnabled = groovyEnabled;
     }
 
     /**
@@ -52,5 +59,9 @@ public class DynAttrUiProperties {
      */
     public int getMaxRecalculationLevel() {
         return maxRecalculationLevel;
+    }
+
+    public boolean isGroovyEnabled() {
+        return groovyEnabled;
     }
 }

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/AttributeOptionsLoaderImpl.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/AttributeOptionsLoaderImpl.java
@@ -27,8 +27,6 @@ import io.jmix.dynattr.OptionsLoaderType;
 import jakarta.annotation.PostConstruct;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
-import org.springframework.scripting.ScriptEvaluator;
-import org.springframework.scripting.support.StaticScriptSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 
@@ -44,7 +42,7 @@ public class AttributeOptionsLoaderImpl implements AttributeOptionsLoader {
     protected StoreAwareLocator storeAwareLocator;
     protected DataManager dataManager;
     protected Metadata metadata;
-    protected ScriptEvaluator scriptEvaluator;
+    protected DynAttrGroovyFeatureSupport dynAttrGroovyFeatureSupport;
 
     protected static final String ENTITY_QUERY_PARAM = "entity";
     protected static final String ENTITY_FIELD_QUERY_PARAM = "entity.";
@@ -53,12 +51,11 @@ public class AttributeOptionsLoaderImpl implements AttributeOptionsLoader {
     public AttributeOptionsLoaderImpl(StoreAwareLocator storeAwareLocator,
                                       DataManager dataManager,
                                       Metadata metadata,
-                                      @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
-                                      ScriptEvaluator scriptEvaluator) {
+                                      DynAttrGroovyFeatureSupport dynAttrGroovyFeatureSupport) {
         this.storeAwareLocator = storeAwareLocator;
         this.dataManager = dataManager;
         this.metadata = metadata;
-        this.scriptEvaluator = scriptEvaluator;
+        this.dynAttrGroovyFeatureSupport = dynAttrGroovyFeatureSupport;
     }
 
     public interface OptionsLoaderStrategy {
@@ -209,7 +206,7 @@ public class AttributeOptionsLoaderImpl implements AttributeOptionsLoader {
 
     protected List<?> executeGroovyScript(Object entity, AttributeDefinition attribute, String script) {
         if (!Strings.isNullOrEmpty(script)) {
-            return (List<?>) scriptEvaluator.evaluate(new StaticScriptSource(script), Collections.singletonMap("entity", entity));
+            return dynAttrGroovyFeatureSupport.evaluateOptionsLoaderScript(script, entity);
         }
         return null;
     }

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/AttributeRecalculationManager.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/AttributeRecalculationManager.java
@@ -24,8 +24,6 @@ import io.jmix.dynattr.DynAttrUtils;
 import io.jmix.dynattr.DynamicAttributes;
 import io.jmix.dynattr.DynamicAttributesState;
 import io.jmix.dynattrflowui.DynAttrUiProperties;
-import org.springframework.scripting.ScriptEvaluator;
-import org.springframework.scripting.support.StaticScriptSource;
 import org.springframework.stereotype.Component;
 
 import java.util.*;
@@ -33,15 +31,14 @@ import java.util.*;
 @Component("dynat_AttributeRecalculationManager")
 public class AttributeRecalculationManager {
 
-    protected final ScriptEvaluator scriptEvaluator;
+    protected final DynAttrGroovyFeatureSupport dynAttrGroovyFeatureSupport;
     protected final AttributeDependencies attributeDependencies;
     protected final DynAttrUiProperties dynAttrUiProperties;
 
-    public AttributeRecalculationManager(@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
-                                         ScriptEvaluator scriptEvaluator,
+    public AttributeRecalculationManager(DynAttrGroovyFeatureSupport dynAttrGroovyFeatureSupport,
                                          AttributeDependencies attributeDependencies,
                                          DynAttrUiProperties dynAttrUiProperties) {
-        this.scriptEvaluator = scriptEvaluator;
+        this.dynAttrGroovyFeatureSupport = dynAttrGroovyFeatureSupport;
         this.attributeDependencies = attributeDependencies;
         this.dynAttrUiProperties = dynAttrUiProperties;
     }
@@ -112,6 +109,6 @@ public class AttributeRecalculationManager {
         params.put("entity", entity);
         params.put("dynamicAttributes", values);
 
-        return scriptEvaluator.evaluate(new StaticScriptSource(script), params);
+        return dynAttrGroovyFeatureSupport.evaluateRecalculationScript(script, params);
     }
 }

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrGroovyFeatureSupport.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/DynAttrGroovyFeatureSupport.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.dynattrflowui.impl;
+
+import io.jmix.core.CoreProperties;
+import io.jmix.core.Messages;
+import io.jmix.dynattrflowui.DynAttrUiProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scripting.ScriptEvaluator;
+import org.springframework.scripting.support.StaticScriptSource;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Component("dynat_DynAttrGroovyFeatureSupport")
+public class DynAttrGroovyFeatureSupport {
+
+    private static final Logger log = LoggerFactory.getLogger(DynAttrGroovyFeatureSupport.class);
+
+    protected final ScriptEvaluator scriptEvaluator;
+    protected final DynAttrUiProperties dynAttrUiProperties;
+    protected final CoreProperties coreProperties;
+    protected final Messages messages;
+
+    public DynAttrGroovyFeatureSupport(ScriptEvaluator scriptEvaluator,
+                                       DynAttrUiProperties dynAttrUiProperties,
+                                       CoreProperties coreProperties,
+                                       Messages messages) {
+        this.scriptEvaluator = scriptEvaluator;
+        this.dynAttrUiProperties = dynAttrUiProperties;
+        this.coreProperties = coreProperties;
+        this.messages = messages;
+    }
+
+    public boolean isGroovyEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && dynAttrUiProperties.isGroovyEnabled();
+    }
+
+    public Object evaluateValidationScript(String script, Object value) {
+        if (!isGroovyEnabled()) {
+            log.warn("Groovy execution is disabled for dynamic attribute validation. Returning a fixed validation error.");
+            return messages.getMessage(getClass(), "validationScriptDisabled");
+        }
+        return scriptEvaluator.evaluate(new StaticScriptSource(script), Collections.singletonMap("value", value));
+    }
+
+    public Object evaluateRecalculationScript(String script, Map<String, Object> parameters) {
+        if (!isGroovyEnabled()) {
+            throw new GroovyScriptExecutionDisabledException(
+                    messages.getMessage(getClass(), "recalculationScriptDisabled"));
+        }
+        return scriptEvaluator.evaluate(new StaticScriptSource(script), parameters);
+    }
+
+    public List<?> evaluateOptionsLoaderScript(String script, Object entity) {
+        if (!isGroovyEnabled()) {
+            log.warn("Groovy execution is disabled for dynamic attribute options loading. Returning an empty list.");
+            return Collections.emptyList();
+        }
+        return (List<?>) scriptEvaluator.evaluate(new StaticScriptSource(script), Collections.singletonMap("entity", entity));
+    }
+}

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/GroovyScriptExecutionDisabledException.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/GroovyScriptExecutionDisabledException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.dynattrflowui.impl;
+
+public class GroovyScriptExecutionDisabledException extends RuntimeException {
+
+    public GroovyScriptExecutionDisabledException(String message) {
+        super(message);
+    }
+}

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/GroovyScriptValidator.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/impl/GroovyScriptValidator.java
@@ -23,15 +23,10 @@ import io.jmix.core.security.CurrentAuthentication;
 import io.jmix.flowui.component.validation.AbstractValidator;
 import io.jmix.flowui.exception.ValidationException;
 import io.jmix.flowui.sys.substitutor.StringSubstitutor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.context.annotation.Scope;
-import org.springframework.scripting.ScriptEvaluator;
-import org.springframework.scripting.support.StaticScriptSource;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
-
-import java.util.Collections;
 
 /**
  * GroovyScript validator runs a custom Groovy script. If the script returns any object,
@@ -58,20 +53,19 @@ public class GroovyScriptValidator<T> extends AbstractValidator<T> {
 
     protected String validatorGroovyScript;
 
-    protected final ScriptEvaluator scriptEvaluator;
+    protected final DynAttrGroovyFeatureSupport dynAttrGroovyFeatureSupport;
 
     public GroovyScriptValidator(Messages messages,
                                  DatatypeRegistry datatypeRegistry,
                                  CurrentAuthentication currentAuthentication,
                                  @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
                                  StringSubstitutor substitutor,
-                                 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
-                                 ScriptEvaluator scriptEvaluator) {
+                                 DynAttrGroovyFeatureSupport dynAttrGroovyFeatureSupport) {
         this.messages = messages;
         this.datatypeRegistry = datatypeRegistry;
         this.currentAuthentication = currentAuthentication;
         this.substitutor = substitutor;
-        this.scriptEvaluator = scriptEvaluator;
+        this.dynAttrGroovyFeatureSupport = dynAttrGroovyFeatureSupport;
     }
 
 
@@ -81,8 +75,7 @@ public class GroovyScriptValidator<T> extends AbstractValidator<T> {
         if (value == null || !StringUtils.hasText(validatorGroovyScript)) {
             return;
         }
-        Object scriptResult = scriptEvaluator.evaluate(new StaticScriptSource(validatorGroovyScript),
-                Collections.singletonMap("value", value));
+        Object scriptResult = dynAttrGroovyFeatureSupport.evaluateValidationScript(validatorGroovyScript, value);
         if (scriptResult != null) {
             setMessage(scriptResult.toString());
             fireValidationException(value);

--- a/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
+++ b/jmix-dynattr/dynattr-flowui/src/main/java/io/jmix/dynattrflowui/view/categoryattr/CategoryAttributesDetailView.java
@@ -50,6 +50,7 @@ import io.jmix.dynattr.model.CategoryAttribute;
 import io.jmix.dynattr.model.CategoryAttributeConfiguration;
 import io.jmix.dynattr.model.ReferenceToEntity;
 import io.jmix.dynattr.utils.DynAttrStringUtils;
+import io.jmix.dynattrflowui.DynAttrUiProperties;
 import io.jmix.dynattrflowui.impl.DynAttrFacetInfo;
 import io.jmix.dynattrflowui.impl.model.TargetViewComponent;
 import io.jmix.dynattrflowui.utils.DataProviderUtils;
@@ -207,6 +208,8 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
     protected EntityStates entityStates;
     @Autowired
     protected Icons icons;
+    @Autowired
+    private DynAttrUiProperties dynAttrUiProperties;
 
     @ViewComponent
     protected JmixCheckbox lookupField;
@@ -383,6 +386,19 @@ public class CategoryAttributesDetailView extends StandardDetailView<CategoryAtt
         tabSheet.addSelectedChangeListener(e -> refreshOnce());
         screenField.addValueChangeListener(e -> getEditedEntity().setScreen(e.getValue()));
         loadTargetViews();
+
+        updateGroovyEditorsState();
+    }
+
+    private void updateGroovyEditorsState() {
+        boolean readOnly = isReadOnly() || !isGroovyEnabled();
+        validationScriptField.setReadOnly(readOnly);
+        recalculationScriptField.setReadOnly(readOnly);
+        optionsLoaderScriptField.setReadOnly(readOnly);
+    }
+
+    protected boolean isGroovyEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && dynAttrUiProperties.isGroovyEnabled();
     }
 
     protected void initDefaultEntityFieldId() {

--- a/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/messages.properties
+++ b/jmix-dynattr/dynattr-flowui/src/main/resources/io/jmix/dynattrflowui/messages.properties
@@ -15,6 +15,9 @@
 #
 menu-config.dynamicattributes.title=Dynamic attributes
 
+io.jmix.dynattrflowui.impl/validationScriptDisabled=Script-based validation is disabled
+io.jmix.dynattrflowui.impl/recalculationScriptDisabled=Script-based recalculation is disabled
+
 # Category List
 io.jmix.dynattrflowui.view.category/categoryListView.title=Dynamic attributes
 io.jmix.dynattrflowui.view.category/categoriesGrid.applyChanges=Apply changes

--- a/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/JmxConsoleProperties.java
+++ b/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/JmxConsoleProperties.java
@@ -30,9 +30,16 @@ public class JmxConsoleProperties {
      */
     int jmxConsoleMBeanOperationTimeoutSec;
 
+    /**
+     * Whether JMX write and invoke operations are enabled.
+     */
+    boolean writeAndInvokeEnabled;
 
-    public JmxConsoleProperties(@DefaultValue("600") int jmxConsoleMBeanOperationTimeoutSec) {
+
+    public JmxConsoleProperties(@DefaultValue("600") int jmxConsoleMBeanOperationTimeoutSec,
+                                @DefaultValue("true") boolean writeAndInvokeEnabled) {
         this.jmxConsoleMBeanOperationTimeoutSec = jmxConsoleMBeanOperationTimeoutSec;
+        this.writeAndInvokeEnabled = writeAndInvokeEnabled;
     }
 
     /**
@@ -40,5 +47,9 @@ public class JmxConsoleProperties {
      */
     public int getJmxConsoleMBeanOperationTimeoutSec() {
         return jmxConsoleMBeanOperationTimeoutSec;
+    }
+
+    public boolean isWriteAndInvokeEnabled() {
+        return writeAndInvokeEnabled;
     }
 }

--- a/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/impl/JmxControlImpl.java
+++ b/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/impl/JmxControlImpl.java
@@ -18,7 +18,9 @@ package io.jmix.jmxconsole.impl;
 
 import io.jmix.core.EntityStates;
 import io.jmix.core.Metadata;
+import io.jmix.core.CoreProperties;
 import io.jmix.jmxconsole.JmxControl;
+import io.jmix.jmxconsole.JmxConsoleProperties;
 import io.jmix.jmxconsole.JmxControlException;
 import io.jmix.jmxconsole.model.*;
 import org.apache.commons.collections4.CollectionUtils;
@@ -67,14 +69,19 @@ public class JmxControlImpl implements JmxControl {
 
     private final Logger log = LoggerFactory.getLogger(JmxControlImpl.class);
     private final EntityStates entityStates;
+    private final CoreProperties coreProperties;
+    private final JmxConsoleProperties jmxConsoleProperties;
 
     protected ApplicationContext applicationContext;
     protected Metadata metadata;
 
-    public JmxControlImpl(ApplicationContext applicationContext, Metadata metadata, EntityStates entityStates) {
+    public JmxControlImpl(ApplicationContext applicationContext, Metadata metadata, EntityStates entityStates,
+                          CoreProperties coreProperties, JmxConsoleProperties jmxConsoleProperties) {
         this.applicationContext = applicationContext;
         this.metadata = metadata;
         this.entityStates = entityStates;
+        this.coreProperties = coreProperties;
+        this.jmxConsoleProperties = jmxConsoleProperties;
     }
 
     @Override
@@ -286,6 +293,7 @@ public class JmxControlImpl implements JmxControl {
     public void saveAttributeValue(final ManagedBeanAttribute attribute) {
         checkNotNullArgument(attribute);
         checkNotNullArgument(attribute.getMbean());
+        checkWriteAndInvokeEnabled();
 
         withConnection((connection) -> {
             try {
@@ -311,6 +319,7 @@ public class JmxControlImpl implements JmxControl {
     public Object invokeOperation(final ManagedBeanOperation operation, final Object[] parameterValues) {
         checkNotNullArgument(operation);
         checkNotNullArgument(operation.getMbean());
+        checkWriteAndInvokeEnabled();
 
         return withConnection((connection) -> {
             try {
@@ -435,6 +444,16 @@ public class JmxControlImpl implements JmxControl {
             mba.setValue(value.toString());
         }
 
+    }
+
+    protected void checkWriteAndInvokeEnabled() {
+        if (!isWriteAndInvokeEnabled()) {
+            throw new JmxControlException("JMX write and invoke operations are disabled");
+        }
+    }
+
+    protected boolean isWriteAndInvokeEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && jmxConsoleProperties.isWriteAndInvokeEnabled();
     }
 
     /**

--- a/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/view/MBeanAttributeDetailView.java
+++ b/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/view/MBeanAttributeDetailView.java
@@ -20,9 +20,11 @@ import com.vaadin.flow.component.AbstractField;
 import com.vaadin.flow.component.HasLabel;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
+import io.jmix.core.CoreProperties;
 import io.jmix.flowui.Notifications;
 import io.jmix.flowui.view.*;
 import io.jmix.jmxconsole.AttributeComponentProvider;
+import io.jmix.jmxconsole.JmxConsoleProperties;
 import io.jmix.jmxconsole.JmxControl;
 import io.jmix.jmxconsole.model.ManagedBeanAttribute;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +44,10 @@ public class MBeanAttributeDetailView extends StandardDetailView<ManagedBeanAttr
     protected AttributeComponentProvider attributeComponentProvider;
     @Autowired
     protected Notifications notifications;
+    @Autowired
+    protected CoreProperties coreProperties;
+    @Autowired
+    protected JmxConsoleProperties jmxConsoleProperties;
     @ViewComponent
     protected MessageBundle messageBundle;
 
@@ -67,6 +73,7 @@ public class MBeanAttributeDetailView extends StandardDetailView<ManagedBeanAttr
         if (attributeField instanceof HasLabel hasLabelComponent) {
             hasLabelComponent.setLabel("Value");
         }
+        attributeField.setReadOnly(isReadOnly() || !isWriteAndInvokeEnabled());
 
         getContent().addComponentAsFirst(attributeField);
     }
@@ -79,6 +86,13 @@ public class MBeanAttributeDetailView extends StandardDetailView<ManagedBeanAttr
     }
 
     protected boolean valueNotAssigned() {
+        if (!isWriteAndInvokeEnabled()) {
+            notifications.create(messageBundle.getMessage("writeAndInvokeDisabled"))
+                    .withType(Notifications.Type.ERROR)
+                    .show();
+            return true;
+        }
+
         ManagedBeanAttribute managedBeanAttribute = getEditedEntity();
 
         Object oldValue = managedBeanAttribute.getValue();
@@ -117,5 +131,9 @@ public class MBeanAttributeDetailView extends StandardDetailView<ManagedBeanAttr
         } else {
             return super.getPageTitle();
         }
+    }
+
+    protected boolean isWriteAndInvokeEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && jmxConsoleProperties.isWriteAndInvokeEnabled();
     }
 }

--- a/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/view/MBeanInfoDetailView.java
+++ b/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/view/MBeanInfoDetailView.java
@@ -24,6 +24,7 @@ import com.vaadin.flow.data.renderer.ComponentRenderer;
 import com.vaadin.flow.data.renderer.Renderer;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
+import io.jmix.core.CoreProperties;
 import io.jmix.flowui.DialogWindows;
 import io.jmix.flowui.UiComponents;
 import io.jmix.flowui.component.details.JmixDetails;
@@ -35,6 +36,7 @@ import io.jmix.flowui.model.InstanceContainer;
 import io.jmix.flowui.view.*;
 import io.jmix.flowui.view.navigation.UrlParamSerializer;
 import io.jmix.jmxconsole.JmxControl;
+import io.jmix.jmxconsole.JmxConsoleProperties;
 import io.jmix.jmxconsole.model.ManagedBeanAttribute;
 import io.jmix.jmxconsole.model.ManagedBeanInfo;
 import org.apache.commons.collections4.CollectionUtils;
@@ -71,6 +73,10 @@ public class MBeanInfoDetailView extends StandardDetailView<ManagedBeanInfo> {
     protected DialogWindows dialogWindows;
     @Autowired
     protected UrlParamSerializer urlParamSerializer;
+    @Autowired
+    protected CoreProperties coreProperties;
+    @Autowired
+    protected JmxConsoleProperties jmxConsoleProperties;
 
     @Override
     protected void setupEntityToEdit(ManagedBeanInfo entityToEdit) {
@@ -186,7 +192,7 @@ public class MBeanInfoDetailView extends StandardDetailView<ManagedBeanInfo> {
     @Install(to = "attributesDataGrid.edit", subject = "enabledRule")
     protected boolean attributesDataGridEditEnabledRule() {
         ManagedBeanAttribute managedBeanAttribute = attributesDataGrid.getSingleSelectedItem();
-        return managedBeanAttribute != null && managedBeanAttribute.getWriteable();
+        return managedBeanAttribute != null && managedBeanAttribute.getWriteable() && isWriteAndInvokeEnabled();
     }
 
     @Subscribe("attributesDataGrid.edit")
@@ -200,6 +206,9 @@ public class MBeanInfoDetailView extends StandardDetailView<ManagedBeanInfo> {
             return;
         }
         if (!managedBeanAttribute.getWriteable()) {
+            return;
+        }
+        if (!isWriteAndInvokeEnabled()) {
             return;
         }
 
@@ -232,8 +241,13 @@ public class MBeanInfoDetailView extends StandardDetailView<ManagedBeanInfo> {
             mbean.getOperations().forEach(managedBeanOperation -> {
                 MBeanOperationComposite mBeanOperationComposite = uiComponents.create(MBeanOperationComposite.class);
                 mBeanOperationComposite.setOperation(managedBeanOperation);
+                mBeanOperationComposite.setWriteAndInvokeEnabled(isWriteAndInvokeEnabled());
                 operations.add(mBeanOperationComposite);
             });
         }
+    }
+
+    protected boolean isWriteAndInvokeEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && jmxConsoleProperties.isWriteAndInvokeEnabled();
     }
 }

--- a/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/view/MBeanOperationComposite.java
+++ b/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/view/MBeanOperationComposite.java
@@ -21,6 +21,7 @@ import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.H4;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
+import io.jmix.core.CoreProperties;
 import io.jmix.core.Messages;
 import io.jmix.flowui.DialogWindows;
 import io.jmix.flowui.Notifications;
@@ -33,6 +34,7 @@ import io.jmix.flowui.model.DataComponents;
 import io.jmix.flowui.view.DialogWindow;
 import io.jmix.flowui.view.View;
 import io.jmix.jmxconsole.AttributeComponentProvider;
+import io.jmix.jmxconsole.JmxConsoleProperties;
 import io.jmix.jmxconsole.model.ManagedBeanAttribute;
 import io.jmix.jmxconsole.model.ManagedBeanOperation;
 import io.jmix.jmxconsole.model.ManagedBeanOperationParameter;
@@ -45,7 +47,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -69,6 +70,8 @@ public class MBeanOperationComposite extends Composite<JmixDetails>
     protected Messages messages;
     protected DataComponents dataComponents;
     protected DialogWindows dialogWindows;
+    protected CoreProperties coreProperties;
+    protected JmxConsoleProperties jmxConsoleProperties;
 
     protected CollectionContainer<ManagedBeanAttribute> attributeDc;
     protected CollectionLoader<ManagedBeanAttribute> attributeDl;
@@ -81,6 +84,7 @@ public class MBeanOperationComposite extends Composite<JmixDetails>
     protected ManagedBeanOperation operation;
     protected AttributeComponentProvider attributeComponentProvider;
     protected Map<Component, String> attributeFieldsTypeMap = new LinkedHashMap<>();
+    protected boolean writeAndInvokeEnabled = true;
 
     @Override
     public void afterPropertiesSet() {
@@ -94,6 +98,9 @@ public class MBeanOperationComposite extends Composite<JmixDetails>
         this.dataComponents = applicationContext.getBean(DataComponents.class);
         this.dialogWindows = applicationContext.getBean(DialogWindows.class);
         this.attributeComponentProvider = applicationContext.getBean(AttributeComponentProvider.class);
+        this.coreProperties = applicationContext.getBean(CoreProperties.class);
+        this.jmxConsoleProperties = applicationContext.getBean(JmxConsoleProperties.class);
+        this.writeAndInvokeEnabled = isWriteAndInvokeEnabled();
     }
 
     @Override
@@ -120,6 +127,7 @@ public class MBeanOperationComposite extends Composite<JmixDetails>
         invokeBtn = uiComponents.create(JmixButton.class);
         invokeBtn.setText(messages.getMessage(getClass(), "invokeButton.text"));
         invokeBtn.addClickListener(this::onInvokeButtonClick);
+        invokeBtn.setEnabled(writeAndInvokeEnabled);
 
         verticalLayout.add(nameLabel, descriptionSpan, operationVbox, invokeBtn);
 
@@ -163,6 +171,13 @@ public class MBeanOperationComposite extends Composite<JmixDetails>
 
 
     protected void onInvokeButtonClick(ClickEvent<Button> buttonClickEvent) {
+        if (!writeAndInvokeEnabled) {
+            notifications.create(messages.getMessage(getClass(), "writeAndInvokeDisabled"))
+                    .withType(Notifications.Type.ERROR)
+                    .show();
+            return;
+        }
+
         Object[] paramValues;
         try {
             paramValues = attributeFieldsTypeMap.entrySet()
@@ -195,5 +210,16 @@ public class MBeanOperationComposite extends Composite<JmixDetails>
 
     public void setOperation(ManagedBeanOperation operation) {
         this.operation = operation;
+    }
+
+    public void setWriteAndInvokeEnabled(boolean writeAndInvokeEnabled) {
+        this.writeAndInvokeEnabled = writeAndInvokeEnabled;
+        if (invokeBtn != null) {
+            invokeBtn.setEnabled(writeAndInvokeEnabled);
+        }
+    }
+
+    protected boolean isWriteAndInvokeEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && jmxConsoleProperties.isWriteAndInvokeEnabled();
     }
 }

--- a/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/view/MBeanOperationResultView.java
+++ b/jmix-jmxconsole/jmxconsole/src/main/java/io/jmix/jmxconsole/view/MBeanOperationResultView.java
@@ -96,6 +96,14 @@ public class MBeanOperationResultView extends StandardView {
 
     @Subscribe
     public void onBeforeShow(final BeforeShowEvent event) {
+        if (!isWriteAndInvokeEnabled()) {
+            notifications.create(messageBundle.getMessage("writeAndInvokeDisabled"))
+                    .withType(Notifications.Type.ERROR)
+                    .show();
+            closeWithDefaultAction();
+            return;
+        }
+
         BackgroundTask<Long, Object> task =
                 new OperationBackgroundTask(jmxConsoleProperties.getJmxConsoleMBeanOperationTimeoutSec(), this);
         taskHandler = backgroundWorker.handle(task);
@@ -139,6 +147,10 @@ public class MBeanOperationResultView extends StandardView {
         textArea.setValue(message);
         textArea.setReadOnly(true);
         return textArea;
+    }
+
+    protected boolean isWriteAndInvokeEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && jmxConsoleProperties.isWriteAndInvokeEnabled();
     }
 
 

--- a/jmix-jmxconsole/jmxconsole/src/main/resources/io/jmix/jmxconsole/messages.properties
+++ b/jmix-jmxconsole/jmxconsole/src/main/resources/io/jmix/jmxconsole/messages.properties
@@ -40,6 +40,7 @@ io.jmix.jmxconsole.view/mbean.operations.none = None
 io.jmix.jmxconsole.view/inspectAction.text=Inspect
 io.jmix.jmxconsole.view/editAttribute.exception = Exception while saving attribute: "%s"
 io.jmix.jmxconsole.view/editAttribute.conversionError = Don't know how to save this attribute type
+io.jmix.jmxconsole.view/writeAndInvokeDisabled = Write and invoke operations are disabled
 
 io.jmix.jmxconsole.view/backgroundWorkProgress.timeout = Error
 io.jmix.jmxconsole.view/backgroundWorkProgress.timeoutMessage = Execution timeout has been exceeded

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/parameter/ReportParameterDetailView.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/parameter/ReportParameterDetailView.java
@@ -12,6 +12,7 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
+import io.jmix.core.CoreProperties;
 import io.jmix.core.MessageTools;
 import io.jmix.core.Messages;
 import io.jmix.core.Metadata;
@@ -36,6 +37,7 @@ import io.jmix.flowui.kit.icon.JmixFontIcon;
 import io.jmix.flowui.model.InstanceContainer;
 import io.jmix.flowui.view.*;
 import io.jmix.reports.ParameterClassResolver;
+import io.jmix.reports.ReportsProperties;
 import io.jmix.reports.entity.ParameterType;
 import io.jmix.reports.entity.PredefinedTransformation;
 import io.jmix.reports.entity.ReportInputParameter;
@@ -95,6 +97,14 @@ public class ReportParameterDetailView extends StandardDetailView<ReportInputPar
     protected InstanceContainer<ReportInputParameter> parameterDc;
     @ViewComponent
     protected TypedTextField<String> alias;
+    @ViewComponent
+    protected CodeEditor transformationScript;
+    @ViewComponent
+    protected CodeEditor validationScript;
+    @ViewComponent
+    protected Button fullScreenTransformationBtn;
+    @ViewComponent
+    protected Button fullScreenValidationBtn;
 
     @Autowired
     protected ParameterClassResolver parameterClassResolver;
@@ -122,6 +132,10 @@ public class ReportParameterDetailView extends StandardDetailView<ReportInputPar
     protected ParameterComponentGenerationStrategy parameterComponentGenerationStrategy;
     @Autowired
     protected ReportParamAliasValidator reportParamAliasValidator;
+    @Autowired
+    protected CoreProperties coreProperties;
+    @Autowired
+    protected ReportsProperties reportsProperties;
 
     @Subscribe
     public void onInit(InitEvent event) {
@@ -141,6 +155,7 @@ public class ReportParameterDetailView extends StandardDetailView<ReportInputPar
         }
         enableControlsByParamType(editedParam.getType());
         initTransformations();
+        updateGroovyEditorsState();
     }
 
     private void initParameterTypeField() {
@@ -181,6 +196,9 @@ public class ReportParameterDetailView extends StandardDetailView<ReportInputPar
 
     @Subscribe("fullScreenTransformationBtn")
     public void onFullScreenTransformationBtnClick(final ClickEvent<Button> event) {
+        if (!isReportsGroovyEnabled()) {
+            return;
+        }
         reportScriptEditor.create(this)
                 .withTitle(messages.getMessage("fullScreenBtn.title"))
                 .withValue(parameterDc.getItem().getTransformationScript())
@@ -207,6 +225,9 @@ public class ReportParameterDetailView extends StandardDetailView<ReportInputPar
 
     @Subscribe("fullScreenValidationBtn")
     public void onFullScreenValidationBtnClick(final ClickEvent<Button> event) {
+        if (!isReportsGroovyEnabled()) {
+            return;
+        }
         reportScriptEditor.create(this)
                 .withTitle(messages.getMessage("fullScreenBtn.title"))
                 .withValue(parameterDc.getItem().getValidationScript())
@@ -316,6 +337,20 @@ public class ReportParameterDetailView extends StandardDetailView<ReportInputPar
             initDefaultValueField();
             initCurrentDateTimeField();
         }
+
+        updateGroovyEditorsState();
+    }
+
+    protected boolean isReportsGroovyEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && reportsProperties.isGroovyEnabled();
+    }
+
+    protected void updateGroovyEditorsState() {
+        boolean groovyEnabled = isReportsGroovyEnabled();
+        transformationScript.setReadOnly(isReadOnly() || !groovyEnabled);
+        validationScript.setReadOnly(isReadOnly() || !groovyEnabled);
+        fullScreenTransformationBtn.setEnabled(groovyEnabled);
+        fullScreenValidationBtn.setEnabled(groovyEnabled);
     }
 
     @Subscribe("isLookupField")

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/report/ReportDetailView.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/report/ReportDetailView.java
@@ -153,6 +153,8 @@ public class ReportDetailView extends StandardDetailView<Report> {
     @ViewComponent
     protected JmixButton dataSetScriptCodeEditorHelpBtn;
     @ViewComponent
+    protected JmixButton dataSetScriptFullScreenBtn;
+    @ViewComponent
     protected JmixSelect<String> dataStoreField;
     @ViewComponent
     protected JmixCheckbox isProcessTemplateField;
@@ -189,6 +191,8 @@ public class ReportDetailView extends StandardDetailView<Report> {
     @ViewComponent
     protected CodeEditor jsonGroovyCodeEditor;
     @ViewComponent
+    protected JmixButton jsonGroovyCodeEditorFullScreenBtn;
+    @ViewComponent
     protected DataGrid<ReportTemplate> templatesDataGrid;
     @ViewComponent
     protected JmixTextArea localeTextField;
@@ -210,6 +214,10 @@ public class ReportDetailView extends StandardDetailView<Report> {
     protected MessageBundle messageBundle;
     @ViewComponent
     protected NativeLabel codeEditorLabel;
+    @ViewComponent
+    protected CodeEditor validationScriptCodeEditor;
+    @ViewComponent
+    protected JmixButton validationScriptFullScreenBtn;
 
     @Autowired
     protected ReportsPersistence reportsPersistence;
@@ -233,6 +241,8 @@ public class ReportDetailView extends StandardDetailView<Report> {
     protected UiProperties uiProperties;
     @Autowired
     protected CoreProperties coreProperties;
+    @Autowired
+    protected ReportsProperties reportsProperties;
     @Autowired
     protected EntityStates entityStates;
     @Autowired
@@ -351,6 +361,7 @@ public class ReportDetailView extends StandardDetailView<Report> {
         bandsTreeDataGrid.select(getEditedEntity().getRootBandDefinition());
 
         sortBandDefinitionsByPosition();
+        updateGroovyEditorsState(dataSetsDc.getItemOrNull());
     }
 
     @Subscribe("bandsTreeDataGrid.create")
@@ -1311,6 +1322,8 @@ public class ReportDetailView extends StandardDetailView<Report> {
 
             dataSetScriptCodeEditorHelpBtn.setVisible(CodeEditorMode.GROOVY.equals(dataSetScriptCodeEditor.getMode()));
         }
+
+        updateGroovyEditorsState(dataSet);
     }
 
     protected void updateFetchPlanNameFieldItems(@Nullable ReportInputParameter reportInputParameter) {
@@ -1386,6 +1399,8 @@ public class ReportDetailView extends StandardDetailView<Report> {
             default:
                 break;
         }
+
+        updateGroovyEditorsState(dataSet);
     }
 
     protected void setJsonDataSetFieldsVisibility(boolean visible) {
@@ -1462,6 +1477,9 @@ public class ReportDetailView extends StandardDetailView<Report> {
 
     protected void onDataSetScriptFieldExpandIconClick() {
         DataSet dataSet = dataSetsDc.getItem();
+        if (isGroovyDataSetLocked(dataSet)) {
+            return;
+        }
         CodeEditorMode codeEditorMode = getCodeEditorMode(dataSet);
         ReportScriptEditor.Builder reportScriptEditorBuilder = reportScriptEditor.create(this)
                 .withTitle(getScriptEditorDialogCaption())
@@ -1501,10 +1519,13 @@ public class ReportDetailView extends StandardDetailView<Report> {
 
     @Subscribe("jsonGroovyCodeEditorFullScreenBtn")
     public void onJsonGroovyCodeEditorFullScreenBtnClick(final ClickEvent<Button> event) {
+        if (isJsonGroovyEditorLocked(dataSetsDc.getItem())) {
+            return;
+        }
         reportScriptEditor.create(this)
                 .withTitle(getScriptEditorDialogCaption())
                 .withValue(dataSetsDc.getItem().getJsonSourceText())
-                .withEditorMode(CodeEditorMode.JSON)
+                .withEditorMode(CodeEditorMode.GROOVY)
                 .withCloseOnClick(value -> dataSetsDc.getItem().setJsonSourceText(value))
                 .withHelpOnClick(this::onJsonGroovyCodeEditorHelpIconClick)
                 .open();
@@ -1645,6 +1666,9 @@ public class ReportDetailView extends StandardDetailView<Report> {
 
     @Subscribe("validationScriptFullScreenBtn")
     public void onValidationScriptFullScreenBtnClick(final ClickEvent<Button> event) {
+        if (!isReportsGroovyEnabled()) {
+            return;
+        }
         reportScriptEditor.create(this)
                 .withTitle(messageBundle.getMessage("fullScreenBtn.title"))
                 .withValue(reportDc.getItem().getValidationScript())
@@ -1700,6 +1724,37 @@ public class ReportDetailView extends StandardDetailView<Report> {
         options.remove(JsonSourceType.DELEGATE); // can't set it up in runtime editor
 
         jsonSourceTypeField.setItems(options);
+    }
+
+    protected boolean isReportsGroovyEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && reportsProperties.isGroovyEnabled();
+    }
+
+    protected void updateGroovyEditorsState(@Nullable DataSet dataSet) {
+        boolean groovyDataSetLocked = isGroovyDataSetLocked(dataSet);
+        boolean jsonGroovyLocked = isJsonGroovyEditorLocked(dataSet);
+
+        dataSetScriptCodeEditor.setReadOnly(isReadOnly() || groovyDataSetLocked);
+        dataSetScriptFullScreenBtn.setEnabled(!groovyDataSetLocked);
+
+        jsonGroovyCodeEditor.setReadOnly(isReadOnly() || jsonGroovyLocked);
+        jsonGroovyCodeEditorFullScreenBtn.setEnabled(!jsonGroovyLocked);
+
+        validationScriptCodeEditor.setReadOnly(isReadOnly() || !isReportsGroovyEnabled());
+        validationScriptFullScreenBtn.setEnabled(isReportsGroovyEnabled());
+    }
+
+    protected boolean isGroovyDataSetLocked(@Nullable DataSet dataSet) {
+        return dataSet != null
+                && dataSet.getType() == DataSetType.GROOVY
+                && !isReportsGroovyEnabled();
+    }
+
+    protected boolean isJsonGroovyEditorLocked(@Nullable DataSet dataSet) {
+        return dataSet != null
+                && dataSet.getType() == DataSetType.JSON
+                && dataSet.getJsonSourceType() == JsonSourceType.GROOVY_SCRIPT
+                && !isReportsGroovyEnabled();
     }
 
     @Install(to = "rolesDataGrid.exclude", subject = "enabledRule")

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/reportvalueformat/ReportValueFormatDetailView.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/reportvalueformat/ReportValueFormatDetailView.java
@@ -8,6 +8,7 @@ import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
+import io.jmix.core.CoreProperties;
 import io.jmix.core.Metadata;
 import io.jmix.flowui.Dialogs;
 import io.jmix.flowui.component.checkbox.JmixCheckbox;
@@ -16,6 +17,7 @@ import io.jmix.flowui.component.combobox.JmixComboBox;
 import io.jmix.flowui.kit.component.codeeditor.CodeEditorMode;
 import io.jmix.flowui.model.InstanceContainer;
 import io.jmix.flowui.view.*;
+import io.jmix.reports.ReportsProperties;
 import io.jmix.reports.entity.ReportValueFormat;
 import io.jmix.reportsflowui.helper.ReportScriptEditor;
 import io.jmix.security.constraint.PolicyStore;
@@ -59,6 +61,8 @@ public class ReportValueFormatDetailView extends StandardDetailView<ReportValueF
     protected CodeEditor groovyCodeEditor;
     @ViewComponent
     protected Div groovyCodeEditorBox;
+    @ViewComponent
+    protected Button fullScreenTransformationBtn;
 
     @ViewComponent
     protected InstanceContainer<ReportValueFormat> valuesFormatsDc;
@@ -73,6 +77,10 @@ public class ReportValueFormatDetailView extends StandardDetailView<ReportValueF
     protected Dialogs dialogs;
     @Autowired
     protected ReportScriptEditor reportScriptEditor;
+    @Autowired
+    protected CoreProperties coreProperties;
+    @Autowired
+    protected ReportsProperties reportsProperties;
     @ViewComponent
     protected MessageBundle messageBundle;
 
@@ -93,6 +101,7 @@ public class ReportValueFormatDetailView extends StandardDetailView<ReportValueF
             }
             formatField.setValue(value);
         }
+        updateGroovyFieldState();
     }
 
     @Subscribe
@@ -115,6 +124,7 @@ public class ReportValueFormatDetailView extends StandardDetailView<ReportValueF
         }
         groovyCodeEditorBox.setVisible(Boolean.TRUE.equals(visible));
         formatField.setVisible(Boolean.FALSE.equals(visible));
+        updateGroovyFieldState();
     }
 
     @Subscribe("groovyCodeEditorHelpBtn")
@@ -124,6 +134,9 @@ public class ReportValueFormatDetailView extends StandardDetailView<ReportValueF
 
     @Subscribe("fullScreenTransformationBtn")
     public void onFullScreenTransformationBtnClick(final ClickEvent<Button> event) {
+        if (!isReportsGroovyEnabled()) {
+            return;
+        }
         reportScriptEditor.create(this)
                 .withTitle(messageBundle.getMessage("fullScreenBtn.title"))
                 .withValue(valuesFormatsDc.getItem().getFormatString())
@@ -166,5 +179,18 @@ public class ReportValueFormatDetailView extends StandardDetailView<ReportValueF
         optionsList.add(caption);
 
         formatField.setItems(optionsList);
+    }
+
+    protected boolean isReportsGroovyEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && reportsProperties.isGroovyEnabled();
+    }
+
+    protected void updateGroovyFieldState() {
+        boolean groovyEnabled = isReportsGroovyEnabled();
+        boolean groovySelected = Boolean.TRUE.equals(groovyField.getValue());
+
+        groovyField.setReadOnly(isReadOnly() || !groovyEnabled);
+        groovyCodeEditor.setReadOnly(isReadOnly() || (groovySelected && !groovyEnabled));
+        fullScreenTransformationBtn.setEnabled(groovySelected && groovyEnabled);
     }
 }

--- a/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/template/ReportTemplateDetailView.java
+++ b/jmix-reports/reports-flowui/src/main/java/io/jmix/reportsflowui/view/template/ReportTemplateDetailView.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
+import io.jmix.core.CoreProperties;
 import io.jmix.core.Metadata;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.flowui.Dialogs;
@@ -46,6 +47,7 @@ import io.jmix.flowui.kit.icon.JmixFontIcon;
 import io.jmix.flowui.model.InstanceContainer;
 import io.jmix.flowui.view.*;
 import io.jmix.reports.ReportPrintHelper;
+import io.jmix.reports.ReportsProperties;
 import io.jmix.reports.entity.CustomTemplateDefinedBy;
 import io.jmix.reports.entity.Report;
 import io.jmix.reports.entity.ReportOutputType;
@@ -90,6 +92,8 @@ public class ReportTemplateDetailView extends StandardDetailView<ReportTemplate>
     @ViewComponent
     protected JmixCodeEditor customDefinitionField;
     @ViewComponent
+    protected Button customDefinitionFullScreenBtn;
+    @ViewComponent
     protected JmixCheckbox alterableField;
     @ViewComponent
     protected FileUploadField templateUploadField;
@@ -125,6 +129,10 @@ public class ReportTemplateDetailView extends StandardDetailView<ReportTemplate>
     protected ReportScriptEditor reportScriptEditor;
     @Autowired
     protected OutputTypeHelper outputTypeHelper;
+    @Autowired
+    protected CoreProperties coreProperties;
+    @Autowired
+    protected ReportsProperties reportsProperties;
 
     protected FontIcon customDefinitionHelpIcon;
     protected TableEditFragment tableEditComposite;
@@ -172,6 +180,7 @@ public class ReportTemplateDetailView extends StandardDetailView<ReportTemplate>
         initTemplateEditor(reportTemplate);
         getDescriptionEditors().forEach(controller -> controller.setReportTemplate(reportTemplate));
         setupVisibility(reportTemplate.getCustom(), reportTemplate.getReportOutputType());
+        updateCustomDefinitionAccess();
     }
 
     @Subscribe
@@ -302,6 +311,9 @@ public class ReportTemplateDetailView extends StandardDetailView<ReportTemplate>
 
     @Subscribe("customDefinitionFullScreenBtn")
     public void onCustomDefinitionFullScreenBtnClick(final ClickEvent<Button> event) {
+        if (isGroovyCustomDefinitionLocked()) {
+            return;
+        }
         reportScriptEditor.create(this)
                 .withTitle(messageBundle.getMessage("customDefinitionField.label"))
                 .withValue(getEditedEntity().getCustomDefinition())
@@ -348,7 +360,12 @@ public class ReportTemplateDetailView extends StandardDetailView<ReportTemplate>
                 setupVisibility(Boolean.TRUE.equals(event.getValue()), reportTemplate.getReportOutputType());
                 break;
             }
+            case CUSTOM_DEFINE_BY_PROPERTY: {
+                updateCustomDefinitionAccess();
+                break;
+            }
         }
+        updateCustomDefinitionAccess();
     }
 
     protected Collection<AbstractDescriptionEditFragment<?>> getDescriptionEditors() {
@@ -444,6 +461,7 @@ public class ReportTemplateDetailView extends StandardDetailView<ReportTemplate>
 
         setupTemplateTypeVisibility(templateOutputVisibility);
         setupVisibilityDescriptionEdit(enabled, reportOutputType);
+        updateCustomDefinitionAccess();
     }
 
     protected void setupTemplateTypeVisibility(boolean visibility) {
@@ -574,6 +592,11 @@ public class ReportTemplateDetailView extends StandardDetailView<ReportTemplate>
         return CustomTemplateDefinedBy.SCRIPT == customTemplateDefinedBy;
     }
 
+    protected boolean hasGroovyCustomDefinedBy(@Nullable CustomTemplateDefinedBy customTemplateDefinedBy) {
+        return customTemplateDefinedBy == CustomTemplateDefinedBy.SCRIPT
+                || customTemplateDefinedBy == CustomTemplateDefinedBy.URL;
+    }
+
     protected boolean hasHtmlCsvTemplateOutput(@Nullable ReportOutputType reportOutputType) {
         return reportOutputType == ReportOutputType.CSV || reportOutputType == ReportOutputType.HTML;
     }
@@ -583,5 +606,21 @@ public class ReportTemplateDetailView extends StandardDetailView<ReportTemplate>
         return secureOperations.isEntityUpdatePermitted(templateMetaClass, policyStore)
                 && secureOperations.isEntityAttrUpdatePermitted(
                 templateMetaClass.getPropertyPath("content"), policyStore);
+    }
+
+    protected boolean isReportsGroovyEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && reportsProperties.isGroovyEnabled();
+    }
+
+    protected boolean isGroovyCustomDefinitionLocked() {
+        return Boolean.TRUE.equals(getEditedEntity().getCustom())
+                && hasGroovyCustomDefinedBy(getEditedEntity().getCustomDefinedBy())
+                && !isReportsGroovyEnabled();
+    }
+
+    protected void updateCustomDefinitionAccess() {
+        boolean locked = isReadOnly() || isGroovyCustomDefinitionLocked();
+        customDefinitionField.setReadOnly(locked);
+        customDefinitionFullScreenBtn.setEnabled(!locked);
     }
 }

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/ReportsProperties.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/ReportsProperties.java
@@ -160,6 +160,11 @@ public class ReportsProperties {
      */
     boolean useLegacyDateTimeTypes;
 
+    /**
+     * Whether Groovy execution is enabled in reports.
+     */
+    boolean groovyEnabled;
+
     public ReportsProperties(@DefaultValue("/") String officePath,
                              @DefaultValue({"8100", "8101", "8102", "8103"}) List<Integer> officePorts,
                              @DefaultValue("20") int docFormatterTimeout,
@@ -185,6 +190,7 @@ public class ReportsProperties {
                              @DefaultValue("false") boolean formulasPostProcessingEvaluationEnabled,
                              @DefaultValue("false") boolean multilineStringsProcessingEnabled,
                              @DefaultValue("false") boolean useLegacyDateTimeTypes,
+                             @DefaultValue("true") boolean groovyEnabled,
                              @DefaultValue({"htm", "html", "jpg", "png", "jpeg", "pdf"}) List<String> viewFileExtensions) {
         this.officePath = officePath;
         this.officePorts = officePorts;
@@ -211,6 +217,7 @@ public class ReportsProperties {
         this.formulasPostProcessingEvaluationEnabled = formulasPostProcessingEvaluationEnabled;
         this.multilineStringsProcessingEnabled = multilineStringsProcessingEnabled;
         this.useLegacyDateTimeTypes = useLegacyDateTimeTypes;
+        this.groovyEnabled = groovyEnabled;
         this.viewFileExtensions = viewFileExtensions;
     }
 
@@ -218,6 +225,10 @@ public class ReportsProperties {
      * @see #viewFileExtensions
      */
     public List<String> getViewFileExtensions() { return viewFileExtensions; }
+
+    public boolean isGroovyEnabled() {
+        return groovyEnabled;
+    }
 
     /**
      * @see #officePath

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/CustomFormatter.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/CustomFormatter.java
@@ -73,6 +73,9 @@ public class CustomFormatter implements CustomReport {
     @Autowired
     protected ApplicationContext applicationContext;
 
+    @Autowired
+    protected ReportsGroovyFeatureSupport groovyFeatureSupport;
+
     public static final String PARAMS = "params";
     private static final String ROOT_BAND = "rootBand";
     private static final String PATH_GROOVY_FILE = "(\\w[\\w\\d_-]*/)*(\\w[\\w\\d-_]*\\.groovy)";
@@ -130,6 +133,9 @@ public class CustomFormatter implements CustomReport {
     }
 
     protected byte[] generateReportWithScript(BandData rootBand, String customDefinition) {
+        if (!groovyFeatureSupport.isGroovyEnabled()) {
+            groovyFeatureSupport.throwGroovyDisabled("custom report script");
+        }
         Object result;
 
         if (customDefinition.startsWith("/")) {
@@ -165,6 +171,9 @@ public class CustomFormatter implements CustomReport {
     }
 
     protected byte[] generateReportWithUrl(BandData rootBand, String customDefinition) {
+        if (!groovyFeatureSupport.isGroovyEnabled()) {
+            groovyFeatureSupport.throwGroovyDisabled("custom report URL definition");
+        }
         Map<String, Object> convertedParams = new HashMap<>();
         for (Map.Entry<String, Object> entry : params.entrySet()) {
             if (entry.getValue() instanceof Date) {

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixGroovyDataLoader.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixGroovyDataLoader.java
@@ -40,6 +40,9 @@ public class JmixGroovyDataLoader implements ReportDataLoader {
     protected GroovyScriptParametersProvider groovyScriptParametersProvider;
 
     @Autowired
+    protected ReportsGroovyFeatureSupport groovyFeatureSupport;
+
+    @Autowired
     public JmixGroovyDataLoader(Scripting scripting) {
         this.scripting = scripting;
     }
@@ -54,6 +57,9 @@ public class JmixGroovyDataLoader implements ReportDataLoader {
             script = StringUtils.trim(script);
             if (script.endsWith(".groovy")) {
                 script = resources.getResourceAsString(script);
+            }
+            if (!groovyFeatureSupport.isGroovyEnabled()) {
+                return groovyFeatureSupport.getDisabledDataSetResult(reportQuery.getName());
             }
             return scripting.evaluateGroovy(script, scriptParams);
         } catch (ValidationException e) {

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixHtmlFormatter.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixHtmlFormatter.java
@@ -77,6 +77,8 @@ public class JmixHtmlFormatter extends HtmlFormatter {
     protected FileStorageLocator fileStorageLocator;
     @Autowired
     protected Resources resources;
+    @Autowired
+    protected ReportsGroovyFeatureSupport groovyFeatureSupport;
 
     public JmixHtmlFormatter(FormatterFactoryInput formatterFactoryInput) {
         super(formatterFactoryInput);
@@ -125,6 +127,14 @@ public class JmixHtmlFormatter extends HtmlFormatter {
             File systemFontsDir = new File(reportsProperties.getPdfFontsDirectory());
             loadFontsFromDirectory(converter, systemFontsDir);
         }
+    }
+
+    @Override
+    protected void writeHtmlDocument(BandData rootBand, OutputStream outputStream) {
+        if (reportTemplate.isGroovy() && !groovyFeatureSupport.isGroovyEnabled()) {
+            groovyFeatureSupport.throwGroovyDisabled("Groovy HTML template");
+        }
+        super.writeHtmlDocument(rootBand, outputStream);
     }
 
     protected String resolveResourceUri(String uri) {

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixJsonDataLoader.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixJsonDataLoader.java
@@ -56,6 +56,9 @@ public class JmixJsonDataLoader extends JsonDataLoader {
     protected Resources resources;
 
     @Autowired
+    protected ReportsGroovyFeatureSupport groovyFeatureSupport;
+
+    @Autowired
     public JmixJsonDataLoader(Scripting scripting) {
         this.scripting = scripting;
     }
@@ -115,6 +118,9 @@ public class JmixJsonDataLoader extends JsonDataLoader {
 
         Map<String, Object> scriptParams = groovyScriptParametersProvider.getParametersForDatasetParameters(
                 reportQuery, parentBand, reportParams);
+        if (!groovyFeatureSupport.isGroovyEnabled()) {
+            return groovyFeatureSupport.getDisabledJsonResult(reportQuery.getName());
+        }
         return scripting.evaluateGroovy(jsonSourceText, scriptParams);
     }
 

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixReporting.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixReporting.java
@@ -64,6 +64,9 @@ public class JmixReporting extends Reporting {
     @Autowired
     protected ApplicationContext applicationContext;
 
+    @Autowired
+    protected ReportsGroovyFeatureSupport groovyFeatureSupport;
+
     public void setScripting(Scripting scripting) {
         this.scripting = scripting;
     }
@@ -129,6 +132,9 @@ public class JmixReporting extends Reporting {
     }
 
     protected Object handleScriptTransformation(Object paramValue, String script, Map<String, Object> params) {
+        if (!groovyFeatureSupport.isGroovyEnabled()) {
+            return groovyFeatureSupport.getDisabledTransformationResult("parameter transformation", paramValue);
+        }
         Map<String, Object> scriptParams = new HashMap<>();
         scriptParams.put("params", params);
         scriptParams.put("paramValue", paramValue);

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixSqlDataLoader.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JmixSqlDataLoader.java
@@ -17,6 +17,7 @@
 package io.jmix.reports.libintegration;
 
 import io.jmix.reports.yarg.loaders.impl.SqlDataLoader;
+import io.jmix.reports.yarg.structure.BandData;
 import io.jmix.reports.yarg.util.db.QueryRunner;
 import io.jmix.reports.yarg.util.db.ResultSetHandler;
 import io.jmix.reports.yarg.structure.ReportQuery;
@@ -26,11 +27,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 
 public class JmixSqlDataLoader extends SqlDataLoader {
 
     @Autowired
     protected StoreAwareLocator storeAwareLocator;
+    @Autowired
+    protected ReportsGroovyFeatureSupport groovyFeatureSupport;
 
     public JmixSqlDataLoader(DataSource dataSource) {
         super(dataSource);
@@ -40,5 +44,13 @@ public class JmixSqlDataLoader extends SqlDataLoader {
     protected List runQuery(ReportQuery reportQuery, String queryString, Object[] params, ResultSetHandler<List> handler) throws SQLException {
         QueryRunner runner = new QueryRunner(storeAwareLocator.getDataSource(StoreUtils.getStoreName(reportQuery)));
         return runner.query(queryString, params, handler);
+    }
+
+    @Override
+    protected String processQueryTemplate(String query, BandData parentBand, Map<String, Object> reportParams) {
+        if (!groovyFeatureSupport.isGroovyEnabled()) {
+            return groovyFeatureSupport.getDisabledQueryTemplateResult("sql", query);
+        }
+        return super.processQueryTemplate(query, parentBand, reportParams);
     }
 }

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JpqlDataLoader.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/JpqlDataLoader.java
@@ -54,6 +54,9 @@ public class JpqlDataLoader extends AbstractDbDataLoader implements ReportDataLo
     @Autowired
     protected StoreAwareLocator storeAwareLocator;
 
+    @Autowired
+    protected ReportsGroovyFeatureSupport groovyFeatureSupport;
+
     private static final String QUERY_END = "%%END%%";
     private static final String ALIAS_PATTERN = "as\\s+\"?([\\w|\\d|_|\\.]+)\"?\\s*";
     private static final Pattern OUTPUT_PARAMS_PATTERN =
@@ -137,6 +140,14 @@ public class JpqlDataLoader extends AbstractDbDataLoader implements ReportDataLo
         //Just transform positional parameters into named - the simplest solution to the problem of mixing
         // input parameters and JPQL macros without modification of YARG (#805).
         return "param_" + parameter.getPosition();
+    }
+
+    @Override
+    protected String processQueryTemplate(String query, BandData parentBand, Map<String, Object> reportParams) {
+        if (!groovyFeatureSupport.isGroovyEnabled()) {
+            return groovyFeatureSupport.getDisabledQueryTemplateResult("jpql", query);
+        }
+        return super.processQueryTemplate(query, parentBand, reportParams);
     }
 
     protected String trimQuery(String query) {

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/ReportsGroovyFeatureSupport.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/libintegration/ReportsGroovyFeatureSupport.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.reports.libintegration;
+
+import io.jmix.core.CoreProperties;
+import io.jmix.reports.ReportsProperties;
+import io.jmix.reports.yarg.exception.ReportingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+@Component("report_ReportsGroovyFeatureSupport")
+public class ReportsGroovyFeatureSupport {
+
+    private static final Logger log = LoggerFactory.getLogger(ReportsGroovyFeatureSupport.class);
+
+    protected final ReportsProperties reportsProperties;
+    protected final CoreProperties coreProperties;
+
+    public ReportsGroovyFeatureSupport(ReportsProperties reportsProperties, CoreProperties coreProperties) {
+        this.reportsProperties = reportsProperties;
+        this.coreProperties = coreProperties;
+    }
+
+    public boolean isGroovyEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && reportsProperties.isGroovyEnabled();
+    }
+
+    public List<Map<String, Object>> getDisabledDataSetResult(String dataSetName) {
+        log.warn("Groovy execution is disabled for reports. Returning an empty data set result for '{}'.", dataSetName);
+        return Collections.emptyList();
+    }
+
+    public String getDisabledJsonResult(String dataSetName) {
+        log.warn("Groovy execution is disabled for reports. Returning an empty JSON array for '{}'.", dataSetName);
+        return "[]";
+    }
+
+    public String getDisabledFormatterResult(String parameterName) {
+        log.warn("Groovy execution is disabled for reports. Returning an empty formatted value for '{}'.", parameterName);
+        return "";
+    }
+
+    public Object getDisabledTransformationResult(String parameterName, Object originalValue) {
+        log.warn("Groovy execution is disabled for reports. Returning the original parameter value for '{}'.", parameterName);
+        return originalValue;
+    }
+
+    public String getDisabledQueryTemplateResult(String dataSetName, String query) {
+        log.warn("Groovy execution is disabled for reports. Returning the original query template for '{}'.", dataSetName);
+        return query;
+    }
+
+    public void throwGroovyDisabled(String featureDescription) {
+        throw new ReportingException("Groovy execution is disabled for reports: " + featureDescription);
+    }
+}

--- a/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/AbstractFormatter.java
+++ b/jmix-reports/reports/src/main/java/io/jmix/reports/yarg/formatters/impl/AbstractFormatter.java
@@ -17,6 +17,7 @@ package io.jmix.reports.yarg.formatters.impl;
 
 import com.google.common.base.Preconditions;
 import io.jmix.reports.libintegration.GroovyScriptParametersProvider;
+import io.jmix.reports.libintegration.ReportsGroovyFeatureSupport;
 import io.jmix.reports.yarg.exception.ReportFormattingException;
 import io.jmix.reports.yarg.exception.ReportingException;
 import io.jmix.reports.yarg.exception.ReportingInterruptedException;
@@ -69,6 +70,8 @@ public abstract class AbstractFormatter implements ReportFormatter {
     protected GroovyScriptParametersProvider groovyScriptParametersProvider;
     @Autowired
     protected Scripting scripting;
+    @Autowired
+    protected ReportsGroovyFeatureSupport groovyFeatureSupport;
 
     /**
      * Chain of responsibility for content inliners
@@ -136,7 +139,11 @@ public abstract class AbstractFormatter implements ReportFormatter {
             if (Boolean.TRUE.equals(isGroovyScript(parameterName, fullParameterName))) {
                 Map<String, Object> params = groovyScriptParametersProvider.getParametersForFormatterParameters();
                 params.put(VALUE, value);
-                valueString = scripting.evaluateGroovy(formatString, params);
+                if (!groovyFeatureSupport.isGroovyEnabled()) {
+                    valueString = groovyFeatureSupport.getDisabledFormatterResult(fullParameterName);
+                } else {
+                    valueString = scripting.evaluateGroovy(formatString, params);
+                }
             } else if (formatString.startsWith("class:")) {
                 String className = formatString.replaceFirst("class:", "");
                 ValueFormat valueFormat;

--- a/jmix-security/security-data/src/main/java/io/jmix/securitydata/SecurityDataConfiguration.java
+++ b/jmix-security/security-data/src/main/java/io/jmix/securitydata/SecurityDataConfiguration.java
@@ -20,6 +20,7 @@ import io.jmix.core.annotation.JmixModule;
 import io.jmix.data.DataConfiguration;
 import io.jmix.security.SecurityConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.*;
 import org.springframework.security.web.authentication.rememberme.JdbcTokenRepositoryImpl;
 import org.springframework.security.web.authentication.rememberme.PersistentTokenRepository;
@@ -28,6 +29,7 @@ import javax.sql.DataSource;
 
 @Configuration
 @ComponentScan
+@EnableConfigurationProperties(SecurityDataProperties.class)
 @JmixModule(dependsOn = {SecurityConfiguration.class, DataConfiguration.class})
 @PropertySource(name = "io.jmix.securitydata", value = "classpath:/io/jmix/securitydata/module.properties")
 public class SecurityDataConfiguration {

--- a/jmix-security/security-data/src/main/java/io/jmix/securitydata/SecurityDataProperties.java
+++ b/jmix-security/security-data/src/main/java/io/jmix/securitydata/SecurityDataProperties.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.securitydata;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties(prefix = "jmix.security.data")
+public class SecurityDataProperties {
+
+    /**
+     * Whether Groovy execution is enabled in row-level role predicates.
+     */
+    boolean groovyEnabled;
+
+    public SecurityDataProperties(@DefaultValue("true") boolean groovyEnabled) {
+        this.groovyEnabled = groovyEnabled;
+    }
+
+    public boolean isGroovyEnabled() {
+        return groovyEnabled;
+    }
+}

--- a/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/role/provider/DatabaseRowLevelRoleProvider.java
+++ b/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/role/provider/DatabaseRowLevelRoleProvider.java
@@ -23,14 +23,11 @@ import io.jmix.security.role.RowLevelRoleProvider;
 import io.jmix.securitydata.entity.RowLevelPolicyEntity;
 import io.jmix.securitydata.entity.RowLevelRoleEntity;
 import org.springframework.context.ApplicationContext;
-import org.springframework.scripting.ScriptEvaluator;
-import org.springframework.scripting.support.StaticScriptSource;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 /**
@@ -40,11 +37,12 @@ import java.util.stream.Collectors;
 public class DatabaseRowLevelRoleProvider extends BaseDatabaseRoleProvider<RowLevelRole>
         implements RowLevelRoleProvider {
 
-    private final ScriptEvaluator scriptEvaluator;
+    private final SecurityDataGroovyFeatureSupport groovyFeatureSupport;
     private final ApplicationContext applicationContext;
 
-    public DatabaseRowLevelRoleProvider(ScriptEvaluator scriptEvaluator, ApplicationContext applicationContext) {
-        this.scriptEvaluator = scriptEvaluator;
+    public DatabaseRowLevelRoleProvider(SecurityDataGroovyFeatureSupport groovyFeatureSupport,
+                                        ApplicationContext applicationContext) {
+        this.groovyFeatureSupport = groovyFeatureSupport;
         this.applicationContext = applicationContext;
     }
 
@@ -103,12 +101,6 @@ public class DatabaseRowLevelRoleProvider extends BaseDatabaseRoleProvider<RowLe
     }
 
     public RowLevelBiPredicate<Object, ApplicationContext> createPredicateFromScript(String script) {
-        return (entity, applicationContext) -> {
-            String modifiedScript = script.replace("{E}", "__entity__");
-            Map<String, Object> arguments = new HashMap<>();
-            arguments.put("__entity__", entity);
-            arguments.put("applicationContext", applicationContext);
-            return Boolean.TRUE.equals(scriptEvaluator.evaluate(new StaticScriptSource(modifiedScript), arguments));
-        };
+        return (entity, applicationContext) -> groovyFeatureSupport.evaluatePredicate(script, entity, applicationContext);
     }
 }

--- a/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/role/provider/SecurityDataGroovyFeatureSupport.java
+++ b/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/role/provider/SecurityDataGroovyFeatureSupport.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.securitydata.impl.role.provider;
+
+import io.jmix.core.CoreProperties;
+import io.jmix.securitydata.SecurityDataProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scripting.ScriptEvaluator;
+import org.springframework.scripting.support.StaticScriptSource;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component("sec_SecurityDataGroovyFeatureSupport")
+public class SecurityDataGroovyFeatureSupport {
+
+    private static final Logger log = LoggerFactory.getLogger(SecurityDataGroovyFeatureSupport.class);
+
+    protected final ScriptEvaluator scriptEvaluator;
+    protected final SecurityDataProperties securityDataProperties;
+    protected final CoreProperties coreProperties;
+
+    public SecurityDataGroovyFeatureSupport(ScriptEvaluator scriptEvaluator,
+                                            SecurityDataProperties securityDataProperties,
+                                            CoreProperties coreProperties) {
+        this.scriptEvaluator = scriptEvaluator;
+        this.securityDataProperties = securityDataProperties;
+        this.coreProperties = coreProperties;
+    }
+
+    public boolean isGroovyEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled() && securityDataProperties.isGroovyEnabled();
+    }
+
+    public boolean evaluatePredicate(String script, Object entity, ApplicationContext applicationContext) {
+        if (!isGroovyEnabled()) {
+            log.warn("Groovy execution is disabled for security row-level predicates. Returning deny result.");
+            return false;
+        }
+
+        String modifiedScript = script.replace("{E}", "__entity__");
+        Map<String, Object> arguments = new HashMap<>();
+        arguments.put("__entity__", entity);
+        arguments.put("applicationContext", applicationContext);
+        return Boolean.TRUE.equals(scriptEvaluator.evaluate(new StaticScriptSource(modifiedScript), arguments));
+    }
+}

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/rowlevelpolicy/RowLevelPolicyModelDetailView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/rowlevelpolicy/RowLevelPolicyModelDetailView.java
@@ -9,10 +9,10 @@ import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.html.Span;
-import com.vaadin.flow.component.orderedlayout.FlexComponent.Alignment;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.select.Select;
 import com.vaadin.flow.component.textfield.TextArea;
+import io.jmix.core.CoreProperties;
 import io.jmix.core.MessageTools;
 import io.jmix.core.Metadata;
 import io.jmix.core.metamodel.model.MetaClass;
@@ -30,6 +30,7 @@ import io.jmix.security.role.RolePersistence;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
 
 import java.util.List;
 import java.util.Map;
@@ -73,6 +74,10 @@ public class RowLevelPolicyModelDetailView extends StandardDetailView<RowLevelPo
     private Metadata metadata;
     @Autowired(required = false)
     private RolePersistence rolePersistence;
+    @Autowired
+    private CoreProperties coreProperties;
+    @Autowired
+    private Environment environment;
 
     @Subscribe
     public void onInit(InitEvent event) {
@@ -111,7 +116,8 @@ public class RowLevelPolicyModelDetailView extends StandardDetailView<RowLevelPo
                 break;
             case PREDICATE:
                 checkSyntaxBtn.setEnabled(!Strings.isNullOrEmpty(entity.getEntityName())
-                        && !Strings.isNullOrEmpty(entity.getScript()));
+                        && !Strings.isNullOrEmpty(entity.getScript())
+                        && isSecurityDataGroovyEnabled());
                 break;
             default:
                 checkSyntaxBtn.setEnabled(false);
@@ -141,6 +147,7 @@ public class RowLevelPolicyModelDetailView extends StandardDetailView<RowLevelPo
                 joinClauseField.setVisible(false);
                 whereClauseField.setVisible(false);
                 scriptField.setVisible(true);
+                scriptField.setReadOnly(isReadOnly() || !isSecurityDataGroovyEnabled());
 
                 getEditedEntity().setWhereClause(null);
                 getEditedEntity().setJoinClause(null);
@@ -156,6 +163,9 @@ public class RowLevelPolicyModelDetailView extends StandardDetailView<RowLevelPo
                 checkJpqlSyntax();
                 break;
             case PREDICATE:
+                if (!isSecurityDataGroovyEnabled()) {
+                    return;
+                }
                 checkPredicateSyntax();
                 break;
             default:
@@ -239,5 +249,10 @@ public class RowLevelPolicyModelDetailView extends StandardDetailView<RowLevelPo
             throw new IllegalStateException("RolePersistence is not available");
         }
         return rolePersistence;
+    }
+
+    private boolean isSecurityDataGroovyEnabled() {
+        return coreProperties.isUnsafeRuntimeFeaturesEnabled()
+                && environment.getProperty("jmix.security.data.groovy-enabled", Boolean.class, true);
     }
 }


### PR DESCRIPTION
## Summary

This PR adds application properties to disable unsafe runtime features. All properties default to `true`, so the current behavior is preserved unless a property is explicitly turned off.

A global kill switch was added in `jmix-core`:

- `jmix.core.unsafe-runtime-features-enabled`

When this property is `false`, all guarded features below are disabled regardless of their module-specific flags.

## Added Properties

- `jmix.core.unsafe-runtime-features-enabled`
  - Global kill switch for all guarded runtime features in this PR.

- `jmix.core.hot-deploy-enabled`
  - Disables loading classes from the file system in `io.jmix.core.impl.JavaClassLoader`.
- `jmix.core.trigger-files-enabled`
  - Disables trigger file processing in `io.jmix.core.impl.TriggerFilesProcessor`.

- `jmix.security.data.groovy-enabled`
  - Disables Groovy execution for predicate row-level policies.
  - When disabled, predicate policies evaluate to deny access.

- `jmix.dynattr.ui.groovy-enabled`
  - Disables Groovy execution for dynamic attribute scripts.
  - Affects:
    - validation scripts
    - recalculation scripts
    - options loader scripts

- `jmix.reports.groovy-enabled`
  - Disables Groovy execution in reports.
  - Affects:
    - Groovy data set queries
    - Groovy JSON data sources
    - Groovy value formatting
    - parameter transformation scripts
    - Groovy-based custom templates
    - Groovy HTML templates
    - Groovy-generated custom template URLs

- `jmix.jmxconsole.write-and-invoke-enabled`
  - Disables write and invoke operations in the JMX console.
  - Read-only inspection remains available.

## Behavioral Changes

- Backend enforcement was added for all guarded features, so disabling a property is not limited to UI restrictions.
- Reports, dynattr, and security log warnings whenever a fallback value is returned instead of executing Groovy.
- Reports UI makes Groovy-related editors read-only when Groovy is disabled.
- Security UI makes the predicate script field read-only when Groovy is disabled.
- JMX console UI disables edit/invoke actions when write/invoke support is disabled.

## Compatibility

- All new properties default to `true`.
- Existing applications keep current behavior unless these properties are explicitly changed.