### PR TITLE
Ability to save entities without triggering events

### DIFF
--- a/jmix-data/data/src/main/java/io/jmix/data/PersistenceHints.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/PersistenceHints.java
@@ -26,6 +26,22 @@ public class PersistenceHints {
 
     public static final String SOFT_DELETION = "jmix.softDeletion";
 
+    /**
+     * Hint that disables sending of {@code io.jmix.core.event.EntitySavingEvent} when saving entities
+     * through {@code DataManager}. Set the value to {@code true} in {@code SaveContext} hints to suppress the event.
+     * <p>
+     * Note: this also disables listeners that rely on the event, such as multitenancy tenant-id assignment.
+     */
+    public static final String SKIP_ENTITY_SAVING_EVENT = "jmix.skipEntitySavingEvent";
+
+    /**
+     * Hint that disables sending of {@code io.jmix.core.event.EntityChangedEvent} when saving entities
+     * through {@code DataManager}. Set the value to {@code true} in {@code SaveContext} hints to suppress the event.
+     * <p>
+     * Note: this also disables listeners that rely on the event, such as full-text search re-indexing.
+     */
+    public static final String SKIP_ENTITY_CHANGED_EVENT = "jmix.skipEntityChangedEvent";
+
     public static final String FETCH_PLAN = "jmix.fetchPlan";
 
     public static final String CACHEABLE = "jmix.cacheable";

--- a/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/JpaDataStore.java
+++ b/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/JpaDataStore.java
@@ -359,10 +359,15 @@ public class JpaDataStore extends AbstractDataStore implements DataSortingOption
     protected Set<Object> saveAll(SaveContext context) {
         EntityManager em = storeAwareLocator.getEntityManager(storeName);
 
+        boolean skipSavingEvent = Boolean.TRUE.equals(
+                context.getHints().get(PersistenceHints.SKIP_ENTITY_SAVING_EVENT));
+
         Set<Object> result = new HashSet<>();
         for (Object entity : context.getEntitiesToSave()) {
             if (entityStates.isNew(entity)) {
-                entityEventManager.publishEntitySavingEvent(entity, true);
+                if (!skipSavingEvent) {
+                    entityEventManager.publishEntitySavingEvent(entity, true);
+                }
                 em.persist(entity);
                 result.add(entity);
             }
@@ -370,7 +375,9 @@ public class JpaDataStore extends AbstractDataStore implements DataSortingOption
 
         for (Object entity : context.getEntitiesToSave()) {
             if (!entityStates.isNew(entity)) {
-                entityEventManager.publishEntitySavingEvent(entity, false);
+                if (!skipSavingEvent) {
+                    entityEventManager.publishEntitySavingEvent(entity, false);
+                }
                 Object merged = em.merge(entity);
                 result.add(merged);
             }
@@ -564,7 +571,11 @@ public class JpaDataStore extends AbstractDataStore implements DataSortingOption
                 }
             }
 
-            entityChangedEventManager.publish(events);
+            boolean skipChangedEvent = Boolean.TRUE.equals(
+                    context.getHints().get(PersistenceHints.SKIP_ENTITY_CHANGED_EVENT));
+            if (!skipChangedEvent) {
+                entityChangedEventManager.publish(events);
+            }
         }
     }
 

--- a/jmix-data/eclipselink/src/test/groovy/events/SaveWithoutEventsTest.groovy
+++ b/jmix-data/eclipselink/src/test/groovy/events/SaveWithoutEventsTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package events
+
+import io.jmix.core.DataManager
+import io.jmix.core.Id
+import io.jmix.core.SaveContext
+import io.jmix.data.PersistenceHints
+import org.springframework.beans.factory.annotation.Autowired
+import test_support.DataSpec
+import test_support.entity.events.Bar
+import test_support.listeners.TestSaveWithoutEventsListener
+
+class SaveWithoutEventsTest extends DataSpec {
+
+    @Autowired
+    DataManager dataManager
+
+    @Autowired
+    TestSaveWithoutEventsListener listener
+
+    void setup() {
+        listener.reset()
+    }
+
+    void cleanup() {
+        jdbc.update('delete from TEST_EVENTS_BAR')
+    }
+
+    def "both events fire by default"() {
+        def bar = dataManager.create(Bar)
+        bar.name = 'b1'
+        bar.amount = 1
+
+        when:
+        dataManager.save(bar)
+
+        then:
+        listener.savingCount == 1
+        listener.changedCount == 1
+    }
+
+    def "EntitySavingEvent is suppressed by hint"() {
+        def bar = dataManager.create(Bar)
+        bar.name = 'b2'
+        bar.amount = 2
+
+        when:
+        dataManager.save(new SaveContext()
+                .saving(bar)
+                .setHint(PersistenceHints.SKIP_ENTITY_SAVING_EVENT, true))
+
+        then:
+        listener.savingCount == 0
+        listener.changedCount == 1
+        dataManager.load(Id.of(bar)).one().amount == 2
+    }
+
+    def "EntityChangedEvent is suppressed by hint"() {
+        def bar = dataManager.create(Bar)
+        bar.name = 'b3'
+        bar.amount = 3
+
+        when:
+        dataManager.save(new SaveContext()
+                .saving(bar)
+                .setHint(PersistenceHints.SKIP_ENTITY_CHANGED_EVENT, true))
+
+        then:
+        listener.savingCount == 1
+        listener.changedCount == 0
+        dataManager.load(Id.of(bar)).one().amount == 3
+    }
+
+    def "both events suppressed and entity still persisted"() {
+        def bar = dataManager.create(Bar)
+        bar.name = 'b4'
+        bar.amount = 4
+
+        when:
+        dataManager.save(new SaveContext()
+                .saving(bar)
+                .setHint(PersistenceHints.SKIP_ENTITY_SAVING_EVENT, true)
+                .setHint(PersistenceHints.SKIP_ENTITY_CHANGED_EVENT, true))
+
+        then:
+        listener.savingCount == 0
+        listener.changedCount == 0
+        dataManager.load(Id.of(bar)).one().amount == 4
+    }
+}

--- a/jmix-data/eclipselink/src/test/java/test_support/listeners/TestSaveWithoutEventsListener.java
+++ b/jmix-data/eclipselink/src/test/java/test_support/listeners/TestSaveWithoutEventsListener.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.listeners;
+
+import io.jmix.core.event.EntityChangedEvent;
+import io.jmix.core.event.EntitySavingEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import test_support.entity.events.Bar;
+
+@Component("test_TestSaveWithoutEventsListener")
+public class TestSaveWithoutEventsListener {
+
+    int savingCount;
+    int changedCount;
+
+    @EventListener
+    void onSaving(EntitySavingEvent<Bar> event) {
+        savingCount++;
+    }
+
+    @EventListener
+    void onChanged(EntityChangedEvent<Bar> event) {
+        changedCount++;
+    }
+
+    void reset() {
+        savingCount = 0;
+        changedCount = 0;
+    }
+}


### PR DESCRIPTION
Adds two `SaveContext` hints that let callers suppress lifecycle events when saving via `DataManager`, for use cases like bulk import and technical/system updates that shouldn't trigger business logic.

**New hints** (`io.jmix.data.PersistenceHints`):
- `SKIP_ENTITY_SAVING_EVENT` — suppresses `EntitySavingEvent`
- `SKIP_ENTITY_CHANGED_EVENT` — suppresses `EntityChangedEvent`

The two are independent; default behavior (hints absent) is unchanged.

```java
dataManager.save(new SaveContext()
        .saving(entity)
        .setHint(PersistenceHints.SKIP_ENTITY_CHANGED_EVENT, true)
        .setHint(PersistenceHints.SKIP_ENTITY_SAVING_EVENT, true));
```

**Implementation:** `JpaDataStore.saveAll()` skips `EntitySavingEvent` publishing; `beforeSaveTransactionCommit()` skips `EntityChangedEvent` publishing while still running change collection and entity detachment.

**Caveats** (documented on the constants): suppressing `EntitySavingEvent` also skips multitenancy tenant-id assignment; suppressing `EntityChangedEvent` also skips full-text search re-indexing and security cache invalidation. Audit fields (JPA descriptor level) and the audit entity log (`JpaLifecycleListener`) are **not** affected.