### PR TITLE
AppSettings: check permissions on save when configured #5311

### DIFF
--- a/jmix-appsettings/appsettings/src/main/java/io/jmix/appsettings/impl/AppSettingsImpl.java
+++ b/jmix-appsettings/appsettings/src/main/java/io/jmix/appsettings/impl/AppSettingsImpl.java
@@ -2,8 +2,10 @@ package io.jmix.appsettings.impl;
 
 import io.jmix.appsettings.AppSettings;
 import io.jmix.appsettings.AppSettingsEntityLoadMode;
+import io.jmix.appsettings.AppSettingsProperties;
 import io.jmix.appsettings.AppSettingsTools;
 import io.jmix.appsettings.entity.AppSettingsEntity;
+import io.jmix.core.DataManager;
 import io.jmix.core.UnconstrainedDataManager;
 import io.jmix.core.entity.EntityValues;
 import io.jmix.core.metamodel.datatype.DatatypeRegistry;
@@ -21,13 +23,19 @@ public class AppSettingsImpl implements AppSettings {
     private static final Logger log = LoggerFactory.getLogger(AppSettingsImpl.class);
 
     @Autowired
-    protected UnconstrainedDataManager dataManager;
+    protected DataManager dataManager;
+
+    @Autowired
+    protected UnconstrainedDataManager unconstrainedDataManager;
 
     @Autowired
     protected DatatypeRegistry datatypeRegistry;
 
     @Autowired
     protected AppSettingsTools appSettingsTools;
+
+    @Autowired
+    protected AppSettingsProperties appSettingsProperties;
 
     @Override
     public <T extends AppSettingsEntity> T load(Class<T> clazz) {
@@ -59,7 +67,11 @@ public class AppSettingsImpl implements AppSettings {
     }
 
     protected <T extends AppSettingsEntity> void saveAppSettingsEntity(T settingsEntity) {
-        dataManager.save(settingsEntity);
+        getDataManagerForAppSettingsEntity().save(settingsEntity);
+    }
+
+    protected UnconstrainedDataManager getDataManagerForAppSettingsEntity() {
+        return appSettingsProperties.isCheckPermissionsForAppSettingsEntity() ? dataManager : unconstrainedDataManager;
     }
 
     protected <T extends AppSettingsEntity> List<String> getPropertyNames(Class<T> clazz) {

--- a/jmix-appsettings/appsettings/src/test/java/io/jmix/appsettings/AppSettingsPermissionEnforcementTest.java
+++ b/jmix-appsettings/appsettings/src/test/java/io/jmix/appsettings/AppSettingsPermissionEnforcementTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.appsettings;
+
+import io.jmix.appsettings.test_entity.TestAppSettingsEntity;
+import io.jmix.appsettings.test_support.entity.TenantTestUser;
+import io.jmix.appsettings.test_support.role.AppSettingsReadOnlyRole;
+import io.jmix.core.Metadata;
+import io.jmix.core.SaveContext;
+import io.jmix.core.UnconstrainedDataManager;
+import io.jmix.core.security.AccessDeniedException;
+import io.jmix.data.PersistenceHints;
+import io.jmix.security.role.RoleGrantedAuthorityUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+
+@SpringBootTest(classes = AppSettingsTestConfiguration.class)
+@TestPropertySource(properties = "jmix.appsettings.check-permissions-for-app-settings-entity=true")
+class AppSettingsPermissionEnforcementTest {
+
+    @Autowired
+    private AppSettings appSettings;
+
+    @Autowired
+    private UnconstrainedDataManager unconstrainedDataManager;
+
+    @Autowired
+    private Metadata metadata;
+
+    @Autowired
+    private RoleGrantedAuthorityUtils roleGrantedAuthorityUtils;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+        List<TestAppSettingsEntity> storedEntities = unconstrainedDataManager.load(TestAppSettingsEntity.class)
+                .all()
+                .hint(PersistenceHints.SOFT_DELETION, false)
+                .list();
+
+        if (!storedEntities.isEmpty()) {
+            SaveContext saveContext = new SaveContext()
+                    .setHint(PersistenceHints.SOFT_DELETION, false);
+            for (TestAppSettingsEntity storedEntity : storedEntities) {
+                saveContext.removing(storedEntity);
+            }
+            unconstrainedDataManager.save(saveContext);
+        }
+    }
+
+    @Test
+    void testSaveDeniedWhenUserHasReadOnlyRole() {
+        TestAppSettingsEntity preExisting = metadata.create(TestAppSettingsEntity.class, 1);
+        preExisting.setTestStringValue("original");
+        unconstrainedDataManager.save(preExisting);
+
+        TestAppSettingsEntity submitted = metadata.create(TestAppSettingsEntity.class, 1);
+        submitted.setTestStringValue("policy-bypass");
+
+        Assertions.assertThrows(AccessDeniedException.class,
+                () -> asReadOnlyUser(() -> {
+                    appSettings.save(submitted);
+                    return null;
+                }));
+
+        TestAppSettingsEntity reloaded = unconstrainedDataManager.load(TestAppSettingsEntity.class)
+                .id(1)
+                .one();
+        Assertions.assertEquals("original", reloaded.getTestStringValue());
+    }
+
+    private <T> T asReadOnlyUser(Supplier<T> action) {
+        TenantTestUser user = metadata.create(TenantTestUser.class);
+        user.setUsername("read-only-user");
+        user.setPassword("{noop}read-only-user");
+        GrantedAuthority authority = roleGrantedAuthorityUtils
+                .createResourceRoleGrantedAuthority(AppSettingsReadOnlyRole.NAME);
+        user.setAuthorities(Collections.singletonList(authority));
+        Authentication authentication = new UsernamePasswordAuthenticationToken(
+                user, user.getPassword(), user.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        try {
+            return action.get();
+        } finally {
+            SecurityContextHolder.clearContext();
+        }
+    }
+}

--- a/jmix-appsettings/appsettings/src/test/java/io/jmix/appsettings/test_support/role/AppSettingsReadOnlyRole.java
+++ b/jmix-appsettings/appsettings/src/test/java/io/jmix/appsettings/test_support/role/AppSettingsReadOnlyRole.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.appsettings.test_support.role;
+
+import io.jmix.appsettings.test_entity.TestAppSettingsEntity;
+import io.jmix.security.model.EntityPolicyAction;
+import io.jmix.security.role.annotation.EntityPolicy;
+import io.jmix.security.role.annotation.ResourceRole;
+
+@ResourceRole(name = AppSettingsReadOnlyRole.NAME, code = AppSettingsReadOnlyRole.NAME)
+public interface AppSettingsReadOnlyRole {
+
+    String NAME = "AppSettingsReadOnlyRole";
+
+    @EntityPolicy(entityClass = TestAppSettingsEntity.class, actions = {EntityPolicyAction.READ})
+    void testAppSettingsEntity();
+}


### PR DESCRIPTION
## Summary
- `AppSettingsImpl#save` now routes through the constrained `DataManager` when `jmix.appsettings.check-permissions-for-app-settings-entity=true`, mirroring the existing behavior of the read path in `AppSettingsToolsImpl`. Previously the save path always used `UnconstrainedDataManager`, bypassing registered entity update constraints even when permission checks were explicitly enabled.
- Default behavior (property = `false`) is preserved for backward compatibility — apps that opt into permission checks now get them on both load and save.

Closes #5311

## Test plan
- [x] New integration test `AppSettingsPermissionEnforcementTest` runs with `check-permissions-for-app-settings-entity=true`, authenticates a user holding a read-only `ResourceRole` on the settings entity, and asserts that `appSettings.save(...)` throws `AccessDeniedException` and the stored value is unchanged.
- [x] Existing `AppSettingsTest` and `AppSettingsTenantProviderOnlyTest` continue to pass (default property value, unconstrained save path unaffected).
- [x] `./gradlew :appsettings:test` — all 6 tests green.