### PR TITLE
GenericFilter does not load configurations if it is placed in a tab other than the first selected one (5315)

### DIFF
--- a/jmix-flowui/flowui-data/src/test/java/filter_configuration_persistence/FilterConfigurationPersistenceTest.java
+++ b/jmix-flowui/flowui-data/src/test/java/filter_configuration_persistence/FilterConfigurationPersistenceTest.java
@@ -16,7 +16,9 @@
 
 package filter_configuration_persistence;
 
+import filter_configuration_persistence.view.FilterConfigurationPersistenceInTabTestView;
 import filter_configuration_persistence.view.FilterConfigurationPersistenceTestView;
+import io.jmix.flowui.component.genericfilter.GenericFilter;
 import io.jmix.core.DataManager;
 import io.jmix.core.EntityStates;
 import io.jmix.core.querycondition.*;
@@ -155,6 +157,63 @@ public class FilterConfigurationPersistenceTest {
                 .orElse(null);
 
         Assertions.assertNotNull(condition);
+    }
+
+    @Test
+    @DisplayName("Load FilterConfiguration for GenericFilter in non-selected tabs")
+    public void loadFilterConfigurationInNonSelectedTabs() {
+        String username = FilterConfigurationPersistenceTestAuthenticator.simpleUser;
+
+        FilterConfigurationModel regularTabConfiguration = createNewConfiguration(
+                "regularTabConfiguration",
+                "[FilterConfigurationPersistenceInTabTestView]genericFilterInRegularTab",
+                username
+        );
+        configurationPersistence.save(regularTabConfiguration);
+
+        FilterConfigurationModel lazyTabConfiguration = createNewConfiguration(
+                "lazyTabConfiguration",
+                "[FilterConfigurationPersistenceInTabTestView]genericFilterInLazyTab",
+                username
+        );
+        configurationPersistence.save(lazyTabConfiguration);
+
+        navigationSupport.navigate(FilterConfigurationPersistenceInTabTestView.class);
+        FilterConfigurationPersistenceInTabTestView view = UiTestUtils.getCurrentView();
+
+        Assertions.assertNull(view.genericFilterInRegularTab.getConfiguration("regularTabConfiguration"));
+        Assertions.assertTrue(view.tabSheet.findComponent("genericFilterInLazyTab").isEmpty());
+
+        /*
+         * Check Regular Tab
+         */
+        view.tabSheet.setSelectedTab(view.regularFiltersTab);
+
+        Configuration regularConfiguration = view.genericFilterInRegularTab.getConfiguration("regularTabConfiguration");
+        Assertions.assertNotNull(regularConfiguration);
+        assertNameCondition(regularConfiguration);
+
+        Assertions.assertTrue(view.tabSheet.findComponent("genericFilterInLazyTab").isEmpty());
+
+        /*
+         * Check Lazy Tab
+         */
+        view.tabSheet.setSelectedTab(view.lazyFiltersTab);
+
+        GenericFilter lazyTabFilter = (GenericFilter) view.tabSheet.findComponent("genericFilterInLazyTab")
+                .orElseThrow();
+
+        Configuration lazyConfiguration = lazyTabFilter.getConfiguration("lazyTabConfiguration");
+        Assertions.assertNotNull(lazyConfiguration);
+        assertNameCondition(lazyConfiguration);
+    }
+
+    private void assertNameCondition(Configuration configuration) {
+        List<Condition> conditions = configuration.getQueryCondition().getConditions();
+        Assertions.assertEquals(1, conditions.size());
+
+        PropertyCondition nameCondition = (PropertyCondition) conditions.get(0);
+        Assertions.assertEquals("name", nameCondition.getProperty());
     }
 
     private FilterConfigurationModel createNewConfiguration(String configurationId, String componentId, String username) {

--- a/jmix-flowui/flowui-data/src/test/java/filter_configuration_persistence/view/FilterConfigurationPersistenceInTabTestView.java
+++ b/jmix-flowui/flowui-data/src/test/java/filter_configuration_persistence/view/FilterConfigurationPersistenceInTabTestView.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filter_configuration_persistence.view;
+
+import com.vaadin.flow.component.tabs.Tab;
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.component.genericfilter.GenericFilter;
+import io.jmix.flowui.component.tabsheet.JmixTabSheet;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+
+@Route("filter-configuration-persistence-in-tab-test-view")
+@ViewController("FilterConfigurationPersistenceInTabTestView")
+@ViewDescriptor("filter-configuration-persistence-in-tab-test-view.xml")
+public class FilterConfigurationPersistenceInTabTestView extends StandardView {
+
+    @ViewComponent
+    public JmixTabSheet tabSheet;
+
+    @ViewComponent
+    public Tab regularFiltersTab;
+
+    @ViewComponent
+    public Tab lazyFiltersTab;
+
+    @ViewComponent
+    public GenericFilter genericFilterInRegularTab;
+}

--- a/jmix-flowui/flowui-data/src/test/resources/filter_configuration_persistence/view/filter-configuration-persistence-in-tab-test-view.xml
+++ b/jmix-flowui/flowui-data/src/test/resources/filter_configuration_persistence/view/filter-configuration-persistence-in-tab-test-view.xml
@@ -1,0 +1,50 @@
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <collection id="projectsDc"
+                    class="test_support.entity.Project">
+            <loader id="projectsLd">
+                <query>select e from test_Project e</query>
+            </loader>
+        </collection>
+    </data>
+    <facets>
+        <dataLoadCoordinator auto="true"/>
+    </facets>
+    <layout>
+        <tabSheet id="tabSheet">
+            <tab id="mainTab" label="Main">
+                <vbox/>
+            </tab>
+            <tab id="regularFiltersTab" label="Regular filters">
+                <vbox>
+                    <genericFilter id="genericFilterInRegularTab" dataLoader="projectsLd">
+                        <properties include=".*"/>
+                    </genericFilter>
+                </vbox>
+            </tab>
+            <tab id="lazyFiltersTab" label="Lazy filters" lazy="true">
+                <vbox>
+                    <genericFilter id="genericFilterInLazyTab" dataLoader="projectsLd">
+                        <properties include=".*"/>
+                    </genericFilter>
+                </vbox>
+            </tab>
+        </tabSheet>
+    </layout>
+</view>

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/component/GenericFilterLoader.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/component/GenericFilterLoader.java
@@ -156,8 +156,8 @@ public class GenericFilterLoader extends AbstractComponentLoader<GenericFilter> 
             resultComponent.loadConfigurationsAndApplyDefault();
         } else {
             resultComponent.addAttachListener(attachEvent -> {
-                // TODO: pinyazhin, check for loading?
-                if (FilterUtils.findCurrentOwner(resultComponent) != null) {
+                if (FilterUtils.findCurrentOwner(resultComponent) != null
+                        && resultComponent.getConfigurations().isEmpty()) {
                     validateFilterPaths(context, filterPaths);
                     resultComponent.loadConfigurationsAndApplyDefault();
                 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/component/GenericFilterLoader.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/loader/component/GenericFilterLoader.java
@@ -137,22 +137,7 @@ public class GenericFilterLoader extends AbstractComponentLoader<GenericFilter> 
         getContext().addInitTask(new AbstractInitTask() {
             @Override
             public void execute(Context context) {
-                ComponentUtil.findComponents(context.getOrigin().getElement(), component -> {
-                    if (component instanceof GenericFilter) {
-                        String path = FilterUtils.generateFilterPath((GenericFilter) component);
-
-                        if (filterPaths.contains(path)) {
-                            throw new GuiDevelopmentException(
-                                    "Filters with the same component path should have different ids",
-                                    getContext()
-                            );
-                        } else {
-                            filterPaths.add(path);
-                        }
-                    }
-                });
-
-                resultComponent.loadConfigurationsAndApplyDefault();
+                loadConfigurationsAndApplyDefault(context, resultComponent, filterPaths);
             }
         });
 
@@ -162,6 +147,40 @@ public class GenericFilterLoader extends AbstractComponentLoader<GenericFilter> 
                 loadConfiguration(resultComponent, configurationElement);
             }
         }
+    }
+
+    protected void loadConfigurationsAndApplyDefault(Context context, GenericFilter resultComponent,
+                                                     Set<String> filterPaths) {
+        if (FilterUtils.findCurrentOwner(resultComponent) != null) {
+            validateFilterPaths(context, filterPaths);
+            resultComponent.loadConfigurationsAndApplyDefault();
+        } else {
+            resultComponent.addAttachListener(attachEvent -> {
+                // TODO: pinyazhin, check for loading?
+                if (FilterUtils.findCurrentOwner(resultComponent) != null) {
+                    validateFilterPaths(context, filterPaths);
+                    resultComponent.loadConfigurationsAndApplyDefault();
+                }
+                attachEvent.unregisterListener();
+            });
+        }
+    }
+
+    protected void validateFilterPaths(Context context, Set<String> filterPaths) {
+        ComponentUtil.findComponents(context.getOrigin().getElement(), component -> {
+            if (component instanceof GenericFilter) {
+                String path = FilterUtils.generateFilterPath((GenericFilter) component);
+
+                if (filterPaths.contains(path)) {
+                    throw new GuiDevelopmentException(
+                            "Filters with the same component path should have different ids",
+                            getContext()
+                    );
+                } else {
+                    filterPaths.add(path);
+                }
+            }
+        });
     }
 
     protected void loadConfiguration(GenericFilter resultComponent, Element configurationElement) {


### PR DESCRIPTION
This PR fixes only loading configurations. The default configuration from Settings cannot be set to `GenericFilter` if it is placed to `Tab` in `JmixTabSheet` that is not selected by default.

### Description of limitation

`DataLoadingSettingsBinder` is intended for settings related to data loading. It is applied before the default data loading in the view, during the `BeforeShow` event. If `GenericFilter` has not loaded its data by that time, we cannot set default configuration. The `DataLoadingSettingsBinder` contract does not allow us to apply it when `GenericFilter` gets attached. Because we can unexpectedly change the view state after its "initial" loading phase has already passed, especially if custom `applyDataLoadingSettingsDelegate` contains logic related with "initial" phase.

In `JmixTabSheet`, for lazy tabs we apply regular settings, and that is correct because the tab content itself is loaded from XML. However, data-loading settings (`applyDataLoadingSettings`) are not applied, because that moment has already passed and applying them later may break the behavior of the current view.