### PR TITLE
Remove orphan Timer metrics  #5290

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/impl/JavaClassLoader.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/JavaClassLoader.java
@@ -21,8 +21,6 @@ import com.google.common.collect.Sets;
 import io.jmix.core.CoreProperties;
 import io.jmix.core.TimeSource;
 import io.jmix.core.common.util.ReflectionHelper;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import jakarta.annotation.PreDestroy;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -62,8 +60,6 @@ public class JavaClassLoader extends URLClassLoader {
     protected TimeSource timeSource;
     @Autowired
     protected SpringBeanLoader springBeanLoader;
-    @Autowired
-    protected MeterRegistry meterRegistry;
 
     @Autowired
     public JavaClassLoader(CoreProperties coreProperties) {
@@ -108,7 +104,6 @@ public class JavaClassLoader extends URLClassLoader {
     public Class loadClass(final String fullClassName, boolean resolve) throws ClassNotFoundException {
         String containerClassName = StringUtils.substringBefore(fullClassName, "$");
 
-        Timer.Sample sample = Timer.start(meterRegistry);
         try {
             lock(containerClassName);
             Class clazz;
@@ -135,7 +130,6 @@ public class JavaClassLoader extends URLClassLoader {
             return clazz;
         } finally {
             unlock(containerClassName);
-            sample.stop(meterRegistry.timer("jmix.JavaClassLoader.loadClass"));
         }
     }
 

--- a/jmix-pessimisticlock/pessimisticlock/src/main/java/io/jmix/pessimisticlock/impl/AnnotationLockDescriptorProvider.java
+++ b/jmix-pessimisticlock/pessimisticlock/src/main/java/io/jmix/pessimisticlock/impl/AnnotationLockDescriptorProvider.java
@@ -23,8 +23,6 @@ import io.jmix.pessimisticlock.entity.LockDescriptor;
 import io.jmix.pessimisticlock.LockDescriptorProvider;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.pessimisticlock.annotation.PessimisticLock;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.Timer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -46,42 +44,33 @@ public class AnnotationLockDescriptorProvider implements LockDescriptorProvider 
     protected final ExtendedEntities extendedEntities;
     protected final MetadataTools metadataTools;
     protected final Metadata metadata;
-    protected final MeterRegistry meterRegistry;
 
     public AnnotationLockDescriptorProvider(ExtendedEntities extendedEntities,
                                             MetadataTools metadataTools,
-                                            Metadata metadata,
-                                            MeterRegistry meterRegistry) {
+                                            Metadata metadata) {
         this.extendedEntities = extendedEntities;
         this.metadataTools = metadataTools;
         this.metadata = metadata;
-        this.meterRegistry = meterRegistry;
     }
 
     @Override
     public List<LockDescriptor> getLockDescriptors() {
-        Timer.Sample sample = Timer.start(meterRegistry);
+        log.info("Collecting pessimistic locks configuration annotations");
+
         List<LockDescriptor> config = new ArrayList<>();
-        try {
-            log.info("Collecting pessimistic locks configuration annotations");
+        for (MetaClass metaClass : metadata.getSession().getClasses()) {
+            MetaClass originalMetaClass = extendedEntities.getOriginalOrThisMetaClass(metaClass);
+            Map<String, Object> attributes =
+                    metadataTools.getMetaAnnotationAttributes(originalMetaClass.getAnnotations(),
+                            PessimisticLock.class);
 
-            for (MetaClass metaClass : metadata.getSession().getClasses()) {
-                MetaClass originalMetaClass = extendedEntities.getOriginalOrThisMetaClass(metaClass);
-                Map<String, Object> attributes =
-                        metadataTools.getMetaAnnotationAttributes(originalMetaClass.getAnnotations(),
-                                PessimisticLock.class);
-
-                if (!attributes.isEmpty()) {
-                    String originalName = originalMetaClass.getName();
-                    Integer timeoutSec = (Integer) attributes.get("timeoutSec");
-                    LockDescriptor descriptor = new LockDescriptor(originalName, timeoutSec);
-                    config.add(descriptor);
-                }
+            if (!attributes.isEmpty()) {
+                String originalName = originalMetaClass.getName();
+                Integer timeoutSec = (Integer) attributes.get("timeoutSec");
+                LockDescriptor descriptor = new LockDescriptor(originalName, timeoutSec);
+                config.add(descriptor);
             }
-        } finally {
-            sample.stop(meterRegistry.timer("jmix.AnnotationLockDescriptorProvider.loadConfig"));
         }
-
         return config;
     }
 }


### PR DESCRIPTION
#5290 — Remove orphan Timer metrics

Removes the two metrics described in the linked issue. 1 commit.

## Changes

- `io.jmix.core.impl.JavaClassLoader` — drop `Timer.start` / `sample.stop` wrapping in `loadClass`, remove the `MeterRegistry` field and related imports.
- `io.jmix.pessimisticlock.impl.AnnotationLockDescriptorProvider` — drop the timer wrapping in `getLockDescriptors`, remove the `MeterRegistry` constructor parameter and related imports.

## Public API changes

`AnnotationLockDescriptorProvider` constructor loses its `MeterRegistry` parameter. The class is in the `.impl` package and is autowired by Spring; no first-party code constructs it manually.

## Breaking changes

- The series `jmix_JavaClassLoader_loadClass_*` and `jmix_AnnotationLockDescriptorProvider_loadConfig_*` disappear from `/actuator/prometheus`. Any external dashboard or alert that references them must be updated.
- External code that manually invokes the four-arg `AnnotationLockDescriptorProvider` constructor must drop the `MeterRegistry` argument.

## QA checklist

- [ ] `/actuator/prometheus` no longer exposes the two metrics.
- [ ] JVM-level class loading metrics (`jvm_classes_*`) keep working.
- [ ] Hot deploy in Jmix Studio works (no functional regression).
- [ ] Pessimistic lock subsystem loads its config on first lock request.
