### PR TITLE
Composition collections in runtime detail view template

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/ViewTemplateHelper.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/ViewTemplateHelper.java
@@ -39,4 +39,17 @@ public interface ViewTemplateHelper {
      * @return filtered entity properties in metadata order
      */
     List<MetaProperty> getProperties(MetaClass metaClass, List<String> includeProperties, List<String> excludeProperties);
+
+    /**
+     * Returns composition collection properties that should be rendered as tabs by a detail view template.
+     * <p>
+     * Implementations return direct composition {@code *-to-many} properties, applying default filtering
+     * rules and then removing properties listed in {@code excludeProperties}. Association collections,
+     * datatype collections, and single-value properties are not returned.
+     *
+     * @param metaClass         entity metadata
+     * @param excludeProperties property names that must be excluded from the result
+     * @return filtered composition collection properties in metadata order
+     */
+    List<MetaProperty> getCollectionProperties(MetaClass metaClass, List<String> excludeProperties);
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/impl/DefaultViewTemplateHelper.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/impl/DefaultViewTemplateHelper.java
@@ -65,6 +65,22 @@ public class DefaultViewTemplateHelper implements ViewTemplateHelper {
                 .toList();
     }
 
+    @Override
+    public List<MetaProperty> getCollectionProperties(MetaClass metaClass, List<String> excludeProperties) {
+        Set<String> excludedPropertyNames = validatePropertyNames(metaClass, excludeProperties);
+
+        return metaClass.getProperties().stream()
+                .filter(this::isSupportedCollectionProperty)
+                .filter(property -> !isDefaultExcluded(property))
+                .filter(property -> !excludedPropertyNames.contains(property.getName()))
+                .toList();
+    }
+
+    protected boolean isSupportedCollectionProperty(MetaProperty metaProperty) {
+        return metaProperty.getRange().getCardinality().isMany()
+                && metaProperty.getType() == MetaProperty.Type.COMPOSITION;
+    }
+
     protected Set<String> validatePropertyNames(MetaClass metaClass, Collection<String> propertyNames) {
         if (propertyNames == null || propertyNames.isEmpty()) {
             return Set.of();
@@ -91,6 +107,14 @@ public class DefaultViewTemplateHelper implements ViewTemplateHelper {
     protected boolean isDefaultExcluded(MetaProperty metaProperty) {
         return metadataTools.isSystemLevel(metaProperty)
                 || metadataTools.isSystem(metaProperty)
-                || metadataTools.isSecret(metaProperty);
+                || metadataTools.isSecret(metaProperty)
+                || isCompositionInverse(metaProperty);
+    }
+
+    protected boolean isCompositionInverse(MetaProperty metaProperty) {
+        MetaProperty inverse = metaProperty.getInverse();
+        return inverse != null
+                && inverse.getRange().getCardinality().isMany()
+                && inverse.getType() == MetaProperty.Type.COMPOSITION;
     }
 }

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/messages.properties
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/messages.properties
@@ -29,9 +29,6 @@ actions.Read=Read
 actions.Add=Add
 actions.Exclude=Exclude
 actions.Refresh=Refresh
-
-viewTemplate.generalTab=General
-
 actions.Apply=Apply
 
 actions.logout.text=Log out
@@ -491,3 +488,5 @@ io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.defaultFor
 io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.rootCondition = Root condition
 io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.sysTenantId = Tenant id
 io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.defaultForMe = Default for me
+
+viewTemplate.generalTab=General

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/messages.properties
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/messages.properties
@@ -29,6 +29,9 @@ actions.Read=Read
 actions.Add=Add
 actions.Exclude=Exclude
 actions.Refresh=Refresh
+
+viewTemplate.generalTab=General
+
 actions.Apply=Apply
 
 actions.logout.text=Log out

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/template/detail-template.ftl
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/template/detail-template.ftl
@@ -37,7 +37,7 @@
     </actions>
     <layout>
         <#if collectionProperties?has_content>
-        <tabSheet id="contentTabSheet" width="100%">
+        <tabSheet id="contentTabSheet" alignSelf="STRETCH">
             <tab id="generalTab" label="msg:///viewTemplate.generalTab">
                 <@formLayout/>
             </tab>

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/template/detail-template.ftl
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/template/detail-template.ftl
@@ -3,6 +3,14 @@
       title="${viewTitle}"
       focusComponent="form">
     <#assign properties = templateHelper.getProperties(entityMetaClass, includeProperties![], excludeProperties![])>
+    <#assign collectionProperties = templateHelper.getCollectionProperties(entityMetaClass, excludeProperties![])>
+    <#macro formLayout>
+        <formLayout id="form" dataContainer="entityDc">
+            <#list properties as property>
+            ${componentXmlFactory.createComponentXml(property, null)}
+            </#list>
+        </formLayout>
+    </#macro>
     <data>
         <instance id="entityDc"
                   class="${entityMetaClass.javaClass.name}">
@@ -10,7 +18,13 @@
                     <#list properties as property>
                     <property name="${property.name}"<#if property.range.isClass()> fetchPlan="_base"</#if>/>
                     </#list>
+                    <#list collectionProperties as collectionProperty>
+                    <property name="${collectionProperty.name}" fetchPlan="_base"/>
+                    </#list>
                 </fetchPlan>
+            <#list collectionProperties as collectionProperty>
+            <collection id="${collectionProperty.name}Dc" property="${collectionProperty.name}"/>
+            </#list>
             <loader/>
         </instance>
     </data>
@@ -22,11 +36,51 @@
         <action id="closeAction" type="detail_close"/>
     </actions>
     <layout>
-        <formLayout id="form" dataContainer="entityDc">
-            <#list properties as property>
-            ${componentXmlFactory.createComponentXml(property, null)}
+        <#if collectionProperties?has_content>
+        <tabSheet id="contentTabSheet" width="100%">
+            <tab id="generalTab" label="msg:///viewTemplate.generalTab">
+                <@formLayout/>
+            </tab>
+            <#list collectionProperties as collectionProperty>
+            <#assign columnProperties = templateHelper.getProperties(collectionProperty.range.asClass(), [], [])>
+            <tab id="${collectionProperty.name}Tab" label="msg://${entityMetaClass.javaClass.package.name}/${entityMetaClass.javaClass.simpleName}.${collectionProperty.name}">
+                <vbox id="${collectionProperty.name}TabContent" padding="false" width="100%">
+                    <hbox id="${collectionProperty.name}ButtonsPanel" classNames="buttons-panel">
+                        <button action="${collectionProperty.name}DataGrid.createAction"/>
+                        <button action="${collectionProperty.name}DataGrid.editAction"/>
+                        <button action="${collectionProperty.name}DataGrid.removeAction"/>
+                    </hbox>
+                    <dataGrid id="${collectionProperty.name}DataGrid"
+                              dataContainer="${collectionProperty.name}Dc"
+                              width="100%"
+                              minHeight="20em"
+                              columnReorderingAllowed="true">
+                        <actions>
+                            <action id="createAction" type="list_create">
+                                <properties>
+                                    <property name="openMode" value="DIALOG"/>
+                                </properties>
+                            </action>
+                            <action id="editAction" type="list_edit">
+                                <properties>
+                                    <property name="openMode" value="DIALOG"/>
+                                </properties>
+                            </action>
+                            <action id="removeAction" type="list_remove"/>
+                        </actions>
+                        <columns resizable="true">
+                            <#list columnProperties as column>
+                            <column property="${column.name}"/>
+                            </#list>
+                        </columns>
+                    </dataGrid>
+                </vbox>
+            </tab>
             </#list>
-        </formLayout>
+        </tabSheet>
+        <#else>
+        <@formLayout/>
+        </#if>
         <hbox id="detailActions">
             <button id="saveAndCloseButton" action="saveCloseAction"/>
             <button id="closeButton" action="closeAction"/>

--- a/jmix-flowui/flowui/src/test/groovy/view_template/DefaultViewTemplateHelperTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/view_template/DefaultViewTemplateHelperTest.groovy
@@ -22,6 +22,8 @@ import io.jmix.flowui.view.template.ViewTemplateHelper
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import test_support.entity.viewtemplate.ViewTemplateFilteringEntity
+import test_support.entity.viewtemplate.ViewTemplateLineEntity
+import test_support.entity.viewtemplate.ViewTemplateMasterEntity
 import test_support.spec.FlowuiTestSpecification
 
 @SpringBootTest
@@ -88,5 +90,61 @@ class DefaultViewTemplateHelperTest extends FlowuiTestSpecification {
 
         then:
         thrown(IllegalArgumentException)
+    }
+
+    def "getCollectionProperties returns composition collections only"() {
+        given:
+        def masterMetaClass = metadata.getClass(ViewTemplateMasterEntity)
+
+        when:
+        List<String> names = templateHelper.getCollectionProperties(masterMetaClass, [])*.name
+
+        then:
+        names == ['lines']
+    }
+
+    def "getCollectionProperties excludes association, datatype collections and single-value properties"() {
+        given:
+        def masterMetaClass = metadata.getClass(ViewTemplateMasterEntity)
+        def filteringMetaClass = metadata.getClass(ViewTemplateFilteringEntity)
+
+        when:
+        List<String> masterNames = templateHelper.getCollectionProperties(masterMetaClass, [])*.name
+
+        then:
+        !masterNames.contains('relatedCustomers')
+        !masterNames.contains('name')
+        templateHelper.getCollectionProperties(filteringMetaClass, []).isEmpty()
+    }
+
+    def "getCollectionProperties honors excludeProperties"() {
+        given:
+        def masterMetaClass = metadata.getClass(ViewTemplateMasterEntity)
+
+        expect:
+        templateHelper.getCollectionProperties(masterMetaClass, ['lines']).isEmpty()
+    }
+
+    def "getProperties excludes the inverse attribute of a composition collection"() {
+        given:
+        def lineMetaClass = metadata.getClass(ViewTemplateLineEntity)
+
+        when:
+        List<String> propertyNames = templateHelper.getProperties(lineMetaClass, [], [])*.name
+
+        then:
+        propertyNames.containsAll(['description', 'quantity'])
+        !propertyNames.contains('master')
+    }
+
+    def "Include properties restores the composition inverse attribute"() {
+        given:
+        def lineMetaClass = metadata.getClass(ViewTemplateLineEntity)
+
+        when:
+        List<String> propertyNames = templateHelper.getProperties(lineMetaClass, ['master'], [])*.name
+
+        then:
+        propertyNames.contains('master')
     }
 }

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateLineEntity.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateLineEntity.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.viewtemplate;
+
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.flowui.view.template.DetailViewTemplate;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+
+/**
+ * Composition line entity used to verify composition collection support in the detail view template.
+ */
+@JmixEntity
+@Table(name = "TEST_VIEW_TEMPLATE_LINE")
+@Entity(name = "test_ViewTemplateLineEntity")
+@DetailViewTemplate(viewId = "test_ViewTemplateLineEntity.detail")
+public class ViewTemplateLineEntity extends TestBaseEntity {
+
+    @Column(name = "DESCRIPTION")
+    protected String description;
+
+    @Column(name = "QUANTITY")
+    protected Integer quantity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MASTER_ID")
+    protected ViewTemplateMasterEntity master;
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Integer getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Integer quantity) {
+        this.quantity = quantity;
+    }
+
+    public ViewTemplateMasterEntity getMaster() {
+        return master;
+    }
+
+    public void setMaster(ViewTemplateMasterEntity master) {
+        this.master = master;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateMasterEntity.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateMasterEntity.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.viewtemplate;
+
+import io.jmix.core.DeletePolicy;
+import io.jmix.core.entity.annotation.OnDelete;
+import io.jmix.core.metamodel.annotation.Composition;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.flowui.view.template.DetailViewTemplate;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+import test_support.entity.sales.Customer;
+
+import java.util.List;
+
+/**
+ * Parent entity with a composition collection ({@code lines}) and an association collection
+ * ({@code relatedCustomers}), used to verify that only composition collections become tabs
+ * in the generated detail view.
+ */
+@JmixEntity
+@Table(name = "TEST_VIEW_TEMPLATE_MASTER")
+@Entity(name = "test_ViewTemplateMasterEntity")
+@DetailViewTemplate(viewId = "test_ViewTemplateMasterEntity.detail")
+public class ViewTemplateMasterEntity extends TestBaseEntity {
+
+    @Column(name = "NAME")
+    protected String name;
+
+    @Composition
+    @OnDelete(DeletePolicy.CASCADE)
+    @OneToMany(mappedBy = "master")
+    protected List<ViewTemplateLineEntity> lines;
+
+    @ManyToMany
+    @JoinTable(name = "TEST_VIEW_TEMPLATE_MASTER_CUSTOMER_LINK")
+    protected List<Customer> relatedCustomers;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<ViewTemplateLineEntity> getLines() {
+        return lines;
+    }
+
+    public void setLines(List<ViewTemplateLineEntity> lines) {
+        this.lines = lines;
+    }
+
+    public List<Customer> getRelatedCustomers() {
+        return relatedCustomers;
+    }
+
+    public void setRelatedCustomers(List<Customer> relatedCustomers) {
+        this.relatedCustomers = relatedCustomers;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/view_template/ViewTemplateIntegrationTest.java
+++ b/jmix-flowui/flowui/src/test/java/view_template/ViewTemplateIntegrationTest.java
@@ -77,6 +77,8 @@ public class ViewTemplateIntegrationTest {
     protected static final String FILTERED_DETAIL_VIEW_ID = "test_ViewTemplateFilteringEntity.edit";
     protected static final String BINDINGS_LIST_VIEW_ID = "test_ViewTemplateBindingsEntity.list";
     protected static final String BINDINGS_DETAIL_VIEW_ID = "test_ViewTemplateBindingsEntity.detail";
+    protected static final String MASTER_DETAIL_VIEW_ID = "test_ViewTemplateMasterEntity.detail";
+    protected static final String LINE_DETAIL_VIEW_ID = "test_ViewTemplateLineEntity.detail";
     protected static final String LIST_VIEW_ROUTE = "templates/view-template/list";
     protected static final String DETAIL_VIEW_BASE_ROUTE = "templates/view-template/detail";
     protected static final String DETAIL_VIEW_ROUTE = DETAIL_VIEW_BASE_ROUTE + "/:id";
@@ -253,6 +255,56 @@ public class ViewTemplateIntegrationTest {
         assertTrue(listDescriptor.contains("action=\"dataGrid.removeAction\""));
 
         assertTrue(detailDescriptor.contains("<instance id=\"entityDc\""));
+        assertTrue(detailDescriptor.contains("<formLayout id=\"form\" dataContainer=\"entityDc\""));
+    }
+
+    @Test
+    void testDetailTemplateRendersCompositionCollectionsAsTabSheet() {
+        String detailDescriptor = getDescriptor(MASTER_DETAIL_VIEW_ID);
+
+        // Composition collection is fetched and gets a nested container
+        assertTrue(detailDescriptor.contains("<property name=\"lines\" fetchPlan=\"_base\"/>"));
+        assertTrue(detailDescriptor.contains("<collection id=\"linesDc\" property=\"lines\"/>"));
+
+        // TabSheet with a general tab holding the form
+        assertTrue(detailDescriptor.contains("<tabSheet id=\"contentTabSheet\""));
+        assertTrue(detailDescriptor.contains(
+                "<tab id=\"generalTab\" label=\"msg:///viewTemplate.generalTab\""));
+        assertTrue(detailDescriptor.contains("<formLayout id=\"form\" dataContainer=\"entityDc\""));
+
+        // Collection tab with a dataGrid, list actions and line-entity columns
+        assertTrue(detailDescriptor.contains("<tab id=\"linesTab\" "
+                + "label=\"msg://test_support.entity.viewtemplate/ViewTemplateMasterEntity.lines\""));
+        assertTrue(detailDescriptor.contains("<hbox id=\"linesButtonsPanel\""));
+        assertTrue(detailDescriptor.contains("<dataGrid id=\"linesDataGrid\""));
+        assertTrue(detailDescriptor.contains("dataContainer=\"linesDc\""));
+        assertTrue(detailDescriptor.contains("<action id=\"createAction\" type=\"list_create\">"));
+        assertTrue(detailDescriptor.contains("<action id=\"editAction\" type=\"list_edit\">"));
+        assertTrue(detailDescriptor.contains("<action id=\"removeAction\" type=\"list_remove\"/>"));
+        assertTrue(detailDescriptor.contains("<property name=\"openMode\" value=\"DIALOG\"/>"));
+        assertTrue(detailDescriptor.contains("<column property=\"description\"/>"));
+        assertTrue(detailDescriptor.contains("<column property=\"quantity\"/>"));
+        assertFalse(detailDescriptor.contains("<column property=\"master\"/>"));
+
+        // Association collection is NOT rendered
+        assertFalse(detailDescriptor.contains("relatedCustomers"));
+    }
+
+    @Test
+    void testCompositionItemDetailTemplateHidesInverseAttribute() {
+        String detailDescriptor = getDescriptor(LINE_DETAIL_VIEW_ID);
+
+        // Composition back-reference to the master must not be rendered as a field
+        assertFalse(detailDescriptor.contains("id=\"masterField\""));
+        assertTrue(detailDescriptor.contains("id=\"descriptionField\""));
+        assertTrue(detailDescriptor.contains("id=\"quantityField\""));
+    }
+
+    @Test
+    void testDetailTemplateWithoutCollectionsHasNoTabSheet() {
+        String detailDescriptor = getDescriptor(DETAIL_VIEW_ID);
+
+        assertFalse(detailDescriptor.contains("<tabSheet"));
         assertTrue(detailDescriptor.contains("<formLayout id=\"form\" dataContainer=\"entityDc\""));
     }
 

--- a/jmix-translations/content/io/jmix/flowui/messages.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages.properties
@@ -488,3 +488,5 @@ io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.defaultFor
 io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.rootCondition = Root condition
 io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.sysTenantId = Tenant id
 io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.defaultForMe = Default for me
+
+viewTemplate.generalTab=General

--- a/jmix-translations/content/io/jmix/flowui/messages_ru.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages_ru.properties
@@ -489,3 +489,5 @@ io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.defaultFor
 io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.rootCondition = Корневое условие
 io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.sysTenantId = Идентификатор владельца
 io.jmix.flowui.component.genericfilter.model/FilterConfigurationModel.defaultForMe = По умолчанию для меня
+
+viewTemplate.generalTab=Основное


### PR DESCRIPTION
## Motivation

Runtime view templates (#5225) generate list/detail views from `@DetailViewTemplate` metadata, but had a known limitation: **composition collections were unsupported** — a generated detail view only rendered single-value fields, with no way to view or edit a composition's child rows.

## What it does

When a `@DetailViewTemplate` entity has composition `*-to-many` properties, the generated detail view now renders a `TabSheet`:
- the first **General** tab holds the form of single-value fields;
- each composition collection gets its own tab with a `dataGrid` (create / edit / remove). Create/edit open the line entity's own detail view in a dialog, so line entities are expected to also carry `@DetailViewTemplate`.

Entities without composition collections render a plain `formLayout` exactly as before.

## Implementation

- **`ViewTemplateHelper#getCollectionProperties`** — returns composition `*-to-many` properties (associations and datatype collections excluded), honoring `excludeProperties`.
- **`detail-template.ftl`** — adds a fetch-plan entry and a nested `<collection>` container per composition property, and a conditional `<tabSheet>`; collection-tab dataGrids use `list_create`/`list_edit`/`list_remove` with `openMode=DIALOG`.
- **Hidden back-reference** — the inverse attribute of a composition collection (the child's parent reference) is excluded by default in both the master's columns and the line entity's own detail form (restorable via `includeProperties`).
- **Localized labels** — tab labels are emitted as `msg://` references so captions resolve per-user at view-load time (the "General" tab uses a new `viewTemplate.generalTab` key).