### PR TITLE
Column filter 'not_...' operations should handle null values jmix-framework/jmix#5242

### DIFF
--- a/jmix-data/data/src/main/java/io/jmix/data/DataProperties.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/DataProperties.java
@@ -34,12 +34,13 @@ public class DataProperties {
     boolean useUserLocaleForRelativeDateTimeMoments;
 
     /**
-     * When {@code true}, negative property condition operators ({@code NOT_EQUAL}, {@code NOT_CONTAINS},
-     * {@code NOT_IN_LIST}) include records with {@code null} value of the filtered property in the result.
-     * By default ({@code false}) such records are excluded due to SQL three-valued logic
-     * (e.g. {@code NULL <> value} evaluates to {@code NULL}).
+     * When {@code true}, an additional {@code is null} clause is appended to the generated JPQL for
+     * negative property condition operators ({@code NOT_EQUAL}, {@code NOT_CONTAINS}, {@code NOT_IN_LIST}),
+     * so that records with {@code null} value of the filtered property are returned by such conditions.
+     * By default ({@code false}) the clause is not added and such records are excluded due to SQL
+     * three-valued logic (e.g. {@code NULL <> value} evaluates to {@code NULL}).
      */
-    boolean negativePropertyConditionIncludesNulls;
+    boolean includeNullClauseInNotConditions;
 
     public DataProperties(
             @DefaultValue("true") boolean useReadOnlyTransactionForLoad,
@@ -47,13 +48,13 @@ public class DataProperties {
             boolean useEntityDataStoreForIdSequence,
             @Nullable String uniqueConstraintViolationPattern,
             @DefaultValue("true") boolean useUserLocaleForRelativeDateTimeMoments,
-            @DefaultValue("false") boolean negativePropertyConditionIncludesNulls) {
+            @DefaultValue("false") boolean includeNullClauseInNotConditions) {
         this.useReadOnlyTransactionForLoad = useReadOnlyTransactionForLoad;
         this.numberIdCacheSize = numberIdCacheSize;
         this.useEntityDataStoreForIdSequence = useEntityDataStoreForIdSequence;
         this.uniqueConstraintViolationPattern = uniqueConstraintViolationPattern;
         this.useUserLocaleForRelativeDateTimeMoments = useUserLocaleForRelativeDateTimeMoments;
-        this.negativePropertyConditionIncludesNulls = negativePropertyConditionIncludesNulls;
+        this.includeNullClauseInNotConditions = includeNullClauseInNotConditions;
     }
 
     public boolean isUseReadOnlyTransactionForLoad() {
@@ -81,9 +82,9 @@ public class DataProperties {
     }
 
     /**
-     * @see #negativePropertyConditionIncludesNulls
+     * @see #includeNullClauseInNotConditions
      */
-    public boolean isNegativePropertyConditionIncludesNulls() {
-        return negativePropertyConditionIncludesNulls;
+    public boolean isIncludeNullClauseInNotConditions() {
+        return includeNullClauseInNotConditions;
     }
 }

--- a/jmix-data/data/src/main/java/io/jmix/data/DataProperties.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/DataProperties.java
@@ -33,17 +33,27 @@ public class DataProperties {
     String uniqueConstraintViolationPattern;
     boolean useUserLocaleForRelativeDateTimeMoments;
 
+    /**
+     * When {@code true}, negative property condition operators ({@code NOT_EQUAL}, {@code NOT_CONTAINS},
+     * {@code NOT_IN_LIST}) include records with {@code null} value of the filtered property in the result.
+     * By default ({@code false}) such records are excluded due to SQL three-valued logic
+     * (e.g. {@code NULL <> value} evaluates to {@code NULL}).
+     */
+    boolean negativePropertyConditionIncludesNulls;
+
     public DataProperties(
             @DefaultValue("true") boolean useReadOnlyTransactionForLoad,
             @DefaultValue("100") int numberIdCacheSize,
             boolean useEntityDataStoreForIdSequence,
             @Nullable String uniqueConstraintViolationPattern,
-            @DefaultValue("true") boolean useUserLocaleForRelativeDateTimeMoments) {
+            @DefaultValue("true") boolean useUserLocaleForRelativeDateTimeMoments,
+            @DefaultValue("false") boolean negativePropertyConditionIncludesNulls) {
         this.useReadOnlyTransactionForLoad = useReadOnlyTransactionForLoad;
         this.numberIdCacheSize = numberIdCacheSize;
         this.useEntityDataStoreForIdSequence = useEntityDataStoreForIdSequence;
         this.uniqueConstraintViolationPattern = uniqueConstraintViolationPattern;
         this.useUserLocaleForRelativeDateTimeMoments = useUserLocaleForRelativeDateTimeMoments;
+        this.negativePropertyConditionIncludesNulls = negativePropertyConditionIncludesNulls;
     }
 
     public boolean isUseReadOnlyTransactionForLoad() {
@@ -68,5 +78,12 @@ public class DataProperties {
 
     public boolean isUseUserLocaleForRelativeDateTimeMoments() {
         return useUserLocaleForRelativeDateTimeMoments;
+    }
+
+    /**
+     * @see #negativePropertyConditionIncludesNulls
+     */
+    public boolean isNegativePropertyConditionIncludesNulls() {
+        return negativePropertyConditionIncludesNulls;
     }
 }

--- a/jmix-data/data/src/main/java/io/jmix/data/impl/jpql/generator/PropertyConditionGenerator.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/impl/jpql/generator/PropertyConditionGenerator.java
@@ -29,6 +29,7 @@ import io.jmix.core.metamodel.model.MetaPropertyPath;
 import io.jmix.core.querycondition.Condition;
 import io.jmix.core.querycondition.PropertyCondition;
 import io.jmix.core.querycondition.PropertyConditionUtils;
+import io.jmix.data.DataProperties;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,6 +49,7 @@ public class PropertyConditionGenerator implements ConditionGenerator<PropertyCo
 
     protected MetadataTools metadataTools;
     protected Metadata metadata;
+    protected DataProperties dataProperties;
 
     @Nullable
     protected InIntervalParametersResolver inIntervalResolver;
@@ -62,6 +64,11 @@ public class PropertyConditionGenerator implements ConditionGenerator<PropertyCo
     public PropertyConditionGenerator(MetadataTools metadataTools, Metadata metadata) {
         this.metadataTools = metadataTools;
         this.metadata = metadata;
+    }
+
+    @Autowired
+    public void setDataProperties(DataProperties dataProperties) {
+        this.dataProperties = dataProperties;
     }
 
     @Autowired(required = false)
@@ -245,6 +252,17 @@ public class PropertyConditionGenerator implements ConditionGenerator<PropertyCo
                         entityAlias,
                         property);
             } else {
+                if (dataProperties.isNegativePropertyConditionIncludesNulls()
+                        && isNegativeComparison(propertyCondition.getOperation())) {
+                    return String.format("(%s.%s %s :%s or %s.%s is null)",
+                            entityAlias,
+                            property,
+                            PropertyConditionUtils.getJpqlOperation(propertyCondition),
+                            propertyCondition.getParameterName(),
+                            entityAlias,
+                            property);
+                }
+
                 return String.format("%s.%s %s :%s",
                         entityAlias,
                         property,

--- a/jmix-data/data/src/main/java/io/jmix/data/impl/jpql/generator/PropertyConditionGenerator.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/impl/jpql/generator/PropertyConditionGenerator.java
@@ -252,7 +252,7 @@ public class PropertyConditionGenerator implements ConditionGenerator<PropertyCo
                         entityAlias,
                         property);
             } else {
-                if (dataProperties.isNegativePropertyConditionIncludesNulls()
+                if (dataProperties.isIncludeNullClauseInNotConditions()
                         && isNegativeComparison(propertyCondition.getOperation())) {
                     return String.format("(%s.%s %s :%s or %s.%s is null)",
                             entityAlias,

--- a/jmix-data/eclipselink/src/test/groovy/data_manager/DataManagerNegativeConditionNullsTest.groovy
+++ b/jmix-data/eclipselink/src/test/groovy/data_manager/DataManagerNegativeConditionNullsTest.groovy
@@ -26,7 +26,7 @@ import org.springframework.test.context.TestPropertySource
 import test_support.DataSpec
 import test_support.entity.TestAppEntity
 
-@TestPropertySource(properties = ["jmix.data.negative-property-condition-includes-nulls=true"])
+@TestPropertySource(properties = ["jmix.data.include-null-clause-in-not-conditions=true"])
 class DataManagerNegativeConditionNullsTest extends DataSpec {
 
     @Autowired

--- a/jmix-data/eclipselink/src/test/groovy/data_manager/DataManagerNegativeConditionNullsTest.groovy
+++ b/jmix-data/eclipselink/src/test/groovy/data_manager/DataManagerNegativeConditionNullsTest.groovy
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data_manager
+
+import io.jmix.core.DataManager
+import io.jmix.core.querycondition.PropertyCondition
+import io.jmix.data.impl.jpql.generator.ConditionGenerationContext
+import io.jmix.data.impl.jpql.generator.PropertyConditionGenerator
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.test.context.TestPropertySource
+import test_support.DataSpec
+import test_support.entity.TestAppEntity
+
+@TestPropertySource(properties = ["jmix.data.negative-property-condition-includes-nulls=true"])
+class DataManagerNegativeConditionNullsTest extends DataSpec {
+
+    @Autowired
+    DataManager dataManager
+
+    @Autowired
+    @Qualifier("data_PropertyConditionGenerator")
+    PropertyConditionGenerator propertyConditionGenerator
+
+    def "NOT_EQUAL includes records with null"() {
+
+        TestAppEntity matching = dataManager.create(TestAppEntity)
+        matching.name = 'target'
+
+        TestAppEntity nonMatching = dataManager.create(TestAppEntity)
+        nonMatching.name = 'other'
+
+        TestAppEntity withNull = dataManager.create(TestAppEntity)
+        withNull.name = null
+
+        dataManager.save(matching, nonMatching, withNull)
+
+        when:
+
+        def list = dataManager.load(TestAppEntity)
+                .condition(PropertyCondition.notEqual("name", "target"))
+                .list()
+
+        then:
+
+        list.size() == 2
+        list.contains(nonMatching)
+        list.contains(withNull)
+    }
+
+    def "NOT_CONTAINS includes records with null"() {
+
+        TestAppEntity matching = dataManager.create(TestAppEntity)
+        matching.name = 'has target inside'
+
+        TestAppEntity nonMatching = dataManager.create(TestAppEntity)
+        nonMatching.name = 'other'
+
+        TestAppEntity withNull = dataManager.create(TestAppEntity)
+        withNull.name = null
+
+        dataManager.save(matching, nonMatching, withNull)
+
+        when:
+
+        def list = dataManager.load(TestAppEntity)
+                .condition(PropertyCondition.createWithValue("name", PropertyCondition.Operation.NOT_CONTAINS, "target"))
+                .list()
+
+        then:
+
+        list.size() == 2
+        list.contains(nonMatching)
+        list.contains(withNull)
+    }
+
+    def "NOT_IN_LIST includes records with null"() {
+
+        TestAppEntity matching = dataManager.create(TestAppEntity)
+        matching.name = 'one'
+
+        TestAppEntity nonMatching = dataManager.create(TestAppEntity)
+        nonMatching.name = 'three'
+
+        TestAppEntity withNull = dataManager.create(TestAppEntity)
+        withNull.name = null
+
+        dataManager.save(matching, nonMatching, withNull)
+
+        when:
+
+        def list = dataManager.load(TestAppEntity)
+                .condition(PropertyCondition.notInList("name", ["one", "two"]))
+                .list()
+
+        then:
+
+        list.size() == 2
+        list.contains(nonMatching)
+        list.contains(withNull)
+    }
+
+    def "generated JPQL wraps NOT_EQUAL with 'is null' check"() {
+        when:
+
+        def property = PropertyCondition.notEqual("name", "target")
+        def context = new ConditionGenerationContext(property)
+        context.entityName = "test_TestAppEntity"
+        context.entityAlias = "e"
+        def where = propertyConditionGenerator.generateWhere(context)
+
+        then:
+
+        where.contains("e.name <>")
+        where.contains("e.name is null")
+        where.startsWith("(")
+        where.endsWith(")")
+    }
+}

--- a/jmix-data/eclipselink/src/test/groovy/data_manager/DataManagerPropertyConditionTest.groovy
+++ b/jmix-data/eclipselink/src/test/groovy/data_manager/DataManagerPropertyConditionTest.groovy
@@ -200,6 +200,45 @@ class DataManagerPropertyConditionTest extends DataSpec {
         list.contains(testEntity3)
     }
 
+    def "NOT_EQUAL excludes records with null by default"() {
+
+        TestAppEntity testEntity1 = dataManager.create(TestAppEntity)
+        testEntity1.name = 'target'
+
+        TestAppEntity testEntity2 = dataManager.create(TestAppEntity)
+        testEntity2.name = 'other'
+
+        TestAppEntity testEntity3 = dataManager.create(TestAppEntity)
+        testEntity3.name = null
+
+        dataManager.save(testEntity1, testEntity2, testEntity3)
+
+        when:
+
+        def list = dataManager.load(TestAppEntity)
+                .condition(PropertyCondition.notEqual("name", "target"))
+                .list()
+
+        then:
+
+        list == [testEntity2]
+    }
+
+    def "generated JPQL for NOT_EQUAL is not wrapped by default"() {
+        when:
+
+        def property = PropertyCondition.notEqual("name", "target")
+        def context = new ConditionGenerationContext(property)
+        context.entityName = "test_TestAppEntity"
+        context.entityAlias = "e"
+        def where = propertyConditionGenerator.generateWhere(context)
+
+        then:
+
+        where.contains("e.name <>")
+        !where.contains("is null")
+    }
+
     def "load using PropertyCondition for non-empty collections"() {
 
         TestAppEntity testAppEntity1 = dataManager.create(TestAppEntity)


### PR DESCRIPTION
### Summary

Added the `jmix.data.include-null-clause-in-not-conditions` application property that controls whether records with a `null` value of the filtered property are included in the result of negative property condition operators (`NOT_EQUAL`, `NOT_CONTAINS`, `NOT_IN_LIST`).

By default the property is `false`. When set to `true`, negative operators include `null` rows.

### Changes

- `DataProperties` — added boolean field `includeNullClauseInNotConditions` with default `false`.
- Element collections are unaffected — their negative-operator path already uses `not exists (...)`, which correctly includes empty collections.

### Generated JPQL

| Operator | Property `false` (default) | Property `true` |
|---|---|---|
| `NOT_EQUAL` | `e.field <> :p` | `(e.field <> :p or e.field is null)` |
| `NOT_CONTAINS` | `e.field not like :p` | `(e.field not like :p or e.field is null)` |
| `NOT_IN_LIST` | `e.field not in :p` | `(e.field not in :p or e.field is null)` |