### PR TITLE
Refactor layout.xsd

### DIFF
--- a/doc/features/flowui-layout-xsd/README.md
+++ b/doc/features/flowui-layout-xsd/README.md
@@ -1,0 +1,13 @@
+# FlowUI Layout XSD — Reference for Agents
+
+Reference material for agents working on `jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd` — the XSD that defines the `http://jmix.io/schema/flowui/layout` namespace used in Jmix view XML.
+
+The goal: when adding a new component, extending an existing one, or defining a new attribute, **reuse existing building blocks first**. New `simpleType`/`complexType`/`attributeGroup` definitions should be introduced only when nothing existing fits.
+
+Read the docs in this order:
+
+1. [reusable-types.md](reusable-types.md) — catalog of the reusable definitions in the XSD: attribute groups (capability mix-ins), base complex types (inheritance chains), shared enums, shared element groups, validators, formatters, renderers.
+2. [component-patterns.md](component-patterns.md) — how to apply the catalog when adding a component, extending an existing one, or deciding whether to introduce a new type.
+3. [known-issues.md](known-issues.md) — pre-existing strict-XSD-validator complaints that were intentionally left unfixed, with context for future cleanup passes.
+
+Both reference docs use real definitions from `layout.xsd` as the source of truth — when in doubt, the XSD wins.

--- a/doc/features/flowui-layout-xsd/component-patterns.md
+++ b/doc/features/flowui-layout-xsd/component-patterns.md
@@ -1,0 +1,312 @@
+# Component Patterns in `layout.xsd`
+
+Patterns for adding or extending components in the FlowUI layout XSD, illustrated with definitions already in the file. Use these as templates and decision rules.
+
+Prerequisite: read [reusable-types.md](reusable-types.md) for the catalog of building blocks referenced below.
+
+---
+
+## 1. Decision tree: which base do I extend?
+
+Pick the **most specific** existing base type that already provides the bulk of what your component needs.
+
+```
+Are you adding...
+
+  a form field that binds to a data container property?
+    └─ extend baseFieldComponent
+         (validatable? → validatableBaseFieldComponent
+            text-input-shaped? → baseTextFieldComponent
+            a value picker with action buttons? → valuePickerComponent
+            an entity picker? → entityPickerComponent)
+
+  a custom action (visible in <actions>)?
+    └─ extend baseAction (or noShortcutBaseAction inside menus/dropdowns)
+
+  an icon-displaying leaf component?
+    └─ extend baseIconComponent
+
+  a tabbed container?
+    └─ extend baseTabsComponent
+
+  a dropdown / split-button-style component?
+    └─ extend baseDropdownButtonComponent
+
+  a filter primitive?
+    └─ extend baseSingleFilterComponent (or one of basePropertyFilter/baseJpqlFilter/baseGroupFilter)
+
+  a thin wrapper around an HTML element?
+    └─ extend baseHtmlComponent / baseHtmlContainer / baseClickableHtmlContainer / clickableHtmlContainerWithArea
+
+  none of the above (a generic visible component)?
+    └─ extend baseComponent
+```
+
+Never extend nothing — every visible component should at least reach `baseComponent` so it inherits `id`, `visible`, `colspan`, `alignSelf`, `justifySelf`, `css`, and the `##other` namespace extension hook.
+
+---
+
+## 2. Example: a new "plain" component extending `baseComponent`
+
+`progressBarComponent` ([layout.xsd](../../../jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd)) is a minimal pattern — visible widget with its own theme set and a handful of typed primitive attributes:
+
+```xml
+<xs:complexType name="progressBarComponent">
+    <xs:complexContent>
+        <xs:extension base="baseComponent">
+            <xs:attribute name="max" type="xs:double"/>
+            <xs:attribute name="min" type="xs:double"/>
+            <xs:attribute name="value" type="xs:double"/>
+            <xs:attribute name="indeterminate" type="xs:boolean"/>
+            <xs:attribute name="themeNames" type="progressBarThemeNames"/>
+
+            <xs:attributeGroup ref="hasSize"/>
+            <xs:attributeGroup ref="hasClassNames"/>
+        </xs:extension>
+    </xs:complexContent>
+</xs:complexType>
+```
+
+Observations:
+
+- Component-specific values that are pure primitives (`min`/`max`/`value`/`indeterminate`) get inline `<xs:attribute>` with a built-in type.
+- Sizing and CSS classes come from `hasSize` + `hasClassNames` — never re-declared.
+- The theme set is its own simpleType (`progressBarThemeNames`) — see §5 for when to add a new theme type.
+
+To register the new component in the view namespace, also add it to the `standardComponent` group:
+
+```xml
+<xs:element name="progressBar" type="progressBarComponent"/>
+```
+
+---
+
+## 3. Example: a new form-field component
+
+Fields go through the data-binding/validation chain. `numberFieldComponent` is the canonical pattern:
+
+```xml
+<xs:complexType name="numberFieldComponent">
+    <xs:complexContent>
+        <xs:extension base="baseTextFieldComponent">
+            <xs:sequence>
+                <xs:element name="validators" minOccurs="0" type="numberFieldValidatorType"/>
+            </xs:sequence>
+
+            <xs:attribute name="max" type="xs:double"/>
+            <xs:attribute name="min" type="xs:double"/>
+            <xs:attribute name="step" type="xs:double"/>
+            <xs:attribute name="stepButtonsVisible" type="xs:boolean"/>
+            <xs:attribute name="allowedCharPattern" type="resourceString"/>
+
+            <xs:attributeGroup ref="hasRequired"/>
+        </xs:extension>
+    </xs:complexContent>
+</xs:complexType>
+```
+
+Key idea: the `<validators>` child uses a **field-specific validator type** (`numberFieldValidatorType`) that already extends `baseValidatorType` and exposes only the rules that make sense for numbers. If a new field type needs validation, create a matching validator (see §6) — do not inline validation elements on the component.
+
+For a selection field (combo, list, etc.) reuse `hasItems` rather than re-declaring `itemsContainer` and `itemsEnum`:
+
+```xml
+<xs:complexType name="radioButtonGroupComponent">
+    <xs:complexContent>
+        <xs:extension base="baseComponent">
+            ...
+            <xs:attribute name="themeNames" type="radioButtonGroupThemeNames"/>
+            <xs:attribute name="datatype" type="fieldDatatypeEnum"/>
+
+            <xs:attributeGroup ref="hasItems"/>
+            <xs:attributeGroup ref="hasSize"/>
+            <xs:attributeGroup ref="hasLabel"/>
+            ...
+        </xs:extension>
+    </xs:complexContent>
+</xs:complexType>
+```
+
+---
+
+## 4. Example: extending an existing component without breaking it
+
+Two safe ways to add functionality to an existing component:
+
+**(a) Create a subtype via `xs:extension`.** This is how `treeDataGridComponent` adds hierarchy to `dataGridComponent`:
+
+```xml
+<xs:complexType name="treeDataGridComponent">
+    <xs:complexContent>
+        <xs:extension base="dataGridComponent">
+            <xs:attribute name="hierarchyProperty" type="xs:string" use="required"/>
+            <xs:attribute name="hierarchyColumn" type="xs:string"/>
+            <xs:attribute name="showOrphans" type="xs:boolean"/>
+        </xs:extension>
+    </xs:complexContent>
+</xs:complexType>
+```
+
+Then register a separate element name (`<treeDataGrid>`) in `standardComponent`. The existing `dataGrid` element keeps its surface intact.
+
+**(b) Add an attribute directly** to the existing complexType. Acceptable when it's a genuine new capability of the same component. Prefer extending an attributeGroup if the same attribute might appear elsewhere:
+
+- If the new attribute is **specific to this component** → inline `<xs:attribute>`.
+- If the new attribute is **shared with ≥2 components** → introduce a `has<X>` attributeGroup and reference it.
+
+Example of the second path: `hasItems` exists exactly because `itemsContainer`/`itemsEnum` are reused across `radioButtonGroup`, `checkboxGroup`, `listBox`, `multiSelectListBox`, `multiSelectComboBox`, `select`, `gridLayout`, `virtualList`, `twinColumn`.
+
+---
+
+## 5. Theme names: when to create a new simpleType
+
+Vaadin theme names are per-component lists of CSS tokens. Conventions:
+
+- **Always** create a `<componentName>ThemeNames` simpleType in the "ThemeNames" block of the XSD when a component supports its own set.
+- The shape is `<xs:union>` of empty string + an `xs:string` enumeration so the attribute is optional and validates known tokens:
+
+  ```xml
+  <xs:simpleType name="myComponentThemeNames">
+      <xs:union>
+          <xs:simpleType><xs:restriction base="xs:string"/></xs:simpleType>
+          <xs:simpleType>
+              <xs:restriction base="xs:string">
+                  <xs:enumeration value="small"/>
+                  <xs:enumeration value="my-variant"/>
+              </xs:restriction>
+          </xs:simpleType>
+      </xs:union>
+  </xs:simpleType>
+  ```
+
+- If your set is **identical** to an existing one (e.g. `gridColumnVisibilityThemeNames` ≡ `buttonThemeNames`), declare it as a single-member union to keep the Java-API-mirroring name without value duplication:
+
+  ```xml
+  <xs:simpleType name="myComponentThemeNames">
+      <xs:union memberTypes="buttonThemeNames"/>
+  </xs:simpleType>
+  ```
+
+- If your set is a **superset** of an existing one (e.g. `tabSheetThemeNames` adds three values to `tabsThemeNames`), express the relationship explicitly with `xs:union`:
+
+  ```xml
+  <xs:simpleType name="myComponentThemeNames">
+      <xs:union memberTypes="parentThemeNames">
+          <xs:simpleType>
+              <xs:restriction base="xs:string">
+                  <xs:enumeration value="extra-token-1"/>
+                  <xs:enumeration value="extra-token-2"/>
+              </xs:restriction>
+          </xs:simpleType>
+      </xs:union>
+  </xs:simpleType>
+  ```
+
+---
+
+## 6. Validators: when to create a new validator type
+
+The validator hierarchy is purpose-built — every leaf field has its own `*ValidatorType` that locks down which rules make sense for that input.
+
+| If you need… | Use / extend |
+|---|---|
+| Just `<notNull>` and `<custom>` | `baseValidatorType` |
+| The above + collection rules (`size`, `notEmpty`) | `collectionValidatorType` |
+| The above + string rules (`notBlank`, `regexp`, `email`) | `stringValidatorType` |
+| The full numeric+string constraint set | `constraintValidatorType` |
+| Date-only checks (`future`, `past`, …) | `dateValidatorsType` |
+| Only `<custom>` (no built-in rules) | `onlyCustomValidatorType` |
+
+If your field needs a **different mix** of rules, create a new validator complexType that extends the closest existing base and adds only the missing rule elements. Re-use the leaf rule types (`messageValidatorType`, `digitsValidatorType`, `decimalMaxMinValidatorType`, `maxMinValidatorType`, `regexpValidatorType`, `sizeValidatorType`, `dateValidatorType`, `customValidatorType`) — never duplicate their attribute surfaces.
+
+---
+
+## 7. Enum simple types: when to create one vs. reuse
+
+**Reuse first.** Before creating a new `<xs:simpleType>` with an enumeration, check the catalog in [reusable-types.md §3](reusable-types.md#3-shared-simple-types-enums). The XSD already covers:
+
+- Direction & alignment (`orientationType`, `alignEnum`, `justifyContentModeEnum`, …)
+- Open modes (`openModeType`)
+- Filtering (`propertyFilterOperation`, `groupFilterOperation`, `likeClauseEnum`)
+- Icons (`jmixFontIconEnum`)
+- Data types (`fieldDatatypeEnum` and date/time subsets)
+- Resource strings (`resourceString`) — use this whenever an attribute can be a translation key
+- Shortcuts (`shortcutCombination`)
+
+**Create a new enum** when:
+
+- The set of values has **no semantic equivalent** elsewhere in the XSD.
+- The values mirror a Java enum that the corresponding component actually accepts.
+- The enum is intentionally an *open* enumeration (allow any string + suggest known values): use the `<xs:union>(empty, enumeration)` shape. This is the case for theme names, picker steps, icon enums, shortcut combinations.
+- The enum is intentionally a *closed* enumeration (only allowed values are valid): use a plain `<xs:restriction base="xs:string">`.
+
+**Aliasing instead of duplication.** When the Java API exposes two distinct enum names that happen to share their values (e.g. `RangeInput.Orientation` and `Orientation`), keep both XSD type names but declare the alias as a `<xs:union memberTypes="..."/>` — this preserves the documentation value of distinct names without duplicating the enumeration values. The XSD does this for `formLabelsPosition`, `rangeInputOrientationEnum`, `userMenuViewItemOpenModeType`, `detailButtonRendererOpenModeType`, `textAreaThemeNames`, `gridColumnVisibilityThemeNames`.
+
+**Naming.** Prefer the suffix `Enum` for new enumeration simpleTypes (`*Enum`); use `Type` only for non-enum simpleTypes (e.g. `boxSizingType` is named with `Type` because of legacy — new types should prefer `Enum`).
+
+---
+
+## 8. Child slots: prefer named types over inline definitions
+
+If your component has a child slot, give it a **type** rather than an inline anonymous `complexType`. This keeps the XSD scannable and lets other components reuse the slot.
+
+Examples that get this right:
+
+- `<tooltip>` always uses `tooltipElement`.
+- `<icon>` slots use `iconComponentElement` (which references `iconComponentGroup`).
+- `<prefix>`/`<suffix>` slots use `prefixOrSuffixComponent`.
+- Card sub-slots (`title`, `subtitle`, `media`, `header`, `footer`) use `singleLayoutOrComponentType`.
+
+When you add a new slot, look for an existing single-element wrapper type first.
+
+For containers that take multiple children, use `<xs:group ref="layoutOrComponent"/>` (or `singleLayoutOrComponent` for "one optional child") inside the type body — see `scrollerContainer`, `accordionContainer`, `sidePanelLayoutComponent`.
+
+---
+
+## 9. Action types: viewAction / gridAction / pickerAction / genericFilterAction
+
+These four complex types are *intentionally* empty extensions of `baseAction`:
+
+```xml
+<xs:complexType name="viewAction">
+    <xs:complexContent>
+        <xs:extension base="baseAction"/>
+    </xs:complexContent>
+</xs:complexType>
+```
+
+The empty extension makes the action element nameable distinctly in different containers (`<viewActions>`, `<dataGrid><actions>`, `<entityPicker><actions>`, `<genericFilter><actions>`) even though their attribute surface is the same. **Do not collapse them into a single type.** If you add a new place that exposes `<action>`, decide whether one of the four fits, or add a fifth empty extension following the same pattern.
+
+---
+
+## 10. Adding a new attribute group
+
+Introduce a `has<Capability>` attributeGroup when:
+
+1. The same attribute set appears (or will appear) on **two or more** components.
+2. The attributes have a coherent semantic name ("focusable attributes", "items source", "click-notifier attributes").
+
+The group lives in the "Interfaces" block of the XSD (between `<!-- Interfaces -->` and `<!-- Utils -->`). Keep the surrounding alphabetical/categorical neighbourhood (identity → text → input → layout/sizing).
+
+Don't create `has<X>` groups for **single-component-only** attributes — keep those inline on the component.
+
+---
+
+## 11. Registering a new top-level component
+
+Two places to update:
+
+1. The complexType in the components section.
+2. The `<xs:group name="standardComponent">` `<xs:choice>` at the bottom of the file — add `<xs:element name="..." type="..."/>` to register the element name in the layout namespace.
+
+After both edits, the component is usable inside any layout container.
+
+---
+
+## 12. Don't-do list
+
+- **Don't** re-declare attributes that are already inherited via the extension chain — it currently causes `Duplicate attribute use` warnings on strict XSD validators. (See `textFieldComponent` / `emailFieldComponent` / `imageComponent` re-declaring `hasDataContainer` as a pre-existing example to avoid copying.)
+- **Don't** use `<xs:restriction>` without `base="xs:string"` (or another base). xmllint rejects it; Xerces accepts it but emits warnings.
+- **Don't** use a single-member `<xs:union>` unless you mean it as an alias. For a plain restricted enum, use `<xs:restriction base="xs:string">`.
+- **Don't** wrap every text attribute in `<xs:string>` — prefer `resourceString` so `msg://`-style i18n tokens validate correctly.
+- **Don't** add `<xs:any>` inside a component body without a `namespace="##other"` constraint — that would silently allow any element from this namespace and undermine validation. The legitimate use is `<xs:anyAttribute namespace="##other" processContents="lax"/>` (already in `baseComponent`) and `<xs:any namespace="##other">` slots in `conditionType`, `formLayoutComponent`, `formRowType`, `urlQueryParametersType`, `facets`.
+- **Don't** duplicate icon-slot choices inline. Use `iconComponentElement` as the type of the slot element, or `<xs:group ref="iconComponentGroup"/>` inside a sequence.

--- a/doc/features/flowui-layout-xsd/known-issues.md
+++ b/doc/features/flowui-layout-xsd/known-issues.md
@@ -1,0 +1,100 @@
+# Known Issues in `layout.xsd`
+
+Pre-existing XSD-compliance issues that were intentionally left unfixed. Listed here so future agents can pick them up without re-analysing the whole file.
+
+All issues are visible only under a strict XSD 1.0 validator (e.g. `xmllint --schema`). IntelliJ IDEA and the Xerces parser used at Jmix runtime accept the current XSD, so view-XML validation works in IDEs and at boot.
+
+---
+
+## 1. `xs:all` + `xs:extension` in the validator type hierarchy
+
+### Where
+
+`baseValidatorType` uses `<xs:all>` as its content model. Several types inherit from it via `<xs:extension base="baseValidatorType">`:
+
+- `collectionValidatorType`
+- `dateValidatorsType`
+- `stringValidatorType` (chain root for the constraint hierarchy)
+- `bigDecimalFieldValidatorType`
+- `numberFieldValidatorType`
+- `integerFieldValidatorType`
+- `constraintValidatorType` (extends `stringValidatorType`)
+
+### Why xmllint complains
+
+XSD 1.0 forbids placing an `<xs:all>` model group inside any other model group. When a complex type with `<xs:all>` is extended, the resulting effective content is conceptually `<xs:sequence><xs:all>…</xs:all> + …</xs:sequence>`, which violates the rule. XSD 1.1 dropped this restriction; Xerces in lax mode does too. xmllint follows XSD 1.0 strictly and refuses to compile the schema.
+
+### Why it is not fixed
+
+The intent behind `<xs:all>` here is correct: validator child elements (`notNull`, `custom`, `notBlank`, `regexp`, etc.) should be writable in any order inside `<validators>`. Switching to `<xs:sequence minOccurs="0">` would compile under strict 1.0 but would impose a fixed order on existing view-XML — a behavioural change we want to avoid.
+
+### What it costs
+
+Strict XSD 1.0 tools can't validate any view-XML that contains a `<validators>` element. IDEs (IntelliJ) and the Jmix runtime are unaffected.
+
+### Possible future directions
+
+- Wait for full XSD 1.1 adoption across tooling and keep the current shape.
+- Drop the `xs:extension` chain among validators: each leaf validator (`stringValidatorType`, `numberFieldValidatorType`, …) would inline its own `<xs:all>` listing all allowed rule elements. Removes the conflict but explodes duplication — every leaf would re-declare `notNull` + `custom`. Probably worth doing only with code-gen.
+- Accept the strict-validator cost and migrate to `<xs:sequence minOccurs="0">` after an audit confirming no view-XML relies on ordering.
+
+---
+
+## 2. `imageComponent` redeclares `themeNames` and `hasDataContainer`
+
+### Where
+
+```xml
+<xs:complexType name="imageComponent">
+    <xs:complexContent>
+        <xs:extension base="imageHtmlComponent">
+            <xs:attributeGroup ref="hasDataContainer"/>
+            <xs:attribute name="themeNames" type="imageThemeNames"/>
+        </xs:extension>
+    </xs:complexContent>
+</xs:complexType>
+```
+
+The inheritance chain:
+
+```
+baseHtmlComponent
+└── baseHtmlContainer            (declares themeNames="badgeThemeNames" + hasDataContainer)
+    └── baseClickableHtmlContainer
+        └── imageHtmlComponent
+            └── imageComponent   (redeclares themeNames + hasDataContainer)
+```
+
+So `imageComponent` triggers three duplicate-attribute errors: `property` and `dataContainer` (from the duplicate `hasDataContainer` group reference) and `themeNames` (from re-declaring the attribute with a different type).
+
+### Why it is not fixed
+
+Two distinct sub-issues are entangled here:
+
+1. **`hasDataContainer` duplicate.** Easy to remove on its own — `imageComponent` inherits the group from `baseHtmlContainer`.
+2. **`themeNames` type narrowing from `badgeThemeNames` to `imageThemeNames`.** This is a deliberate attempt to narrow the type of an inherited attribute. XSD 1.0 allows attribute-type narrowing only via `xs:restriction`, not `xs:extension`. The current code uses extension, so the parser sees two attributes with the same name and different types — a hard conflict.
+
+   Untangling this would require either:
+   - Removing the `themeNames="badgeThemeNames"` default from `baseHtmlContainer` (a behaviour change — every plain HTML container like `div`, `span`, `h1`…`h6`, `p`, `pre` would lose its `themeNames` attribute), or
+   - Rewriting `imageComponent` via `xs:restriction` (much more verbose — restriction requires re-stating every inherited attribute), or
+   - Generalising the `themeNames` attribute on `baseHtmlContainer` to `xs:string` so subtypes can re-declare it freely (loses validation of allowed badge values for the containers that should still use them).
+
+   None of these are zero-risk; the call deferred until we are ready for a deeper refactor of HTML-container theming.
+
+### What it costs
+
+Same as #1 — strict validators reject the schema; IDEs and Jmix runtime accept it.
+
+### Possible future directions
+
+- Remove `themeNames="badgeThemeNames"` from `baseHtmlContainer` (preferred, but a behaviour change) and then drop the explicit redeclaration in `imageComponent`. The `unorderedListHtmlContainer` had a similar redundant redeclaration already removed in the earlier refactor.
+- If the goal is to also kill the `hasDataContainer` duplicate without touching `themeNames`, that single fix can be done in isolation — but the `themeNames` conflict will remain visible to strict validators, so the value of the partial fix is limited.
+
+---
+
+## Quick reference
+
+| Issue | Affected types | Error class | Behaviour change to fix? |
+|---|---|---|---|
+| 1 | validator type hierarchy | `xs:all` cannot be inside `xs:sequence` from extension | Yes — forces element ordering |
+| 2 | `imageComponent` | duplicate `themeNames` / `dataContainer` / `property` | Yes — removes `themeNames` from plain HTML containers, OR requires `xs:restriction` rewrite |

--- a/doc/features/flowui-layout-xsd/reusable-types.md
+++ b/doc/features/flowui-layout-xsd/reusable-types.md
@@ -1,0 +1,482 @@
+# Reusable Types in `layout.xsd`
+
+Catalog of definitions that should be **referenced**, not duplicated, when adding or extending components in the FlowUI layout XSD. Grouped by intent.
+
+XSD file: `jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd`.
+
+---
+
+## 1. Attribute groups (capability mix-ins)
+
+Attribute groups model individual capabilities ("has X"). Compose them on a complex type to add the capability without re-declaring the attributes.
+
+### Identity & lifecycle
+| Group | Attribute(s) | Use on |
+|---|---|---|
+| `hasId` | `id` (optional) | Anything that may be referenced by id but is optional. |
+| `requiresId` | `id` (required) | Items where id is mandatory (action items, menu items, tabs, form rows). |
+| `hasEnabled` | `enabled` | Anything that can be disabled. |
+
+### Text / labelling
+| Group | Attribute(s) | Use on |
+|---|---|---|
+| `hasText` | `text`, `whiteSpace` | Components whose primary text is a label/content (buttons, HTML containers). |
+| `hasLabel` | `label` | Form fields (the field caption shown to the side or above). |
+| `hasTitle` | `title` | Browser-tooltip-style title attribute. |
+| `hasPlaceholder` | `placeholder` | Editable fields with placeholder hint. |
+| `hasHelperText` | `helperText` | Form fields with helper text under the input. |
+| `hasAriaLabel` | `ariaLabel`, `ariaLabelledBy` | Anything that needs explicit accessibility labelling. |
+
+### Icons & shortcuts
+| Group | Attribute(s) | Use on |
+|---|---|---|
+| `hasIcon` | `icon` (typed `jmixFontIconEnum`) | Components/actions that accept a built-in icon by name. |
+| `hasShortcutCombination` | `shortcutCombination` | Actions/buttons that support a keyboard shortcut. |
+| `hasFocusableAttributes` | `tabIndex`, `focusShortcut` | Anything focusable. |
+| `hasClickNotifierAttributes` | `clickShortcut` | Anything click-notifying. |
+
+### Data binding & items
+| Group | Attribute(s) | Use on |
+|---|---|---|
+| `hasDataContainer` | `dataContainer`, `property` | Fields/containers bound to a data container property. |
+| `hasItems` | `itemsContainer`, `itemsEnum` | Selection components whose option list comes from a collection container or an enum class. |
+| `hasValueAndElement` | `readOnly` | Editable components with read-only mode. |
+| `hasValueChangeMode` | `valueChangeTimeout`, `valueChangeMode` | Fields that need value-change-mode tuning (EAGER/LAZY/...). |
+| `hasValidation` | `errorMessage` | Components that can show a validation error. |
+| `hasSecurityConstraint` | `constraintEntityOp` | Actions/components needing entity-op security gating. |
+
+### Input behaviour
+| Group | Attribute(s) | Use on |
+|---|---|---|
+| `hasRequired` | `required`, `requiredMessage` | Fields that may be marked required. |
+| `hasTrimming` | `trimEnabled` | Text fields with optional whitespace trimming. |
+| `hasAutocomplete` | `autocomplete` | Input fields exposing HTML autocomplete hint. |
+| `hasAutocapitalize` | `autocapitalize` | Input fields exposing HTML autocapitalize. |
+| `hasAutocorrect` | `autocorrect` | Input fields with autocorrect toggle. |
+
+### Layout / styling
+| Group | Attribute(s) | Use on |
+|---|---|---|
+| `hasSize` | `width`, `height`, `min/maxWidth`, `min/maxHeight` | Anything sizeable. |
+| `hasClassNames` | `classNames` | Anything stylable via CSS class names. |
+| `hasOverlayWidth` | `overlayWidth` | Pickers / dropdowns that open an overlay. |
+| `hasThemable` | `spacing`, `margin`, `padding`, `boxSizing` | Layouts. |
+| `hasFlexible` | `alignItems`, `justifyContent`, plus `hasSize`/`hasEnabled`/`hasClassNames` | Flex layouts (already composes the layout-relevant size/enable/classes). |
+
+### Misc
+| Group | Use on |
+|---|---|
+| `columnsLoadType` | `includeAll`, `exclude` for the `columns` element of `dataGrid`. |
+
+---
+
+## 2. Base complex types (inheritance chains)
+
+Use `xs:extension base="..."` to inherit a chain of attributes rather than re-declaring them. The main chains:
+
+### Plain components
+
+```
+baseComponent
+├── (most components extend this directly)
+```
+
+`baseComponent` provides: `hasId`, `visible`, `colspan`, `alignSelf`, `justifySelf`, `css`, plus `<xs:anyAttribute namespace="##other">` for XSD-extension across schemas. **Every visible component should ultimately extend `baseComponent`.**
+
+### Form fields
+
+```
+baseComponent
+└── baseFieldComponent              (+ size, label, enabled, classes, helperText, dataContainer, valueAndElement)
+    └── validatableBaseFieldComponent  (+ <validators> element, hasValidation)
+        ├── baseTextFieldComponent      (+ tooltip/prefix/suffix slots, value, autofocus, autoselect, themeNames=textFieldThemeNames, clearButtonVisible,
+        │                                  hasTitle/Placeholder/Autocorrect/Autocomplete/Autocapitalize/ValueChangeMode/Focusable/AriaLabel)
+        │   ├── textFieldComponent
+        │   ├── emailFieldComponent
+        │   ├── passwordFieldComponent
+        │   ├── numberFieldComponent
+        │   ├── integerFieldComponent
+        │   └── bigDecimalFieldComponent
+        ├── valuePickerComponent      (+ actions element, formatter, prefix/suffix, autofocus, allowCustomValue, title/focusable/required/placeholder/ariaLabel)
+        │   └── entityPickerComponent  (+ metaClass)
+        ├── multiSelectComboBoxComponent
+        ├── timePickerComponent / datePickerComponent / dateTimePickerComponent
+        ├── baseSingleFilterComponent (filter base)
+        │   ├── baseJpqlFilterComponent
+        │   │   └── jpqlFilterComponent
+        │   └── basePropertyFilterComponent
+        │       └── propertyFilterComponent
+        └── (others)
+```
+
+`baseComboBoxPickerComponent` is a parallel branch (extends `baseComponent` directly, not the field chain) used by `entityComboBoxComponent`.
+
+### HTML containers
+
+```
+baseComponent
+└── baseHtmlComponent              (+ size, title, classes)
+    └── baseHtmlContainer           (+ singleLayoutOrComponent group, themeNames, text, enabled, dataContainer)
+        ├── baseClickableHtmlContainer (+ clickShortcut)
+        │   ├── unorderedListHtmlContainer / orderedListHtmlContainer
+        │   ├── imageHtmlComponent
+        │   ├── htmlObjectComponent
+        │   ├── sectionHtmlComponent
+        │   └── (h1..h6, div, span, p, pre, header, footer, aside, article, ... via the standardComponent group)
+        ├── htmlContainerWithAria
+        │   └── clickableHtmlContainerWithArea
+        │       └── nativeButtonComponent
+        └── labelComponent / fieldSetHtmlComponent
+```
+
+Pick the right entry point: clickable HTML element → `baseClickableHtmlContainer`; with explicit aria → `htmlContainerWithAria`/`clickableHtmlContainerWithArea`; plain leaf (hr, etc.) → `baseHtmlComponent`.
+
+### Actions
+
+```
+baseAction                  (+ properties/shortcutCombination/icon sub-elements; type/visible/text/description/actionVariant/hasIcon/hasShortcutCombination/requiresId/hasEnabled)
+├── viewAction
+├── gridAction
+├── pickerAction
+├── genericFilterAction
+└── securityConstraintAction  (+ hasSecurityConstraint)
+
+noShortcutBaseAction        (same surface MINUS shortcutCombination element/group — for items in menus/dropdowns where shortcuts aren't applicable)
+├── dropdownButtonAction
+└── userMenuAction
+```
+
+The empty-extension actions (`viewAction`, `gridAction`, `pickerAction`, `genericFilterAction`) exist on purpose: they preserve a distinct element name in different containers, even though attribute surface is identical. **Do not "consolidate" them.**
+
+### Icons & icon slots
+
+```
+baseIconComponent (+ tooltip slot, color, size, hasClassNames, hasClickNotifierAttributes)
+├── iconComponent       (Vaadin icon — required icon enum attribute)
+├── svgIconComponent    (symbol + resource)
+└── fontIconComponent   (iconClassNames / fontFamily / charCode / ligature)
+```
+
+For elements that accept an icon as a *child* (e.g. `<icon>`/`<svgIcon>`/`<fontIcon>`/`<image>` inside a button), use **`iconComponentElement`** as the type and let `iconComponentGroup` produce the choice. Do not redefine the choice inline.
+
+### Tabs
+
+```
+baseTabsComponent (+ tab children, hasClassNames, hasSize)
+├── tabsContainer    (+ orientation, themeNames=tabsThemeNames)
+└── tabSheetComponent (+ prefix/suffix, lazyTabComponent children, themeNames=tabSheetThemeNames)
+```
+
+### Dropdown / combo buttons
+
+```
+baseDropdownButtonComponent (+ items element with actionItem/componentItem/textItem/separator, icon, openOnHover, themeNames=dropdownButtonThemeNames; hasSize/Text/Icon/Focusable/Title/Classes/Enabled)
+├── dropdownButtonComponent (+ dropdownIndicatorVisible)
+└── comboButtonComponent    (+ dropdownIcon slot + attr, action, hasShortcutCombination)
+```
+
+### Filters
+
+```
+baseSingleFilterComponent (extends baseComponent; layoutOrComponent child + tooltip + validators; parameterName, label/validation/required/valueAndElement/focusable/ariaLabel; labelVisible, themeNames, defaultValue)
+├── baseJpqlFilterComponent     (+ <condition> element, parameterClass required, hasInExpression)
+│   └── jpqlFilterComponent
+└── basePropertyFilterComponent (+ property required, operation required, operationsList, operationEditable, operationTextVisible)
+    └── propertyFilterComponent
+```
+
+```
+baseGroupFilterComponent (+ responsiveSteps + nested group/property/jpql filters; operation required; summaryText; operationTextVisible)
+└── groupFilterComponent (+ dataLoader required, autoApply)
+```
+
+### Login
+
+```
+baseLoginComponent (+ form/errorMessage/additionalInformation sub-elements; forgotPasswordButtonVisible; hasEnabled/Classes)
+├── loginFormComponent  (+ <form type=jmixLoginFormType>, rememberMeVisible, localesVisible)
+└── loginOverlayComponent (+ header/customFormArea/footer, opened)
+```
+
+`loginFormType` → `jmixLoginFormType` adds `rememberMe`; both are content types for `<form>` slots.
+
+### Upload
+
+```
+baseFieldComponent
+└── baseUploadFieldComponent (+ tooltip & uploadIcon slots; many text-resource attrs for i18n; maxFileSize, acceptedFileTypes, uploadIcon, dropAllowed; hasRequired/Validation)
+    ├── fileUploadFieldComponent       (+ fileName)
+    └── fileStorageUploadFieldComponent (+ fileStoragePutMode, fileStorageName)
+```
+
+`uploadComponent` (the standalone uploader) extends `baseComponent` directly — different model from the upload *field*.
+
+### Items query (combo box data sources)
+
+```
+baseComboBoxItemsQueryType (+ <query> element; searchStringFormat, escapeValueForLike)
+├── comboBoxItemsQueryType                 (alias — no additions)
+├── entityComboBoxItemsQueryType           (+ fetchPlan element/attr, class required)
+└── multiSelectComboBoxItemsQueryType      (+ fetchPlan element/attr, class)
+```
+
+### Validators
+
+```
+baseValidatorType (notNull + custom)
+├── collectionValidatorType  (+ size, notEmpty)
+│   └── stringValidatorType  (+ notBlank, regexp, email)
+│       └── constraintValidatorType (+ digits, decimalMin/Max, doubleMin/Max, sign predicates, max/min)
+├── dateValidatorsType        (future, futureOrPresent, past, pastOrPresent)
+├── bigDecimalFieldValidatorType
+├── numberFieldValidatorType
+├── integerFieldValidatorType
+├── onlyCustomValidatorType  (only allows <custom>)
+└── checkboxValidatorType    (only allows <custom>)
+```
+
+Each leaf validator element body type (`messageValidatorType`, `customValidatorType`, `dateValidatorType`, `sizeValidatorType`, `regexpValidatorType`, `digitsValidatorType`, `decimalMaxMinValidatorType`, `maxMinValidatorType`) is its own complexType — reuse them when adding validation rules.
+
+### Formatters
+
+```
+formatterType (choice of: collection | custom | date | number)
+├── customFormatterType        (bean required)
+├── formattableFormatterType   (format)
+│   └── dateFormatterType      (+ type, useUserTimezone)
+```
+
+### Grid renderers
+
+`<xs:group name="renderers">` makes the choice of `numberRenderer | localDateRenderer | localDateTimeRenderer | detailLinkRenderer | detailButtonRenderer`. Refer to it via `<xs:group ref="renderers"/>` inside a column-like type.
+
+```
+formattableRendererType        (format required, nullRepresentation)
+numberRendererType             (format, numberFormat, nullRepresentation)
+detailRendererType             (viewId/viewClass; text/css/classNames)
+├── detailLinkRendererType     (+ target)
+└── detailButtonRendererType   (+ icon slot, openMode, themeNames=buttonThemeNames, hasIcon)
+```
+
+### Generic component / fragment
+
+```
+genericComponent      (+ <properties type=genericComponentProperties>, class required)
+fragmentComponent     (same shape, + hasClassNames)
+fragmentRendererElement (+ <properties>, class required) — used inline inside list/grid components
+```
+
+`genericComponentProperties` / `genericComponentProperty` are reusable for *any* "property bag" element with `name`/`value`/`type` triples (the value-type enum is `genericComponentPropertyValueType`).
+
+---
+
+## 3. Shared simple types (enums)
+
+Reuse these instead of defining a fresh `xs:restriction base="xs:string"`.
+
+### Layout / direction / alignment
+
+| Type | Values |
+|---|---|
+| `orientationType` | `HORIZONTAL`, `VERTICAL` |
+| `scrollDirection` | `HORIZONTAL`, `VERTICAL`, `BOTH`, `NONE` |
+| `alignEnum` | `START`, `END`, `CENTER`, `STRETCH`, `BASELINE`, `AUTO` |
+| `justifyContentModeEnum` | `START`, `END`, `CENTER`, `BETWEEN`, `AROUND`, `EVENLY` |
+| `contentAlignmentEnum` | `START`, `END`, `CENTER`, `STRETCH`, `SPACE_BETWEEN`, `SPACE_AROUND` |
+| `flexDirectionEnum` | `ROW`, `ROW_REVERSE`, `COLUMN`, `COLUMN_REVERSE` |
+| `flexWrapEnum` | `NOWRAP`, `WRAP`, `WRAP_REVERSE` |
+| `tooltipPosition` | 12 positions around the element |
+| `sidePanelPositionType` | `TOP`, `RIGHT`, `BOTTOM`, `LEFT`, `INLINE_START`, `INLINE_END` |
+| `boxSizingType` | `CONTENT_BOX`, `BORDER_BOX`, `UNDEFINED` |
+
+> `rangeInputOrientationEnum` is intentionally kept as a named alias of `orientationType` (it mirrors a Java type). The XSD declares it as `<xs:union memberTypes="orientationType"/>`. Do not redefine the same values inline.
+
+### Form labels
+
+| Type | Values | Notes |
+|---|---|---|
+| `labelPositionType` | `ASIDE`, `TOP` | Used on `propertyFilter` / `jpqlFilter`. |
+| `formLabelsPosition` | `ASIDE`, `TOP` | Used on `formLayout` and `responsiveStep`. Alias of `labelPositionType` via union. |
+
+### Sizing
+
+| Type | What it represents |
+|---|---|
+| `componentSize` | Empty string OR `100%`. Underlying base for `width`/`height`/`min*`/`max*`. |
+
+### Resource strings (i18n)
+
+`resourceString` accepts an arbitrary string OR an `msg://` token. **All user-visible text attributes** (`label`, `text`, `title`, `placeholder`, `helperText`, etc.) should use `resourceString` rather than `xs:string`.
+
+### Time / date / shortcuts
+
+| Type | What it represents |
+|---|---|
+| `timePickerStep` | Common step shortcuts: `900s`, `15m`, `20m`, `30m`, `2h`, ..., `12h`. Allows any string too. |
+| `shortcutCombination` | Predefined tokens like `${SAVE_SHORTCUT}`, `${GRID_CREATE_SHORTCUT}`, plus any string. |
+
+### Action / theming
+
+| Type | Values |
+|---|---|
+| `actionVariant` | `DEFAULT`, `PRIMARY`, `DANGER`, `SUCCESS` |
+| `actionTypeEnum` | Built-in action type names (`entity_clear`, `list_create`, `detail_save`, ...). |
+| `openModeType` | `NAVIGATION`, `DIALOG`. Aliases: `userMenuViewItemOpenModeType`, `detailButtonRendererOpenModeType` (declared as unions over `openModeType`). |
+
+### Icons
+
+| Type | What it represents |
+|---|---|
+| `jmixFontIconEnum` | Union of `jmixSpecificIconEnum` (Jmix action icons) and `vaadinIconEnum` (the full Vaadin icon set). Use this everywhere an icon string attribute is exposed. |
+
+### Field datatypes
+
+| Type | Values |
+|---|---|
+| `fieldDatatypeEnum` | All scalar Jmix datatype tokens (`string`, `int`, `long`, `uuid`, `date`, `localDate`, `decimal`, `fileRef`, etc.). |
+| `dateDatatypeEnum`, `timeDatatypeEnum`, `dateTimeDatatypeEnum` | Restricted subsets for the corresponding pickers. |
+
+### Filters
+
+| Type | Values |
+|---|---|
+| `groupFilterOperation` | `AND`, `OR` |
+| `propertyFilterOperation` | Single operation token (`EQUAL`, `CONTAINS`, ...). |
+| `propertyFilterOperationsList` | Empty OR `propertyFilterOperation` (intended as a whitespace-separated list of operations for an editable property filter). |
+| `likeClauseEnum` | `NONE`, `CASE_SENSITIVE`, `CASE_INSENSITIVE` |
+| `menuFilterFieldFilterMode` | `CASE_SENSITIVE`, `CASE_INSENSITIVE` |
+
+### Grid
+
+| Type | Values |
+|---|---|
+| `gridDropMode` | `BETWEEN`, `ON_TOP`, `ON_TOP_OR_BETWEEN`, `ON_GRID` |
+| `gridSelectionMode` | `SINGLE`, `MULTI`, `NONE` |
+| `gridColumnRendering` | `EAGER`, `LAZY` |
+| `gridMultiSortPriority` | `APPEND`, `PREPEND` |
+| `gridNestedNullBehaviorEnum` | `THROW`, `ALLOW_NULLS` |
+| `gridColumnTextAlignEnum` | `START`, `CENTER`, `END` |
+| `aggregationType` | `SUM`, `COUNT`, `AVG`, `MIN`, `MAX` |
+| `aggregationPosition` | `TOP`, `BOTTOM` |
+| `itemsQueryFetchPlanFetchMode` | `AUTO`, `UNDEFINED`, `JOIN`, `BATCH` |
+
+### Specific component enums
+
+| Type | Notes |
+|---|---|
+| `valueChangeModeEnum` | `EAGER`, `LAZY`, `TIMEOUT`, `ON_BLUR`, `ON_CHANGE` |
+| `whiteSpaceEnum` | CSS `white-space` values |
+| `anchorTarget` | `DEFAULT`, `SELF`, `BLANK`, `PARENT`, `TOP` |
+| `autocompleteEnum` | The full HTML autocomplete token set |
+| `autocapitalizeEnum` | `NONE`, `SENTENCES`, `WORDS`, `CHARACTERS` |
+| `numberingType` | `NUMBER`, `UPPERCASE_LETTER`, ... — for ordered lists |
+| `inputTypeEnum` | HTML `<input type>` values |
+| `importanceTypeEnum` | `AUTO`, `HIGH`, `LOW` |
+| `sandboxTypeEnum` | HTML iframe sandbox tokens |
+| `formatterDateType` | `DATE`, `DATETIME` |
+| `genericComponentPropertyValueType` | Empty / `CONTAINER_REF` / `LOADER_REF` / `ICON` |
+| `onViewEventEnum` | `Init`, `BeforeShow`, `Ready` |
+| `multiSelectComboBoxAutoExpandModeEnum` | `VERTICAL`, `HORIZONTAL`, `BOTH`, `NONE` |
+| `markdownEditorMode` | `EDIT`, `PREVIEW` |
+| `codeEditorMode`, `codeEditorTheme` | Long enums of supported ACE modes/themes |
+| `fileStoragePutMode` | `MANUAL`, `IMMEDIATE` |
+| `rangeInputOrientationEnum` | Alias of `orientationType` — see above |
+| `userMenuViewItemOpenModeType`, `detailButtonRendererOpenModeType` | Aliases of `openModeType` — see above |
+
+### Theme names
+
+Each Vaadin-themable component has its own `*ThemeNames` simpleType. They all follow the same shape — `<xs:union>` of an empty string and an enumeration of allowed CSS theme tokens — so the attribute is optional and accepts only known values.
+
+| Type | Component(s) |
+|---|---|
+| `buttonThemeNames` | `button`, `drawerToggle` |
+| `gridColumnVisibilityThemeNames` | `gridColumnVisibility` (alias of `buttonThemeNames` via union) |
+| `dropdownButtonThemeNames` | `dropdownButton`, `comboButton` |
+| `comboBoxThemeNames` | combo-box-like fields |
+| `selectThemeNames` | `select` |
+| `textFieldThemeNames` | `textField`, `emailField`, `passwordField`, `numberField`, ... |
+| `textAreaThemeNames` | `textArea` (alias of `textFieldThemeNames`) |
+| `timePickerThemeNames` / `datePickerThemeNames` / `dateTimePickerThemeNames` | corresponding pickers |
+| `progressBarThemeNames` | `progressBar` |
+| `radioButtonGroupThemeNames` / `checkboxGroupThemeNames` | group fields |
+| `markdownEditorThemeNames` / `richTextEditorThemeNames` | editors |
+| `badgeThemeNames` | spans/badges (and currently inherited by `baseHtmlContainer.themeNames`) |
+| `detailsThemeNames` | `details`, `genericFilter` (uses the same theme set) |
+| `spacingThemeNames` | layout containers (via `componentLayout.themeNames`) |
+| `tabThemeNames` / `tabsThemeNames` / `tabSheetThemeNames` | tab components |
+| `cardThemeNames` | `card` |
+| `splitThemeNames` | `split` |
+| `imageThemeNames` | `image`, `imageIcon` |
+| `avatarThemeNames` | `avatar` |
+| `gridThemeNames` | `dataGrid`, `treeDataGrid` |
+| `twinColumnThemeNames` | `twinColumn` |
+| `userMenuThemeNames`, `userMenuItemThemeNames` | `userMenu`, user-menu items |
+| `listMenuThemeNames`, `menuFilterFieldThemeNames` | side menu, menu filter field |
+
+---
+
+## 4. Shared element groups (`xs:group`)
+
+Element groups bundle a `<choice>` of allowed children. Reference them via `<xs:group ref="..."/>` instead of inlining.
+
+| Group | Produces |
+|---|---|
+| `iconComponentGroup` | Optional choice of `<icon>` / `<svgIcon>` / `<fontIcon>` / `<image>`. Used inside any component that has a child icon slot. |
+| `htmlHeaders` | Choice of `<h1>` ... `<h6>`. |
+| `htmlLists` | Choice of `<listItem>` / `<orderedList>` / `<unorderedList>`. |
+| `renderers` | Column-cell renderer choice (`numberRenderer`, `localDateRenderer`, `localDateTimeRenderer`, `detailLinkRenderer`, `detailButtonRenderer`). |
+| `standardComponent` | The full registry of HTML, layout, and component elements that can appear inside a layout. Add new top-level components here. |
+| `layoutOrComponent` | Unbounded `<choice>` of `standardComponent` + `<xs:any namespace="##other">`. Use as the content of containers that accept multiple children. |
+| `singleLayoutOrComponent` | Same as above but at most one child. Use for "slot" elements (e.g. `prefix`, `suffix`, `startSlot`, `media`). |
+
+The corresponding *type* `singleLayoutOrComponentType` wraps `singleLayoutOrComponent` for use as an element's `type` attribute (e.g. card slots).
+
+---
+
+## 5. Common sub-element types
+
+These small complex types are reused as the type of named child elements. Use them as-is when adding child slots:
+
+| Type | Used as type of element(s) |
+|---|---|
+| `tooltipElement` | `<tooltip>` everywhere |
+| `prefixOrSuffixComponent` | `<prefix>` / `<suffix>` slots in fields |
+| `iconComponentElement` | `<icon>` slot inside buttons, items, etc. (see `iconComponentGroup`) |
+| `actionProperties` / `actionProperty` | `<properties>` / `<property>` inside `baseAction` |
+| `actionShortcutCombination` | `<shortcutCombination>` inside `baseAction` |
+| `contextMenuType` / `contextMenuItemType` | `<contextMenu>` slot in grids |
+| `dialogMode` | `dialogMode` settings element on screens |
+| `responsiveStepsType` | `<responsiveSteps>` in `formLayout` and `genericFilter` |
+| `formRowType` / `formItemType` | Children of `formLayout` |
+| `gridAggregationType` | `<aggregation>` inside `dataGridColumnComponent` |
+| `dataGridColumnComponent` / `dataGridEditorActionsColumn` / `gridEditorButtonType` | Inside `<columns>` of a data grid |
+| `urlQueryParametersType` and its `*UrlQueryParametersType` variants | URL-query-parameter facet definitions |
+| `dataLoadCoordinatorType`, `dataLoadCoordinatorTriggerType`, `onViewEventType`, `onContainerItemChangedType`, `onComponentValueChangedType` | Inside `<facets>` |
+| `timerType`, `settingsFacetType`, `settingsComponentType` | Other facets |
+| `filterConditions` / `filterConfigurations` / `filterConfiguration` | Inside `<genericFilter>` |
+| `gridColumnVisibilityMenuItemType` | `<menuItem>` inside `gridColumnVisibility` |
+| `userMenuBaseItemType` and descendants | Items inside `<userMenu>` |
+| `dropdownActionItemType` / `dropdownComponentItemType` / `dropdownTextItemType` | Items inside `baseDropdownButtonComponent` |
+| `conditionType` | `<condition>` inside JPQL filter (allows `##other` namespace content) |
+| `viewActions`, `facets` | Top-level view sections |
+| `rootLayout`, `baseLayout`, `componentLayout`, `hboxComponent`, `flexLayoutComponent` | Layout containers |
+
+---
+
+## 6. Type-naming conventions in this XSD
+
+When you do need to introduce something new, follow these conventions so it fits with the rest of the file:
+
+| Kind | Convention | Example |
+|---|---|---|
+| Component complex type | `<componentName>Component` | `progressBarComponent` |
+| Container complex type | `<containerName>Container` | `scrollerContainer` |
+| Layout complex type | `<layoutName>Layout` or `*Component` | `flexLayoutComponent` |
+| Action complex type | `<actionName>Action` or `*Type` | `dropdownButtonAction` |
+| Capability mix-in | `has<Capability>` attributeGroup | `hasHelperText` |
+| Required-version capability | `requires<Capability>` | `requiresId` |
+| Element-body type (no top-level element) | `<purpose>Type` | `tooltipPosition`, `loginHeaderType` |
+| Enum simple type | `<purpose>Enum` (preferred) or `<purpose>Type` (legacy) | `valueChangeModeEnum`, `boxSizingType` |
+| Theme-name enum | `<componentName>ThemeNames` | `comboBoxThemeNames` |
+| Validator type | `<form>ValidatorType` | `stringValidatorType` |
+| Renderer type | `<purpose>RendererType` | `numberRendererType` |

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/AGENTS.md
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/AGENTS.md
@@ -1,6 +1,28 @@
 # layout.xsd — Agent Guidelines
 
-When modifying `layout.xsd` in this directory, check whether the change should also be reflected in `doc/features/flowui-layout-xsd/` (paths relative to the repository root). Update the docs when the change introduces or alters something that agents use as a reference when working on the XSD.
+`doc/features/flowui-layout-xsd/` (paths relative to the repository root) is the agent-facing reference for `layout.xsd`. Use it both as input *before* editing and as output *after* editing.
+
+## Before editing `layout.xsd` — read the docs first
+
+When asked to add a new component, extend an existing one, introduce a new attribute, or otherwise modify `layout.xsd`, read the reference docs **before writing any XSD**. They tell you which reusable building block to apply instead of inventing a new one.
+
+| If the task is to… | Read first |
+|---|---|
+| Add a new component | `component-patterns.md` §1 (decision tree for picking a base type) + §2/§3 (worked examples) + §11 (registering in `standardComponent`) |
+| Add a new attribute to an existing component | `reusable-types.md` §1 (attribute groups) — check whether the attribute already exists as part of a `has<X>` group before declaring it inline |
+| Add a new enum/simpleType | `reusable-types.md` §3 + `component-patterns.md` §7 (decision rule: reuse vs. create vs. alias via `xs:union`) |
+| Add a new theme-names type | `component-patterns.md` §5 (shape for new theme types, when to alias an existing one) |
+| Add validation rules to a field | `reusable-types.md` §2 (validator hierarchy) + `component-patterns.md` §6 |
+| Add an icon slot | `reusable-types.md` §5 — use `iconComponentElement` / `iconComponentGroup`, don't redefine inline |
+| Add a child container slot | `reusable-types.md` §4 (`layoutOrComponent` / `singleLayoutOrComponent` / `singleLayoutOrComponentType`) |
+| Add an action type | `reusable-types.md` §2 (action types) + `component-patterns.md` §9 |
+| Anything else touching the XSD | At minimum skim `component-patterns.md` §12 (don't-do list) and `known-issues.md` |
+
+If a reusable definition fits — **use it** (`<xs:extension base="…">`, `<xs:attributeGroup ref="…">`, `<xs:group ref="…">`, `type="…"`). Only introduce a new `simpleType` / `complexType` / `attributeGroup` when no existing one matches; in that case follow the naming conventions in `reusable-types.md` §6.
+
+## After editing `layout.xsd` — update the docs
+
+When the change introduces or alters something that agents use as a reference, update the docs in the same change.
 
 ## What to update and where
 

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/AGENTS.md
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/AGENTS.md
@@ -1,0 +1,26 @@
+# layout.xsd — Agent Guidelines
+
+When modifying `layout.xsd` in this directory, check whether the change should also be reflected in `doc/features/flowui-layout-xsd/` (paths relative to the repository root). Update the docs when the change introduces or alters something that agents use as a reference when working on the XSD.
+
+## What to update and where
+
+| Change in `layout.xsd` | File to update |
+|---|---|
+| New or renamed `attributeGroup` (`has<Capability>`, `requires<Capability>`) | `reusable-types.md` §1 — add a row to the appropriate table |
+| New or changed base `complexType` (inheritance chain) | `reusable-types.md` §2 — extend the relevant ASCII tree and description |
+| New `simpleType` enum, alias, or theme-name type | `reusable-types.md` §3 — add a row to the appropriate table |
+| New `xs:group` (element group) | `reusable-types.md` §4 — add a row to the group table |
+| New reusable sub-element `complexType` | `reusable-types.md` §5 — add a row to the sub-element table |
+| New type-naming convention or deviation from it | `reusable-types.md` §6 |
+| New component-construction pattern or "don't do" rule | `component-patterns.md` — add or update the relevant section |
+| New decision rule for base-type selection | `component-patterns.md` §1 decision tree |
+
+## When NOT to update docs
+
+- Pure bug fixes (e.g. correcting a typo in an attribute value, fixing a duplicate attribute warning) that do not change the public XSD surface.
+- Changes to component-specific attributes that are already covered by an existing pattern — no new building block is introduced.
+- Cosmetic reformatting of the XSD with no semantic change.
+
+## Doc accuracy rule
+
+The docs describe the XSD as the source of truth. If a doc section is already wrong (e.g. it references a type that was renamed), fix the stale entry as part of the same change.

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/CLAUDE.md
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
@@ -918,10 +918,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="rangeInputOrientationEnum">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="HORIZONTAL"/>
-            <xs:enumeration value="VERTICAL"/>
-        </xs:restriction>
+        <xs:union memberTypes="orientationType"/>
     </xs:simpleType>
 
     <xs:simpleType name="multiSelectComboBoxAutoExpandModeEnum">
@@ -1398,7 +1395,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="alignEnum">
-        <xs:restriction>
+        <xs:restriction base="xs:string">
             <xs:enumeration value="START"/>
             <xs:enumeration value="END"/>
             <xs:enumeration value="CENTER"/>
@@ -1409,7 +1406,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="justifyContentModeEnum">
-        <xs:restriction>
+        <xs:restriction base="xs:string">
             <xs:enumeration value="START"/>
             <xs:enumeration value="END"/>
             <xs:enumeration value="CENTER"/>
@@ -1420,7 +1417,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="contentAlignmentEnum">
-        <xs:restriction>
+        <xs:restriction base="xs:string">
             <xs:enumeration value="START"/>
             <xs:enumeration value="END"/>
             <xs:enumeration value="CENTER"/>
@@ -1431,7 +1428,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="flexDirectionEnum">
-        <xs:restriction>
+        <xs:restriction base="xs:string">
             <xs:enumeration value="ROW"/>
             <xs:enumeration value="ROW_REVERSE"/>
             <xs:enumeration value="COLUMN"/>
@@ -1440,7 +1437,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="flexWrapEnum">
-        <xs:restriction>
+        <xs:restriction base="xs:string">
             <xs:enumeration value="NOWRAP"/>
             <xs:enumeration value="WRAP"/>
             <xs:enumeration value="WRAP_REVERSE"/>
@@ -1448,7 +1445,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="uploadReceiverEnum">
-        <xs:restriction>
+        <xs:restriction base="xs:string">
             <xs:enumeration value="MEMORY_BUFFER"/>
             <xs:enumeration value="MULTI_FILE_MEMORY_BUFFER"/>
             <xs:enumeration value="FILE_TEMPORARY_STORAGE_BUFFER"/>
@@ -1457,28 +1454,25 @@
     </xs:simpleType>
 
     <xs:simpleType name="uploadUploadHandlerEnum">
-        <xs:restriction>
+        <xs:restriction base="xs:string">
             <xs:enumeration value="IN_MEMORY"/>
             <xs:enumeration value="FILE_TEMPORARY_STORAGE"/>
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="labelPositionType">
-        <xs:restriction>
+        <xs:restriction base="xs:string">
             <xs:enumeration value="ASIDE"/>
             <xs:enumeration value="TOP"/>
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="formLabelsPosition">
-        <xs:restriction>
-            <xs:enumeration value="ASIDE"/>
-            <xs:enumeration value="TOP"/>
-        </xs:restriction>
+        <xs:union memberTypes="labelPositionType"/>
     </xs:simpleType>
 
     <xs:simpleType name="tooltipPosition">
-        <xs:restriction>
+        <xs:restriction base="xs:string">
             <xs:enumeration value="TOP_START"/>
             <xs:enumeration value="TOP"/>
             <xs:enumeration value="TOP_END"/>
@@ -1495,7 +1489,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="boxSizingType">
-        <xs:restriction>
+        <xs:restriction base="xs:string">
             <xs:enumeration value="CONTENT_BOX"/>
             <xs:enumeration value="BORDER_BOX"/>
             <xs:enumeration value="UNDEFINED"/>
@@ -1568,9 +1562,50 @@
     </xs:simpleType>
 
     <xs:simpleType name="orientationType">
-        <xs:restriction>
+        <xs:restriction base="xs:string">
             <xs:enumeration value="HORIZONTAL"/>
             <xs:enumeration value="VERTICAL"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="sidePanelPositionType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="TOP"/>
+            <xs:enumeration value="RIGHT"/>
+            <xs:enumeration value="BOTTOM"/>
+            <xs:enumeration value="LEFT"/>
+            <xs:enumeration value="INLINE_START"/>
+            <xs:enumeration value="INLINE_END"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="fileStoragePutMode">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="MANUAL"/>
+            <xs:enumeration value="IMMEDIATE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="menuFilterFieldFilterMode">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="CASE_SENSITIVE"/>
+            <xs:enumeration value="CASE_INSENSITIVE"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="onViewEventEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="Init"/>
+            <xs:enumeration value="BeforeShow"/>
+            <xs:enumeration value="Ready"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="likeClauseEnum">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="NONE"/>
+            <xs:enumeration value="CASE_SENSITIVE"/>
+            <xs:enumeration value="CASE_INSENSITIVE"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -1602,16 +1637,12 @@
     </xs:simpleType>
 
     <xs:simpleType name="actionVariant">
-        <xs:union>
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="DEFAULT"/>
-                    <xs:enumeration value="PRIMARY"/>
-                    <xs:enumeration value="DANGER"/>
-                    <xs:enumeration value="SUCCESS"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="DEFAULT"/>
+            <xs:enumeration value="PRIMARY"/>
+            <xs:enumeration value="DANGER"/>
+            <xs:enumeration value="SUCCESS"/>
+        </xs:restriction>
     </xs:simpleType>
 
     <xs:complexType name="baseValidatorType">
@@ -1867,31 +1898,9 @@
     </xs:simpleType>
 
     <xs:simpleType name="propertyFilterOperationsList">
-        <xs:union>
+        <xs:union memberTypes="propertyFilterOperation">
             <xs:simpleType>
                 <xs:restriction base="xs:string"/>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="EQUAL"/>
-                    <xs:enumeration value="NOT_EQUAL"/>
-                    <xs:enumeration value="GREATER"/>
-                    <xs:enumeration value="GREATER_OR_EQUAL"/>
-                    <xs:enumeration value="LESS"/>
-                    <xs:enumeration value="LESS_OR_EQUAL"/>
-                    <xs:enumeration value="CONTAINS"/>
-                    <xs:enumeration value="NOT_CONTAINS"/>
-                    <xs:enumeration value="STARTS_WITH"/>
-                    <xs:enumeration value="ENDS_WITH"/>
-                    <xs:enumeration value="IS_SET"/>
-                    <xs:enumeration value="IN_LIST"/>
-                    <xs:enumeration value="NOT_IN_LIST"/>
-                    <xs:enumeration value="IN_INTERVAL"/>
-                    <xs:enumeration value="DATE_EQUALS"/>
-                    <xs:enumeration value="IS_COLLECTION_EMPTY"/>
-                    <xs:enumeration value="MEMBER_OF_COLLECTION"/>
-                    <xs:enumeration value="NOT_MEMBER_OF_COLLECTION"/>
-                </xs:restriction>
             </xs:simpleType>
         </xs:union>
     </xs:simpleType>
@@ -1943,22 +1952,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="textAreaThemeNames">
-        <xs:union>
-            <xs:simpleType>
-                <xs:restriction base="xs:string"/>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="small"/>
-                    <xs:enumeration value="align-left"/>
-                    <xs:enumeration value="align-start"/>
-                    <xs:enumeration value="align-end"/>
-                    <xs:enumeration value="align-center"/>
-                    <xs:enumeration value="align-right"/>
-                    <xs:enumeration value="helper-above-field"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
+        <xs:union memberTypes="textFieldThemeNames"/>
     </xs:simpleType>
 
     <xs:simpleType name="markdownEditorThemeNames">
@@ -2342,25 +2336,7 @@
     </xs:simpleType>
 
     <xs:simpleType name="gridColumnVisibilityThemeNames">
-        <xs:union>
-            <xs:simpleType>
-                <xs:restriction base="xs:string"/>
-            </xs:simpleType>
-            <xs:simpleType>
-                <xs:restriction base="xs:string">
-                    <xs:enumeration value="small"/>
-                    <xs:enumeration value="large"/>
-                    <xs:enumeration value="tertiary"/>
-                    <xs:enumeration value="tertiary-inline"/>
-                    <xs:enumeration value="primary"/>
-                    <xs:enumeration value="success"/>
-                    <xs:enumeration value="warning"/>
-                    <xs:enumeration value="error"/>
-                    <xs:enumeration value="contrast"/>
-                    <xs:enumeration value="icon"/>
-                </xs:restriction>
-            </xs:simpleType>
-        </xs:union>
+        <xs:union memberTypes="buttonThemeNames"/>
     </xs:simpleType>
 
     <xs:simpleType name="menuFilterFieldThemeNames">
@@ -2438,18 +2414,19 @@
         </xs:union>
     </xs:simpleType>
 
-    <xs:simpleType name="userMenuViewItemOpenModeType">
+    <xs:simpleType name="openModeType">
         <xs:restriction base="xs:string">
             <xs:enumeration value="NAVIGATION"/>
             <xs:enumeration value="DIALOG"/>
         </xs:restriction>
     </xs:simpleType>
 
+    <xs:simpleType name="userMenuViewItemOpenModeType">
+        <xs:union memberTypes="openModeType"/>
+    </xs:simpleType>
+
     <xs:simpleType name="detailButtonRendererOpenModeType">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="NAVIGATION"/>
-            <xs:enumeration value="DIALOG"/>
-        </xs:restriction>
+        <xs:union memberTypes="openModeType"/>
     </xs:simpleType>
 
     <!-- Interfaces -->
@@ -2506,6 +2483,11 @@
 
     <xs:attributeGroup name="hasIcon">
         <xs:attribute name="icon" type="jmixFontIconEnum"/>
+    </xs:attributeGroup>
+
+    <xs:attributeGroup name="hasItems">
+        <xs:attribute name="itemsContainer" type="xs:string"/>
+        <xs:attribute name="itemsEnum" type="xs:string"/>
     </xs:attributeGroup>
 
     <xs:attributeGroup name="hasShortcutCombination">
@@ -2798,7 +2780,6 @@
                 <xs:attribute name="autoOpen" type="xs:boolean"/>
                 <xs:attribute name="pageSize" type="xs:integer"/>
                 <xs:attribute name="autofocus" type="xs:boolean"/>
-                <xs:attribute name="required" type="xs:boolean"/>
                 <xs:attribute name="allowCustomValue" type="xs:boolean"/>
                 <xs:attribute name="themeNames" type="comboBoxThemeNames"/>
                 <xs:attribute name="allowedCharPattern" type="resourceString"/>
@@ -2810,6 +2791,7 @@
                 <xs:attributeGroup ref="hasFocusableAttributes"/>
                 <xs:attributeGroup ref="hasClassNames"/>
                 <xs:attributeGroup ref="hasOverlayWidth"/>
+                <xs:attributeGroup ref="hasRequired"/>
                 <xs:attributeGroup ref="hasValidation"/>
                 <xs:attributeGroup ref="hasHelperText"/>
                 <xs:attributeGroup ref="hasPlaceholder"/>
@@ -2893,10 +2875,6 @@
                 <xs:sequence minOccurs="0" maxOccurs="unbounded">
                     <xs:group ref="htmlLists"/>
                 </xs:sequence>
-
-                <xs:attribute name="themeNames" type="badgeThemeNames"/>
-                <xs:attributeGroup ref="hasEnabled"/>
-                <xs:attributeGroup ref="hasText"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -3082,15 +3060,15 @@
         <xs:sequence minOccurs="0" maxOccurs="unbounded">
             <xs:element name="property" type="itemsQueryFetchPlanPropertyType"/>
         </xs:sequence>
-        <xs:attribute name="extends"/>
+        <xs:attribute name="extends" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="itemsQueryFetchPlanPropertyType">
         <xs:sequence minOccurs="0" maxOccurs="unbounded">
             <xs:element name="property" type="itemsQueryFetchPlanPropertyType"/>
         </xs:sequence>
-        <xs:attribute name="name"/>
-        <xs:attribute name="fetchPlan"/>
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="fetchPlan" type="xs:string"/>
         <xs:attribute name="fetch" type="itemsQueryFetchPlanFetchMode"/>
     </xs:complexType>
 
@@ -3510,7 +3488,6 @@
                 <xs:attribute name="minLength" type="xs:integer"/>
                 <xs:attribute name="datatype" type="fieldDatatypeEnum"/>
 
-                <xs:attributeGroup ref="hasDataContainer"/>
                 <xs:attributeGroup ref="hasRequired"/>
                 <xs:attributeGroup ref="hasTrimming"/>
             </xs:extension>
@@ -3529,7 +3506,6 @@
                 <xs:attribute name="maxLength" type="xs:integer"/>
                 <xs:attribute name="minLength" type="xs:integer"/>
 
-                <xs:attributeGroup ref="hasDataContainer"/>
                 <xs:attributeGroup ref="hasRequired"/>
             </xs:extension>
         </xs:complexContent>
@@ -3667,8 +3643,7 @@
                     <xs:element name="tooltip" type="tooltipElement"/>
                 </xs:sequence>
 
-                <xs:attribute name="itemsContainer" type="xs:string"/>
-                <xs:attribute name="itemsEnum" type="xs:string"/>
+                <xs:attributeGroup ref="hasItems"/>
 
                 <xs:attribute name="selectAllButtonsVisible" type="xs:boolean"/>
                 <xs:attribute name="reorderable" type="xs:boolean"/>
@@ -3805,12 +3780,12 @@
                 </xs:sequence>
 
                 <xs:attribute name="opened" type="xs:boolean"/>
-                <xs:attribute name="itemsEnum" type="xs:string"/>
                 <xs:attribute name="autoOpen" type="xs:boolean"/>
                 <xs:attribute name="pageSize" type="xs:integer"/>
                 <xs:attribute name="autofocus" type="xs:boolean"/>
                 <xs:attribute name="selectedItemsOnTop" type="xs:boolean"/>
-                <xs:attribute name="itemsContainer" type="xs:string"/>
+
+                <xs:attributeGroup ref="hasItems"/>
                 <xs:attribute name="allowCustomValue" type="xs:boolean"/>
                 <xs:attribute name="allowedCharPattern" type="resourceString"/>
                 <xs:attribute name="clearButtonVisible" type="xs:boolean"/>
@@ -3822,7 +3797,6 @@
                 <xs:attributeGroup ref="hasRequired"/>
                 <xs:attributeGroup ref="hasFocusableAttributes"/>
                 <xs:attributeGroup ref="hasPlaceholder"/>
-                <xs:attributeGroup ref="hasValidation"/>
                 <xs:attributeGroup ref="hasOverlayWidth"/>
                 <xs:attributeGroup ref="hasAriaLabel"/>
             </xs:extension>
@@ -3862,7 +3836,6 @@
                 <xs:attribute name="metaClass" type="xs:string"/>
                 <xs:attribute name="itemsContainer" type="xs:string"/>
 
-                <xs:attributeGroup ref="hasRequired"/>
                 <xs:attributeGroup ref="hasDataContainer"/>
             </xs:extension>
         </xs:complexContent>
@@ -3978,9 +3951,9 @@
                 </xs:sequence>
 
                 <xs:attribute name="themeNames" type="radioButtonGroupThemeNames"/>
-                <xs:attribute name="itemsContainer" type="xs:string"/>
-                <xs:attribute name="itemsEnum" type="xs:string"/>
                 <xs:attribute name="datatype" type="fieldDatatypeEnum"/>
+
+                <xs:attributeGroup ref="hasItems"/>
 
                 <xs:attributeGroup ref="hasSize"/>
                 <xs:attributeGroup ref="hasLabel"/>
@@ -4005,10 +3978,9 @@
                     <xs:element name="fragmentRenderer" type="fragmentRendererElement"/>
                 </xs:sequence>
 
-                <xs:attribute name="itemsContainer" type="xs:string"/>
-                <xs:attribute name="itemsEnum" type="xs:string"/>
-
                 <xs:attribute name="themeNames" type="checkboxGroupThemeNames"/>
+
+                <xs:attributeGroup ref="hasItems"/>
 
                 <xs:attributeGroup ref="hasSize"/>
                 <xs:attributeGroup ref="hasLabel"/>
@@ -4033,10 +4005,9 @@
                     <xs:element name="fragmentRenderer" type="fragmentRendererElement"/>
                 </xs:sequence>
 
-                <xs:attribute name="itemsContainer" type="xs:string"/>
-                <xs:attribute name="itemsEnum" type="xs:string"/>
                 <xs:attribute name="readOnly" type="xs:boolean"/>
 
+                <xs:attributeGroup ref="hasItems"/>
                 <xs:attributeGroup ref="hasSize"/>
                 <xs:attributeGroup ref="hasEnabled"/>
                 <xs:attributeGroup ref="hasClassNames"/>
@@ -4054,10 +4025,9 @@
                     <xs:element name="fragmentRenderer" type="fragmentRendererElement"/>
                 </xs:sequence>
 
-                <xs:attribute name="itemsContainer" type="xs:string"/>
-                <xs:attribute name="itemsEnum" type="xs:string"/>
                 <xs:attribute name="readOnly" type="xs:boolean"/>
 
+                <xs:attributeGroup ref="hasItems"/>
                 <xs:attributeGroup ref="hasSize"/>
                 <xs:attributeGroup ref="hasEnabled"/>
                 <xs:attributeGroup ref="hasClassNames"/>
@@ -4358,9 +4328,9 @@
                 <xs:attribute name="autofocus" type="xs:boolean"/>
                 <xs:attribute name="emptySelectionCaption" type="resourceString"/>
                 <xs:attribute name="emptySelectionAllowed" type="xs:boolean"/>
-                <xs:attribute name="itemsContainer" type="xs:string"/>
-                <xs:attribute name="itemsEnum" type="xs:string"/>
                 <xs:attribute name="datatype" type="fieldDatatypeEnum"/>
+
+                <xs:attributeGroup ref="hasItems"/>
                 <xs:attribute name="themeNames" type="selectThemeNames"/>
                 <xs:attribute name="noVerticalOverlap" type="xs:boolean"/>
 
@@ -4427,17 +4397,6 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
-
-    <xs:simpleType name="sidePanelPositionType">
-        <xs:restriction>
-            <xs:enumeration value="TOP"/>
-            <xs:enumeration value="RIGHT"/>
-            <xs:enumeration value="BOTTOM"/>
-            <xs:enumeration value="LEFT"/>
-            <xs:enumeration value="INLINE_START"/>
-            <xs:enumeration value="INLINE_END"/>
-        </xs:restriction>
-    </xs:simpleType>
 
     <!-- SidePanelLayoutCloser -->
 
@@ -4541,10 +4500,10 @@
                     <xs:group ref="layoutOrComponent"/>
                 </xs:sequence>
 
-                <xs:attribute name="itemsContainer" type="xs:string"/>
-                <xs:attribute name="itemsEnum" type="xs:string"/>
                 <xs:attribute name="columnMinWidth" type="xs:string"/>
                 <xs:attribute name="gap" type="xs:string"/>
+
+                <xs:attributeGroup ref="hasItems"/>
 
                 <xs:attributeGroup ref="hasEnabled"/>
                 <xs:attributeGroup ref="hasSize"/>
@@ -4728,13 +4687,6 @@
         </xs:complexContent>
     </xs:complexType>
 
-    <xs:simpleType name="fileStoragePutMode">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="MANUAL"/>
-            <xs:enumeration value="IMMEDIATE"/>
-        </xs:restriction>
-    </xs:simpleType>
-
     <!-- Image -->
     <xs:complexType name="imageComponent">
         <xs:complexContent>
@@ -4822,9 +4774,7 @@
                 <xs:attributeGroup ref="hasClassNames"/>
                 <xs:attributeGroup ref="hasEnabled"/>
                 <xs:attributeGroup ref="hasFocusableAttributes"/>
-
-                <xs:attribute name="itemsContainer" type="xs:string"/>
-                <xs:attribute name="itemsEnum" type="xs:string"/>
+                <xs:attributeGroup ref="hasItems"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -4894,13 +4844,6 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
-
-    <xs:simpleType name="menuFilterFieldFilterMode">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="CASE_SENSITIVE"/>
-            <xs:enumeration value="CASE_INSENSITIVE"/>
-        </xs:restriction>
-    </xs:simpleType>
 
     <!-- RichTextEditorComponent -->
     <xs:complexType name="richTextEditorComponent">
@@ -5453,32 +5396,16 @@
         <xs:attribute name="type" type="onViewEventEnum" use="required"/>
     </xs:complexType>
 
-    <xs:simpleType name="onViewEventEnum">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="Init"/>
-            <xs:enumeration value="BeforeShow"/>
-            <xs:enumeration value="Ready"/>
-        </xs:restriction>
-    </xs:simpleType>
-
     <xs:complexType name="onContainerItemChangedType">
-        <xs:attribute name="container" use="required"/>
+        <xs:attribute name="container" type="xs:string" use="required"/>
         <xs:attribute name="param" type="xs:string"/>
     </xs:complexType>
 
     <xs:complexType name="onComponentValueChangedType">
-        <xs:attribute name="component" use="required"/>
+        <xs:attribute name="component" type="xs:string" use="required"/>
         <xs:attribute name="param" type="xs:string"/>
         <xs:attribute name="likeClause" type="likeClauseEnum"/>
     </xs:complexType>
-
-    <xs:simpleType name="likeClauseEnum">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="NONE"/>
-            <xs:enumeration value="CASE_SENSITIVE"/>
-            <xs:enumeration value="CASE_INSENSITIVE"/>
-        </xs:restriction>
-    </xs:simpleType>
 
     <!-- urlQueryParameters -->
 


### PR DESCRIPTION
## Summary
- Refactor `layout.xsd` to fix schema errors (missing `xs:restriction` bases,
  malformed `xs:union`, missing attribute types), deduplicate value-identical
  simple types via `xs:union memberTypes`, remove redundant attribute
  re-declarations on field components, and introduce a `hasItems`
  attributeGroup for selection components.
- Add reference docs under `doc/features/flowui-layout-xsd/` that catalogue
  the reusable building blocks in the XSD and the patterns for adding or
  extending components.

The refactor changes only how types are expressed — no view-XML element
or attribute is removed, renamed, or made required. The only surface
addition is the optional `requiredMessage` attribute on `entityComboBox`,
which follows from promoting `required` to the shared `hasRequired` group
on its base type (previously `required` was declared directly).