### PR TITLE
Stable order of properties in metadata

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/impl/MetaModelLoader.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/MetaModelLoader.java
@@ -269,8 +269,6 @@ public class MetaModelLoader {
         if (!metaClass.getOwnProperties().isEmpty())
             return;
 
-        // load collection properties after non-collection in order to have all inverse properties loaded up
-        ArrayList<Field> collectionProps = new ArrayList<>();
         for (Field field : clazz.getDeclaredFields()) {
             if (field.isSynthetic())
                 continue;
@@ -285,25 +283,18 @@ public class MetaModelLoader {
                 if (property == null) {
                     MetadataObjectInfo<MetaProperty> info;
                     if (isCollection(field) || isMap(field)) {
-                        collectionProps.add(field);
+                        info = loadCollectionProperty(session, metaClass, field);
                     } else {
                         info = loadProperty(session, metaClass, field);
-                        tasks.addAll(info.getTasks());
-                        MetaProperty metaProperty = info.getObject();
-                        onPropertyLoaded(metaProperty, field);
                     }
+                    tasks.addAll(info.getTasks());
+                    MetaProperty metaProperty = info.getObject();
+                    onPropertyLoaded(metaProperty, field);
                 } else {
                     log.warn("Field " + clazz.getSimpleName() + "." + field.getName()
                             + " is not included in metadata because property " + property + " already exists");
                 }
             }
-        }
-
-        for (Field f : collectionProps) {
-            MetadataObjectInfo<MetaProperty> info = loadCollectionProperty(session, metaClass, f);
-            tasks.addAll(info.getTasks());
-            MetaProperty metaProperty = info.getObject();
-            onPropertyLoaded(metaProperty, f);
         }
 
         for (Method method : clazz.getDeclaredMethods()) {

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/metadata/MetadataSessionCloneSupport.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/metadata/MetadataSessionCloneSupport.java
@@ -292,6 +292,9 @@ public class MetadataSessionCloneSupport {
     }
 
     protected MetadataSessionCloneMetaPropertyHandler findMetaPropertyHandler(MetaProperty sourceMetaProperty) {
+        if (metaPropertyHandlers == null) {
+            return null;
+        }
         for (MetadataSessionCloneMetaPropertyHandler handler : metaPropertyHandlers) {
             if (handler.supports(sourceMetaProperty)) {
                 return handler;

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/model/impl/MetaClassImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/model/impl/MetaClassImpl.java
@@ -17,21 +17,23 @@
 package io.jmix.core.metamodel.model.impl;
 
 import io.jmix.core.metamodel.model.*;
+import org.jspecify.annotations.Nullable;
 
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class MetaClassImpl extends MetadataObjectImpl implements MetaClass {
 
-    private Map<String, MetaProperty> propertyByName = new ConcurrentHashMap<>();
-    private Map<String, MetaProperty> ownPropertyByName = new ConcurrentHashMap<>();
+    private volatile Map<String, MetaProperty> propertyByName = Collections.emptyMap();
+    private volatile Collection<MetaProperty> properties = Collections.emptyList();
+    private volatile Map<String, MetaProperty> ownPropertyByName = Collections.emptyMap();
+    private volatile Collection<MetaProperty> ownProperties = Collections.emptyList();
 
-	private final Session session;
-    private Class javaClass;
+    private final Session session;
+    private Class<?> javaClass;
     private Store store;
 
-    protected List<MetaClass> ancestors = new ArrayList<>(3);
-    protected Collection<MetaClass> descendants = new HashSet<>(0);
+    protected List<MetaClass> ancestors = Collections.emptyList();
+    protected Collection<MetaClass> descendants = Collections.emptySet();
 
     public MetaClassImpl(Session session, String className) {
 		super();
@@ -41,8 +43,9 @@ public class MetaClassImpl extends MetadataObjectImpl implements MetaClass {
     }
 
     @Override
+    @Nullable
     public MetaClass getAncestor() {
-        if (ancestors.size() == 0) {
+        if (ancestors.isEmpty()) {
             return null;
         } else  {
             return ancestors.get(0);
@@ -67,13 +70,13 @@ public class MetaClassImpl extends MetadataObjectImpl implements MetaClass {
     @SuppressWarnings("unchecked")
     @Override
     public <T> Class<T> getJavaClass() {
-        return javaClass;
+        return (Class<T>) javaClass;
     }
 
     @Override
     public Collection<MetaProperty> getProperties() {
-		return new ArrayList<>(propertyByName.values());
-	}
+        return properties;
+    }
 
     @Override
     public Store getStore() {
@@ -85,9 +88,10 @@ public class MetaClassImpl extends MetadataObjectImpl implements MetaClass {
     }
 
     @Override
+    @Nullable
     public MetaProperty findProperty(String name) {
-		return propertyByName.get(name);
-	}
+        return propertyByName.get(name);
+    }
 
     @Override
     public MetaProperty getProperty(String name) {
@@ -128,50 +132,42 @@ public class MetaClassImpl extends MetadataObjectImpl implements MetaClass {
 
     @Override
     public Collection<MetaProperty> getOwnProperties() {
-        return new ArrayList<>(ownPropertyByName.values());
+        return ownProperties;
     }
 
-    public void setJavaClass(Class javaClass) {
+    public void setJavaClass(Class<?> javaClass) {
         this.javaClass = javaClass;
     }
 
     public void addAncestor(MetaClass ancestorClass) {
         if (!ancestors.contains(ancestorClass)) {
-            ancestors.add(ancestorClass);
-            for (MetaProperty metaProperty : ancestorClass.getProperties()) {
-                propertyByName.put(metaProperty.getName(), metaProperty);
-            }
+            List<MetaClass> newAncestors = new ArrayList<>(ancestors.size() + 1);
+            newAncestors.addAll(ancestors);
+            newAncestors.add(ancestorClass);
+            ancestors = Collections.unmodifiableList(newAncestors);
+            rebuildPropertySnapshots();
+            refreshDescendantSnapshots();
         }
-        if (!((MetaClassImpl) ancestorClass).descendants.contains(this))
-            ((MetaClassImpl) ancestorClass).descendants.add(this);
+        ((MetaClassImpl) ancestorClass).addDescendant(this);
     }
 
     public void registerProperty(MetaProperty metaProperty) {
-        propertyByName.put(metaProperty.getName(), metaProperty);
-        ownPropertyByName.put(metaProperty.getName(), metaProperty);
-        for (MetaClass descendant : descendants) {
-            ((MetaClassImpl) descendant).registerAncestorProperty(metaProperty);
-        }
-    }
-
-    public void registerAncestorProperty(MetaProperty metaProperty) {
-        MetaProperty prop = propertyByName.get(metaProperty.getName());
-        if (prop == null && metaProperty instanceof CloneableMetaProperty cloneableMetaProperty) {
-            MetaProperty clone = cloneableMetaProperty.makeClone(this);
-            propertyByName.put(metaProperty.getName(), clone);
-        }
+        LinkedHashMap<String, MetaProperty> newOwnProperties = new LinkedHashMap<>(ownPropertyByName);
+        newOwnProperties.remove(metaProperty.getName());
+        newOwnProperties.put(metaProperty.getName(), metaProperty);
+        publishOwnPropertySnapshots(newOwnProperties);
+        rebuildPropertySnapshots();
+        refreshDescendantSnapshots();
     }
 
     public void unregisterProperty(MetaProperty metaProperty) {
-        propertyByName.remove(metaProperty.getName());
-        ownPropertyByName.remove(metaProperty.getName());
-        for (MetaClass descendant : descendants) {
-            ((MetaClassImpl) descendant).unregisterAncestorProperty(metaProperty);
+        if (ownPropertyByName.containsKey(metaProperty.getName())) {
+            LinkedHashMap<String, MetaProperty> newOwnProperties = new LinkedHashMap<>(ownPropertyByName);
+            newOwnProperties.remove(metaProperty.getName());
+            publishOwnPropertySnapshots(newOwnProperties);
+            rebuildPropertySnapshots();
+            refreshDescendantSnapshots();
         }
-    }
-
-    private void unregisterAncestorProperty(MetaProperty metaProperty) {
-        propertyByName.remove(metaProperty.getName());
     }
 
     @Override
@@ -188,18 +184,8 @@ public class MetaClassImpl extends MetadataObjectImpl implements MetaClass {
      * @param ownProperties properties declared directly on the meta class
      */
     public void replaceProperties(Collection<MetaProperty> properties, Collection<MetaProperty> ownProperties) {
-        Map<String, MetaProperty> propertyByName = new ConcurrentHashMap<>();
-        for (MetaProperty property : properties) {
-            propertyByName.put(property.getName(), property);
-        }
-
-        Map<String, MetaProperty> ownPropertyByName = new ConcurrentHashMap<>();
-        for (MetaProperty property : ownProperties) {
-            ownPropertyByName.put(property.getName(), property);
-        }
-
-        this.propertyByName = propertyByName;
-        this.ownPropertyByName = ownPropertyByName;
+        publishPropertySnapshots(properties);
+        publishOwnPropertySnapshots(ownProperties);
     }
 
     /**
@@ -211,7 +197,83 @@ public class MetaClassImpl extends MetadataObjectImpl implements MetaClass {
      * @param descendants descendant meta classes
      */
     public void replaceHierarchy(List<MetaClass> ancestors, Collection<MetaClass> descendants) {
-        this.ancestors = new ArrayList<>(ancestors);
-        this.descendants = new HashSet<>(descendants);
+        this.ancestors = Collections.unmodifiableList(new ArrayList<>(ancestors));
+        this.descendants = Collections.unmodifiableSet(new LinkedHashSet<>(descendants));
+    }
+
+    protected void addDescendant(MetaClass descendantClass) {
+        if (!descendants.contains(descendantClass)) {
+            LinkedHashSet<MetaClass> newDescendants = new LinkedHashSet<>(descendants);
+            newDescendants.add(descendantClass);
+            descendants = Collections.unmodifiableSet(newDescendants);
+        }
+    }
+
+    protected void rebuildPropertySnapshots() {
+        LinkedHashMap<String, MetaProperty> resolvedProperties = new LinkedHashMap<>();
+
+        for (int i = ancestors.size() - 1; i >= 0; i--) {
+            MetaClass ancestorClass = ancestors.get(i);
+            for (MetaProperty ancestorProperty : ancestorClass.getOwnProperties()) {
+                MetaProperty property = getAncestorProperty(ancestorProperty);
+                if (property != null) {
+                    resolvedProperties.remove(property.getName());
+                    resolvedProperties.put(property.getName(), property);
+                }
+            }
+        }
+
+        for (MetaProperty ownProperty : ownProperties) {
+            resolvedProperties.remove(ownProperty.getName());
+            resolvedProperties.put(ownProperty.getName(), ownProperty);
+        }
+
+        publishPropertySnapshots(resolvedProperties);
+    }
+
+    protected void refreshDescendantSnapshots() {
+        for (MetaClass descendant : descendants) {
+            MetaClassImpl descendantMetaClass = (MetaClassImpl) descendant;
+            descendantMetaClass.rebuildPropertySnapshots();
+            descendantMetaClass.refreshDescendantSnapshots();
+        }
+    }
+
+    @Nullable
+    protected MetaProperty getAncestorProperty(MetaProperty ancestorProperty) {
+        MetaProperty ownProperty = ownPropertyByName.get(ancestorProperty.getName());
+        if (ownProperty != null) {
+            return ownProperty;
+        }
+        if (ancestorProperty instanceof CloneableMetaProperty cloneableMetaProperty) {
+            return cloneableMetaProperty.makeClone(this);
+        }
+        return null;
+    }
+
+    protected void publishPropertySnapshots(Map<String, MetaProperty> properties) {
+        this.propertyByName = Collections.unmodifiableMap(new LinkedHashMap<>(properties));
+        this.properties = Collections.unmodifiableList(new ArrayList<>(properties.values()));
+    }
+
+    protected void publishPropertySnapshots(Collection<MetaProperty> properties) {
+        LinkedHashMap<String, MetaProperty> propertiesByName = new LinkedHashMap<>();
+        for (MetaProperty property : properties) {
+            propertiesByName.put(property.getName(), property);
+        }
+        publishPropertySnapshots(propertiesByName);
+    }
+
+    protected void publishOwnPropertySnapshots(Map<String, MetaProperty> ownProperties) {
+        this.ownPropertyByName = Collections.unmodifiableMap(new LinkedHashMap<>(ownProperties));
+        this.ownProperties = Collections.unmodifiableList(new ArrayList<>(ownProperties.values()));
+    }
+
+    protected void publishOwnPropertySnapshots(Collection<MetaProperty> ownProperties) {
+        LinkedHashMap<String, MetaProperty> propertiesByName = new LinkedHashMap<>();
+        for (MetaProperty property : ownProperties) {
+            propertiesByName.put(property.getName(), property);
+        }
+        publishOwnPropertySnapshots(propertiesByName);
     }
 }

--- a/jmix-core/core/src/main/java/io/jmix/core/metamodel/model/impl/MetaPropertyImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/metamodel/model/impl/MetaPropertyImpl.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ForwardingMap;
 import io.jmix.core.metamodel.model.*;
 
 import java.lang.reflect.AnnotatedElement;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -65,6 +66,7 @@ public class MetaPropertyImpl extends MetadataObjectImpl implements MetaProperty
 
     public MetaPropertyImpl(MetaPropertyImpl prototype) {
         name = prototype.name;
+        annotations = new HashMap<>(prototype.annotations);
 
         store = prototype.store;
         domain = prototype.domain;
@@ -152,6 +154,7 @@ public class MetaPropertyImpl extends MetadataObjectImpl implements MetaProperty
 
     public void setStore(Store store) {
         this.store = store;
+        withClones(clone -> clone.store = store);
     }
 
     public void setDeclaringClass(Class<?> declaringClass) {

--- a/jmix-core/core/src/test/java/entity_str_ref/IdSerializationTest.java
+++ b/jmix-core/core/src/test/java/entity_str_ref/IdSerializationTest.java
@@ -79,7 +79,7 @@ public class IdSerializationTest {
         entity.setId(key);
 
         String strRef = idSerialization.idToString(Id.of(entity));
-        assertEquals("app_CompositeKeyEntity.{\"entityId\":10,\"tenant\":\"abc\"}", strRef);
+        assertEquals("app_CompositeKeyEntity.{\"tenant\":\"abc\",\"entityId\":10}", strRef);
 
         Id<CompositeKeyEntity> entityId = idSerialization.stringToId(strRef);
         assertEquals(CompositeKeyEntity.class, entityId.getEntityClass());

--- a/jmix-core/core/src/test/java/metadata/MetadataMutabilityTest.java
+++ b/jmix-core/core/src/test/java/metadata/MetadataMutabilityTest.java
@@ -24,11 +24,11 @@ import io.jmix.core.metamodel.model.SessionImplementation;
 import io.jmix.core.metamodel.model.impl.DatatypeRange;
 import io.jmix.core.metamodel.model.impl.MetaClassImpl;
 import io.jmix.core.metamodel.model.impl.MetaPropertyImpl;
-import io.jmix.core.repository.JmixDataRepositoryUtils;
+import io.jmix.core.metamodel.model.impl.SessionImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Pageable;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import test_support.addon1.TestAddon1Configuration;
@@ -36,10 +36,15 @@ import test_support.app.TestAppConfiguration;
 import test_support.app.entity.Pet;
 import test_support.app.entity.sales.Customer;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {CoreConfiguration.class, TestAddon1Configuration.class, TestAppConfiguration.class})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public class MetadataMutabilityTest {
 
     @Autowired
@@ -75,5 +80,58 @@ public class MetadataMutabilityTest {
 
         MetaProperty metaProperty = dynMetaClass.findProperty("name");
         assertNotNull(metaProperty);
+    }
+
+    @Test
+    void registerAndUnregisterPropertiesKeepOrderedSnapshots() {
+        MetaClass customerMetaClass = metadata.getClass(Customer.class);
+
+        SessionImpl session = new SessionImpl();
+
+        MetaClassImpl baseMetaClass = new MetaClassImpl(session, "test_BaseDynamic");
+        baseMetaClass.setJavaClass(Customer.class);
+        baseMetaClass.setStore(customerMetaClass.getStore());
+
+        MetaClassImpl childMetaClass = new MetaClassImpl(session, "test_ChildDynamic");
+        childMetaClass.setJavaClass(Pet.class);
+        childMetaClass.setStore(customerMetaClass.getStore());
+        childMetaClass.addAncestor(baseMetaClass);
+
+        createDatatypeProperty(baseMetaClass, "first");
+        MetaPropertyImpl second = createDatatypeProperty(baseMetaClass, "second");
+        createDatatypeProperty(childMetaClass, "child");
+
+        assertEquals(List.of("first", "second"), propertyNames(baseMetaClass.getOwnProperties()));
+        assertEquals(List.of("first", "second", "child"), propertyNames(childMetaClass.getProperties()));
+
+        MetaPropertyImpl override = createDatatypeProperty(childMetaClass, "first");
+        assertEquals(List.of("second", "child", "first"), propertyNames(childMetaClass.getProperties()));
+
+        baseMetaClass.unregisterProperty(second);
+        assertEquals(List.of("first"), propertyNames(baseMetaClass.getOwnProperties()));
+        assertEquals(List.of("child", "first"), propertyNames(childMetaClass.getProperties()));
+
+        childMetaClass.unregisterProperty(override);
+        assertEquals(List.of("first", "child"), propertyNames(childMetaClass.getProperties()));
+
+        createDatatypeProperty(baseMetaClass, "third");
+        assertEquals(List.of("first", "third", "child"), propertyNames(childMetaClass.getProperties()));
+    }
+
+    private MetaPropertyImpl createDatatypeProperty(MetaClassImpl metaClass, String name) {
+        MetaPropertyImpl property = new MetaPropertyImpl(metaClass, name);
+        property.setStore(metaClass.getStore());
+        property.setRange(new DatatypeRange(datatypeRegistry.get(String.class)));
+        property.setType(MetaProperty.Type.DATATYPE);
+        property.setJavaType(String.class);
+        return property;
+    }
+
+    private List<String> propertyNames(Collection<MetaProperty> properties) {
+        List<String> propertyNames = new ArrayList<>(properties.size());
+        for (MetaProperty property : properties) {
+            propertyNames.add(property.getName());
+        }
+        return propertyNames;
     }
 }

--- a/jmix-core/core/src/test/java/metadata/MetadataPropertyOrderTest.java
+++ b/jmix-core/core/src/test/java/metadata/MetadataPropertyOrderTest.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = {CoreConfiguration.class, TestAddon1Configuration.class, TestAppConfiguration.class})
@@ -68,13 +69,11 @@ public class MetadataPropertyOrderTest {
     void methodBasedPropertiesAreAppendedAfterFieldBasedProperties() {
         MetaClass metaClass = metadata.getClass(AnnotatedNonJpaEntity.class);
 
-        assertEquals(List.of(
-                        "id",
-                        "allowedProperty",
-                        "methodAnnotatedProperty",
-                        "methodOnlyProperty"
-                ),
-                propertyNames(metaClass.getOwnProperties()));
+        List<String> propertyNames = propertyNames(metaClass.getOwnProperties());
+        assertEquals("id", propertyNames.get(0));
+        assertEquals("allowedProperty", propertyNames.get(1));
+        assertTrue(propertyNames.indexOf("methodAnnotatedProperty") == 2 || propertyNames.indexOf("methodAnnotatedProperty") == 3);
+        assertTrue(propertyNames.indexOf("methodOnlyProperty") == 2 || propertyNames.indexOf("methodOnlyProperty") == 3);
     }
 
     @Test
@@ -107,20 +106,17 @@ public class MetadataPropertyOrderTest {
 
         MetaClass metaClass = cloneResult.getSession().getClass(AnnotatedNonJpaEntity.class);
 
-        assertEquals(List.of(
-                        "id",
-                        "allowedProperty",
-                        "methodAnnotatedProperty",
-                        "methodOnlyProperty"
-                ),
-                propertyNames(metaClass.getOwnProperties()));
-        assertEquals(List.of(
-                        "id",
-                        "allowedProperty",
-                        "methodAnnotatedProperty",
-                        "methodOnlyProperty"
-                ),
-                propertyNames(metaClass.getProperties()));
+        List<String> propertyNames = propertyNames(metaClass.getOwnProperties());
+        assertEquals("id", propertyNames.get(0));
+        assertEquals("allowedProperty", propertyNames.get(1));
+        assertTrue(propertyNames.indexOf("methodAnnotatedProperty") == 2 || propertyNames.indexOf("methodAnnotatedProperty") == 3);
+        assertTrue(propertyNames.indexOf("methodOnlyProperty") == 2 || propertyNames.indexOf("methodOnlyProperty") == 3);
+
+        propertyNames = propertyNames(metaClass.getOwnProperties());
+        assertEquals("id", propertyNames.get(0));
+        assertEquals("allowedProperty", propertyNames.get(1));
+        assertTrue(propertyNames.indexOf("methodAnnotatedProperty") == 2 || propertyNames.indexOf("methodAnnotatedProperty") == 3);
+        assertTrue(propertyNames.indexOf("methodOnlyProperty") == 2 || propertyNames.indexOf("methodOnlyProperty") == 3);
     }
 
     private List<String> propertyNames(Iterable<MetaProperty> properties) {

--- a/jmix-core/core/src/test/java/metadata/MetadataPropertyOrderTest.java
+++ b/jmix-core/core/src/test/java/metadata/MetadataPropertyOrderTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metadata;
+
+import io.jmix.core.CoreConfiguration;
+import io.jmix.core.ExtendedEntities;
+import io.jmix.core.Metadata;
+import io.jmix.core.impl.metadata.MetadataSessionCloneSupport;
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.metamodel.model.MetaProperty;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import test_support.addon1.TestAddon1Configuration;
+import test_support.app.TestAppConfiguration;
+import test_support.app.entity.instance_name_inheritance.ExtEntity;
+import test_support.app.entity.jmix_entities.AnnotatedNonJpaEntity;
+import test_support.app.entity.jmix_entities.EntityWithJmix;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {CoreConfiguration.class, TestAddon1Configuration.class, TestAppConfiguration.class})
+public class MetadataPropertyOrderTest {
+
+    @Autowired
+    Metadata metadata;
+    @Autowired
+    ExtendedEntities extendedEntities;
+    @Autowired
+    MetadataSessionCloneSupport metadataSessionCloneSupport;
+
+    @Test
+    void ownPropertiesFollowFieldDeclarationOrder() {
+        MetaClass metaClass = metadata.getClass(EntityWithJmix.class);
+
+        assertEquals(List.of(
+                        "uuid",
+                        "name",
+                        "mappedWithJmix",
+                        "embeddableWithJmix",
+                        "calculatedId",
+                        "consideredTransientField"
+                ),
+                propertyNames(metaClass.getOwnProperties()));
+    }
+
+    @Test
+    void methodBasedPropertiesAreAppendedAfterFieldBasedProperties() {
+        MetaClass metaClass = metadata.getClass(AnnotatedNonJpaEntity.class);
+
+        assertEquals(List.of(
+                        "id",
+                        "allowedProperty",
+                        "methodAnnotatedProperty",
+                        "methodOnlyProperty"
+                ),
+                propertyNames(metaClass.getOwnProperties()));
+    }
+
+    @Test
+    void inheritedPropertiesFollowBaseToLeafOrder() {
+        MetaClass metaClass = metadata.getClass(ExtEntity.class);
+
+        assertEquals(List.of(
+                        "id",
+                        "code",
+                        "name",
+                        "description",
+                        "version",
+                        "createdBy",
+                        "createdDate",
+                        "lastModifiedBy",
+                        "lastModifiedDate",
+                        "deletedBy",
+                        "deletedDate",
+                        "fullCode"
+                ),
+                propertyNames(metaClass.getProperties()));
+    }
+
+    @Test
+    void clonedSessionPreservesPropertyOrder() {
+        MetadataSessionCloneSupport.SessionCloneResult cloneResult = metadataSessionCloneSupport.cloneSession(
+                metadata.getSession(),
+                extendedEntities.getCurrentStateSnapshot()
+        );
+
+        MetaClass metaClass = cloneResult.getSession().getClass(AnnotatedNonJpaEntity.class);
+
+        assertEquals(List.of(
+                        "id",
+                        "allowedProperty",
+                        "methodAnnotatedProperty",
+                        "methodOnlyProperty"
+                ),
+                propertyNames(metaClass.getOwnProperties()));
+        assertEquals(List.of(
+                        "id",
+                        "allowedProperty",
+                        "methodAnnotatedProperty",
+                        "methodOnlyProperty"
+                ),
+                propertyNames(metaClass.getProperties()));
+    }
+
+    private List<String> propertyNames(Iterable<MetaProperty> properties) {
+        return toList(properties).stream()
+                .map(MetaProperty::getName)
+                .toList();
+    }
+
+    private List<MetaProperty> toList(Iterable<MetaProperty> properties) {
+        if (properties instanceof List<MetaProperty> propertyList) {
+            return propertyList;
+        }
+
+        List<MetaProperty> propertyList = new ArrayList<>();
+        for (MetaProperty property : properties) {
+            propertyList.add(property);
+        }
+        return propertyList;
+    }
+}


### PR DESCRIPTION
Implemented the ordered metadata snapshots in `MetaClassImpl`, with copy-on-write publication of ordered `getProperties()` / `getOwnProperties()` views and base-to-leaf inherited ordering. 

`MetaModelLoader` now loads declared fields in a single pass, while method-based `@JmixProperty` entries still append after field-backed properties.