### PR TITLE
Unreliable entity enhancement and descriptor generation

### DIFF
--- a/jmix-core/framework-test-support/framework-test-support.gradle
+++ b/jmix-core/framework-test-support/framework-test-support.gradle
@@ -19,6 +19,12 @@ apply plugin: 'io.jmix'
 group = 'io.jmix.core'
 archivesBaseName = 'jmix-framework-test-support'
 
+jmix {
+    entitiesEnhancing {
+        enabled = false
+    }
+}
+
 dependencies {
     api project(':core')
     api project(':data')
@@ -27,8 +33,3 @@ dependencies {
     api 'org.apache.commons:commons-dbcp2'
     api 'org.liquibase:liquibase-core'
 }
-
-tasks.matching { it.name in ['enhanceJmixMain', 'copyJmixEnhancingResourcesMain'] }
-        .configureEach {
-            enabled = false
-        }

--- a/jmix-gradle-plugin/src/main/groovy/io/jmix/gradle/EnhancingAction.groovy
+++ b/jmix-gradle-plugin/src/main/groovy/io/jmix/gradle/EnhancingAction.groovy
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
 
 import static io.jmix.gradle.DescriptorGenerationUtils.CONVERTERS_LIST_PROPERTY
@@ -50,29 +51,149 @@ class EnhancingAction implements Action<Task> {
         this.sourceSetName = sourceSetName
     }
 
+    static String enhancedClassesDir(Project project, String sourceSetName) {
+        return "$project.buildDir/classes/jmix/$sourceSetName"
+    }
+
     @Override
     void execute(Task task) {
         Project project = task.getProject()
         project.logger.lifecycle "Enhancing entities in $project for source set '$sourceSetName'"
         SourceSet sourceSet = project.sourceSets.findByName(sourceSetName)
 
-        ClassesInfo classesInfo = collectClasses(project, sourceSet)
+        String compiledDir = sourceSet.java.destinationDirectory.get().getAsFile().absolutePath
+        String enhancedDir = enhancedClassesDir(project, sourceSetName)
+
+        if (!hasCompiledClasses(project, compiledDir)) {
+            project.logger.info "No compiled classes in $compiledDir; entity enhancing for source set '$sourceSetName' is not required"
+            return
+        }
+
+        ClassesInfo classesInfo = collectClasses(project, sourceSet, compiledDir)
 
         addAbsentEmptyStores(classesInfo, sourceSet, project)
 
-        constructDescriptors(project, sourceSet, classesInfo)
+        constructDescriptors(project, sourceSet, classesInfo, compiledDir)
+
+        Set<String> enhancedClassNames = classesInfo.getAllEntities() as Set
+
+        reconcileEnhancedDir(project, compiledDir, enhancedDir, enhancedClassNames)
 
         boolean entitiesEnhancingRequired = !project.jmix.entitiesEnhancing.skipUnmodifiedEntitiesEnhancing ||
-                entityClassesChangedSinceLastBuild(project, sourceSet, classesInfo)
+                entityClassesChangedSinceLastBuild(project, classesInfo, compiledDir) ||
+                enhancedEntitiesMissing(compiledDir, enhancedDir, enhancedClassNames)
 
         if (entitiesEnhancingRequired) {
-            persistenceProviderEnhancing().run(project, sourceSet, classesInfo.allStores())
-            runJmixEnhancing(project, sourceSet, classesInfo)
+            copyClasses(compiledDir, enhancedDir, enhancedClassNames)
+            persistenceProviderEnhancing().run(project, sourceSet, enhancedDir, classesInfo.allStores())
+            runJmixEnhancing(project, sourceSet, enhancedDir, classesInfo)
             if (project.jmix.entitiesEnhancing.skipUnmodifiedEntitiesEnhancing) {
-                saveEntityClassesChecksumForNextBuild(project, sourceSet, classesInfo)
+                saveEntityClassesChecksumForNextBuild(project, classesInfo, compiledDir)
             }
         } else {
             project.logger.lifecycle "Entities enhancing was skipped, because entity classes haven't been changed since the last build"
+        }
+    }
+
+    /**
+     * Reconciles the enhanced output directory against the compiled (input) directory:
+     * <ul>
+     *     <li>removes stale {@code *.class} files in {@code enhancedDir} whose <em>outer</em> class has no
+     *         counterpart in {@code compiledDir};</li>
+     *     <li>copies every non-enhanced class (not in {@code enhancedClassNames}) from {@code compiledDir} to {@code enhancedDir}.</li>
+     * </ul>
+     * Staleness is keyed on the outer class so that classes the enhancer <em>generates</em> (e.g.
+     * {@code SomeEntity$JmixEntityEntry}), which have no compiled counterpart of their own, are kept as long
+     * as their entity is still compiled, yet a removed class drops all of its (inner and generated) artifacts.
+     */
+    protected void reconcileEnhancedDir(Project project, String compiledDir, String enhancedDir, Set<String> enhancedClassNames) {
+        File compiledRoot = new File(compiledDir)
+        File enhancedRoot = new File(enhancedDir)
+
+        Set<String> enhancedRelativePaths = enhancedClassNames.collect { it.replace('.', '/') + '.class' } as Set
+
+        if (enhancedRoot.exists()) {
+            project.fileTree(enhancedRoot).each { File file ->
+                if (file.name.endsWith('.class')) {
+                    String relativePath = enhancedRoot.toPath().relativize(file.toPath()).toString().replace(File.separator, '/')
+                    File compiledOuterClass = new File(compiledRoot, outerClassFile(relativePath))
+                    if (!compiledOuterClass.exists()) {
+                        project.logger.info "Removing stale enhanced class: $relativePath"
+                        file.delete()
+                    }
+                }
+            }
+        }
+
+        if (compiledRoot.exists()) {
+            project.fileTree(compiledRoot).each { File file ->
+                if (file.name.endsWith('.class')) {
+                    String relativePath = compiledRoot.toPath().relativize(file.toPath()).toString().replace(File.separator, '/')
+                    if (!enhancedRelativePaths.contains(relativePath)) {
+                        File target = new File(enhancedRoot, relativePath)
+                        target.getParentFile().mkdirs()
+                        Files.copy(file.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns {@code true} if the compiled-classes directory exists and contains at least one {@code *.class}
+     * file. A source set with no compiled classes (e.g. a module with no test sources) has nothing to enhance,
+     * so enhancement is skipped to avoid running the persistence provider weaver with no input.
+     */
+    protected boolean hasCompiledClasses(Project project, String compiledDir) {
+        File compiledRoot = new File(compiledDir)
+        return compiledRoot.exists() && !project.fileTree(compiledRoot).matching { include '**/*.class' }.empty
+    }
+
+    /**
+     * Maps a class-file relative path to the relative path of its outer (top-level) class file, e.g.
+     * {@code a/b/Entity$JmixEntityEntry.class} -> {@code a/b/Entity.class}. Returns the input unchanged for
+     * a top-level class.
+     */
+    protected static String outerClassFile(String relativeClassFile) {
+        int dollarIndex = relativeClassFile.indexOf('$')
+        return dollarIndex < 0 ? relativeClassFile : relativeClassFile.substring(0, dollarIndex) + '.class'
+    }
+
+    /**
+     * Returns {@code true} if any entity class that belongs to this project (i.e. present in {@code compiledDir})
+     * is absent from {@code enhancedDir}. Guards the {@code skipUnmodifiedEntitiesEnhancing} optimization: the
+     * enhanced output dir and the saved checksum live in different {@code build} subtrees, so the enhanced dir
+     * can be cleared (e.g. {@code rm -rf build/classes}, an IDE rebuild, a partial clean) while the checksum
+     * survives. Without this check the task would run but skip weaving, leaving entities missing from the
+     * enhanced dir that downstream modules consume.
+     */
+    protected boolean enhancedEntitiesMissing(String compiledDir, String enhancedDir, Set<String> enhancedClassNames) {
+        File compiledRoot = new File(compiledDir)
+        File enhancedRoot = new File(enhancedDir)
+        for (String className : enhancedClassNames) {
+            String relativePath = className.replace('.', '/') + '.class'
+            if (new File(compiledRoot, relativePath).exists() && !new File(enhancedRoot, relativePath).exists()) {
+                return true
+            }
+        }
+        return false
+    }
+
+    /**
+     * Copies fresh, un-enhanced copies of the given classes from {@code compiledDir} to {@code enhancedDir},
+     * overwriting any previously enhanced copies, so they can be (re-)woven.
+     */
+    protected void copyClasses(String compiledDir, String enhancedDir, Set<String> classNames) {
+        File compiledRoot = new File(compiledDir)
+        File enhancedRoot = new File(enhancedDir)
+        for (String className : classNames) {
+            String relativePath = className.replace('.', '/') + '.class'
+            File source = new File(compiledRoot, relativePath)
+            if (source.exists()) {
+                File target = new File(enhancedRoot, relativePath)
+                target.getParentFile().mkdirs()
+                Files.copy(source.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+            }
         }
     }
 
@@ -117,14 +238,16 @@ class EnhancingAction implements Action<Task> {
         }
     }
 
-    protected ClassesInfo collectClasses(Project project, SourceSet sourceSet) {
+    protected ClassesInfo collectClasses(Project project, SourceSet sourceSet, String projectClassesDir) {
         ClassesInfo classesInfo = new ClassesInfo()
 
         if (sourceSetName == TEST_SET_NAME) {
-            collectEntitiesFromSources(project, project.sourceSets.findByName(MAIN_SET_NAME), classesInfo)
+            def mainSourceSet = project.sourceSets.findByName(MAIN_SET_NAME)
+            String mainClassesDir = mainSourceSet.java.destinationDirectory.get().getAsFile().absolutePath
+            collectEntitiesFromSources(project, mainSourceSet, classesInfo, mainClassesDir)
         }
 
-        collectEntitiesFromSources(project, sourceSet, classesInfo)
+        collectEntitiesFromSources(project, sourceSet, classesInfo, projectClassesDir)
 
         if (sourceSetName == TEST_SET_NAME && classesInfo.modulePaths.size() > 1) {
             //test sourceSet can have 0 or more Configurations. Production Configuration path should be removed in case of test Configuration presence
@@ -138,7 +261,7 @@ class EnhancingAction implements Action<Task> {
             classesInfo.converters.add(it)
         }
 
-        collectEntitiesFromClasspathes(project, sourceSet, classesInfo)
+        collectEntitiesFromClasspathes(project, sourceSet, classesInfo, projectClassesDir)
 
         project.logger.info("Found entities:\n    JPA: ${classesInfo.getJpaEntities()};\n    DTO: ${classesInfo.getDtoEntities()}.\n" +
                 "Converters: ${classesInfo.getConverters()}")
@@ -146,8 +269,8 @@ class EnhancingAction implements Action<Task> {
         return classesInfo
     }
 
-    protected void collectEntitiesFromSources(Project project, sourceSet, ClassesInfo classesInfo) {
-        ClassPool classPool = createClassPool(project, sourceSet)
+    protected void collectEntitiesFromSources(Project project, sourceSet, ClassesInfo classesInfo, String projectClassesDir) {
+        ClassPool classPool = createClassPool(project, sourceSet, projectClassesDir)
 
         sourceSet.allJava.getSrcDirs().each { File srcDir ->
             project.fileTree(srcDir).each { File file ->
@@ -172,8 +295,8 @@ class EnhancingAction implements Action<Task> {
         }
     }
 
-    protected void collectEntitiesFromClasspathes(Project project, sourceSet, ClassesInfo classesInfo) {
-        ClassPool classPool = createClassPool(project, sourceSet)
+    protected void collectEntitiesFromClasspathes(Project project, sourceSet, ClassesInfo classesInfo, String projectClassesDir) {
+        ClassPool classPool = createClassPool(project, sourceSet, projectClassesDir)
 
         ClassesInfo compileClasses = collectEntitiesFromClasspath(project, sourceSet.compileClasspath, classPool)
         ClassesInfo runtimeClasses = collectEntitiesFromClasspath(project, sourceSet.runtimeClasspath, classPool)
@@ -232,7 +355,7 @@ class EnhancingAction implements Action<Task> {
         }
     }
 
-    protected void constructDescriptors(Project project, sourceSet, ClassesInfo classesInfo) {
+    protected void constructDescriptors(Project project, sourceSet, ClassesInfo classesInfo, String projectClassesDir) {
         for (String storeName : classesInfo.allStores()) {
             for (String modulePath : classesInfo.modulePaths) {
 
@@ -257,50 +380,43 @@ class EnhancingAction implements Action<Task> {
                 DescriptorGenerationUtils.constructOrmXml(
                         ormFileName,
                         jpaClasses,
-                        createClassPool(project, sourceSet))
+                        createClassPool(project, sourceSet, projectClassesDir))
 
-                //store all generated persistence/orm xml files in temporary resources dir, because output resources dir is not prepared yet
-                String tmpPath = "$project.buildDir/tmp/entitiesEnhancing/resources/$sourceSetName/$modulePath"
-                project.logger.info "Copying files $persistenceFileName and $ormFileName to $tmpPath"
+                //write generated persistence/orm xml into a dedicated generated resources dir,
+                //which is registered as a resources srcDir and consumed by processResources (single owner of build/resources)
+                String generatedPath = "${generatedDescriptorsDir(project, sourceSetName)}/$modulePath"
+                project.logger.info "Copying files $persistenceFileName and $ormFileName to $generatedPath"
                 project.copy {
                     from persistenceFileName, ormFileName
-                    into tmpPath
+                    into generatedPath
                     rename "persistence.xml", "${storePrefix}persistence.xml"
                 }
             }
         }
     }
 
-    static void copyGeneratedFiles(Project project, String sourceSetName) {
-        String sourcePath = "$project.buildDir/tmp/entitiesEnhancing/resources/$sourceSetName/"
-        String destPath = "$project.buildDir/resources/$sourceSetName/"
-        project.logger.info "Copying files from $sourcePath to $destPath"
-        project.copy {
-            from sourcePath
-            into destPath
-        }
+    static String generatedDescriptorsDir(Project project, String sourceSetName) {
+        return "$project.buildDir/generated/jmix-descriptors/$sourceSetName"
     }
 
-    protected void runJmixEnhancing(Project project, sourceSet, ClassesInfo classesInfo) {
+    protected void runJmixEnhancing(Project project, sourceSet, String enhancedDir, ClassesInfo classesInfo) {
         if (!classesInfo.getAllEntities().isEmpty()) {
             project.logger.lifecycle "Running Jmix enhancer in $project for $sourceSet"
 
-            String javaOutputDir = sourceSet.java.destinationDirectory.get().getAsFile().absolutePath
-
             for (EnhancingStep step : enhancingSteps()) {
 
-                ClassPool classPool = createClassPool(project, sourceSet)
+                ClassPool classPool = createClassPool(project, sourceSet, enhancedDir)
 
                 step.classPool = classPool
-                step.outputDir = javaOutputDir
+                step.outputDir = enhancedDir
                 step.logger = project.logger
 
                 for (className in classesInfo.getAllEntities()) {
                     def classFileName = className.replace('.', '/') + '.class'
-                    def classFile = new File(javaOutputDir, classFileName)
+                    def classFile = new File(enhancedDir, classFileName)
 
                     if (classFile.exists()) {
-                        // skip files from dependencies, enhance only classes from `javaOutputDir`
+                        // skip files from dependencies, enhance only classes from the enhanced output dir
                         step.execute(className)
                     }
                 }
@@ -314,8 +430,8 @@ class EnhancingAction implements Action<Task> {
      * On the next project build, the checksum of entities classes from the "build" directory will be compared with the
      * checksum saved to the file to find out if entities have been changed since the last compilation.
      */
-    protected void saveEntityClassesChecksumForNextBuild(Project project, sourceSet, ClassesInfo classesInfo) {
-        def allEntityClassesChecksum = evaluateEntityClassesChecksum(project, sourceSet, classesInfo)
+    protected void saveEntityClassesChecksumForNextBuild(Project project, ClassesInfo classesInfo, String compiledDir) {
+        def allEntityClassesChecksum = evaluateEntityClassesChecksum(project, classesInfo, compiledDir)
         Path checksumFilePath = getEntitiesChecksumFilePath(project)
         if (!Files.exists(checksumFilePath.getParent())) {
             Files.createDirectories(checksumFilePath.getParent())
@@ -326,16 +442,15 @@ class EnhancingAction implements Action<Task> {
     /**
      * Evaluates a single checksum for all entity classes (of the current project) extracted from the ClassesInfo.
      */
-    protected String evaluateEntityClassesChecksum(Project project, sourceSet, ClassesInfo classesInfo) {
+    protected String evaluateEntityClassesChecksum(Project project, ClassesInfo classesInfo, String compiledDir) {
         StringBuilder sb = new StringBuilder()
-        String javaOutputDir = sourceSet.java.destinationDirectory.get().getAsFile().absolutePath
         Collection<String> allEntities = classesInfo.getAllEntities()
         allEntities.sort()
         for (className in allEntities) {
             def classFileName = className.replace('.', '/') + '.class'
-            def classFile = new File(javaOutputDir, classFileName)
+            def classFile = new File(compiledDir, classFileName)
 
-            // skip files from dependencies, copy only classes from `javaOutputDir`
+            // skip files from dependencies, consider only compiled classes from `compiledDir`
             if (classFile.exists()) {
                 def fileChecksum = checkSum(classFile)
                 sb.append(fileChecksum)
@@ -350,14 +465,14 @@ class EnhancingAction implements Action<Task> {
      * the same. Method compares the checksum of entity classes saved during previous compilation with the checksum of
      * actual entity classes collection.
      */
-    protected boolean entityClassesChangedSinceLastBuild(Project project, SourceSet sourceSet, ClassesInfo classesInfo) {
+    protected boolean entityClassesChangedSinceLastBuild(Project project, ClassesInfo classesInfo, String compiledDir) {
         Path entitiesChecksumFilePath = getEntitiesChecksumFilePath(project)
         if (!Files.exists(entitiesChecksumFilePath)) {
             //previous entity classes checksum was not saved
             return true
         }
         def prevChecksum = Files.readString(entitiesChecksumFilePath)
-        def currentChecksum = evaluateEntityClassesChecksum(project, sourceSet, classesInfo)
+        def currentChecksum = evaluateEntityClassesChecksum(project, classesInfo, compiledDir)
         project.logger.debug("Previous entities checksum: {}, current entities checksum: {}", prevChecksum, currentChecksum)
         return prevChecksum != currentChecksum
     }
@@ -376,10 +491,10 @@ class EnhancingAction implements Action<Task> {
      * Returns a path to a file where entity classes checksum will be stored to.
      */
     protected Path getEntitiesChecksumFilePath(Project project) {
-        return Paths.get("$project.buildDir/tmp/entitiesEnhancing/entities.checksum")
+        return Paths.get("$project.buildDir/tmp/entitiesEnhancing/$sourceSetName/entities.checksum")
     }
 
-    static ClassPool createClassPool(Project project, sourceSet) {
+    static ClassPool createClassPool(Project project, sourceSet, String projectClassesDir) {
         ClassPool classPool = new ClassPool(null)
         classPool.appendSystemPath()
 
@@ -387,7 +502,7 @@ class EnhancingAction implements Action<Task> {
             classPool.insertClassPath(file.getAbsolutePath())
         }
 
-        classPool.insertClassPath(sourceSet.java.destinationDirectory.get().getAsFile().absolutePath)
+        classPool.insertClassPath(projectClassesDir)
 
         project.configurations.enhancing.files.each { File dep ->
             classPool.insertClassPath(dep.absolutePath)

--- a/jmix-gradle-plugin/src/main/groovy/io/jmix/gradle/JmixPlugin.groovy
+++ b/jmix-gradle-plugin/src/main/groovy/io/jmix/gradle/JmixPlugin.groovy
@@ -78,16 +78,6 @@ class JmixPlugin implements Plugin<Project> {
                 def mainCompileTasks = []
                 def testCompileTasks = []
 
-                // Run enhancing when compile tasks actually produced outputs, including outputs restored from build cache.
-                // This avoids skipping enhancement on FROM_CACHE while still skipping for up-to-date/no-source compiles.
-                def shouldRunEnhancing = { taskProviders ->
-                    !taskProviders.isEmpty() && taskProviders.any { taskProvider ->
-                        def state = taskProvider.get().state
-                        def outcome = state.hasProperty('outcome') ? state.outcome?.toString() : null
-                        state.didWork || outcome == 'FROM_CACHE' || (state.skipMessage?.contains('FROM-CACHE') ?: false)
-                    }
-                }
-
                 if (javaPlugin) {
                     mainCompileTasks.add(project.tasks.named('compileJava'))
                     testCompileTasks.add(project.tasks.named('compileTestJava'))
@@ -102,44 +92,47 @@ class JmixPlugin implements Plugin<Project> {
                     testCompileTasks.add(project.tasks.named('compileTestKotlin'))
                 }
 
+                def enhancedMainDir = project.file(EnhancingAction.enhancedClassesDir(project, 'main'))
+                def enhancedTestDir = project.file(EnhancingAction.enhancedClassesDir(project, 'test'))
+
                 enhanceMainTask.configure {
                     dependsOn(mainCompileTasks)
                     dependsOnClasspathArtifacts(project, it, 'main')
-                    onlyIf { shouldRunEnhancing(mainCompileTasks) }
+                    inputs.files(project.sourceSets.main.java.classesDirectory)
+                            .withPropertyName('compiledClasses')
+                            .withPathSensitivity(org.gradle.api.tasks.PathSensitivity.RELATIVE)
+                    inputs.files(project.sourceSets.main.compileClasspath)
+                            .withNormalizer(org.gradle.api.tasks.ClasspathNormalizer)
+                    outputs.dir(enhancedMainDir).withPropertyName('enhancedClasses')
+                    outputs.dir(project.file(EnhancingAction.generatedDescriptorsDir(project, 'main'))).withPropertyName('descriptors')
+                    outputs.cacheIf { true }
                 }
                 enhanceTestTask.configure {
                     dependsOn(testCompileTasks)
                     dependsOnClasspathArtifacts(project, it, 'test')
-                    onlyIf { shouldRunEnhancing(testCompileTasks) }
+                    inputs.files(project.sourceSets.test.java.classesDirectory)
+                            .withPropertyName('compiledClasses')
+                            .withPathSensitivity(org.gradle.api.tasks.PathSensitivity.RELATIVE)
+                    inputs.files(project.sourceSets.test.compileClasspath)
+                            .withNormalizer(org.gradle.api.tasks.ClasspathNormalizer)
+                    outputs.dir(enhancedTestDir).withPropertyName('enhancedClasses')
+                    outputs.dir(project.file(EnhancingAction.generatedDescriptorsDir(project, 'test'))).withPropertyName('descriptors')
+                    outputs.cacheIf { true }
                 }
 
-                def copyEnhancingResourcesMainTask = project.tasks.register('copyJmixEnhancingResourcesMain') {
-                    doLast({ EnhancingAction.copyGeneratedFiles(project, 'main') })
-                }
-                def copyEnhancingResourcesTestTask = project.tasks.register('copyJmixEnhancingResourcesTest') {
-                    doLast({ EnhancingAction.copyGeneratedFiles(project, 'test') })
-                }
+                project.sourceSets.main.output.classesDirs.setFrom(enhancedMainDir)
+                project.sourceSets.main.output.classesDirs.builtBy(enhanceMainTask)
+                project.tasks.named(project.sourceSets.main.classesTaskName) { dependsOn(enhanceMainTask) }
 
-                copyEnhancingResourcesMainTask.configure {
-                    dependsOn(enhanceMainTask)
-                    onlyIf { enhanceMainTask.get().state.didWork }
-                    if (project.tasks.findByName('processResources')) {
-                        mustRunAfter(project.tasks.named('processResources'))
-                    }
-                }
-                copyEnhancingResourcesTestTask.configure {
-                    dependsOn(enhanceTestTask)
-                    onlyIf { enhanceTestTask.get().state.didWork }
-                    if (project.tasks.findByName('processTestResources')) {
-                        mustRunAfter(project.tasks.named('processTestResources'))
-                    }
-                }
+                project.sourceSets.test.output.classesDirs.setFrom(enhancedTestDir)
+                project.sourceSets.test.output.classesDirs.builtBy(enhanceTestTask)
+                project.tasks.named(project.sourceSets.test.classesTaskName) { dependsOn(enhanceTestTask) }
 
-                project.tasks.named('classes') {
-                    dependsOn(copyEnhancingResourcesMainTask)
-                }
-                project.tasks.named('testClasses') {
-                    dependsOn(copyEnhancingResourcesTestTask)
+                registerGeneratedDescriptors(project, 'main', enhanceMainTask)
+                registerGeneratedDescriptors(project, 'test', enhanceTestTask)
+
+                if (kotlinPlugin) {
+                    redirectKotlinArchiveOutput(project, 'main', enhancedMainDir)
                 }
             }
 
@@ -186,6 +179,62 @@ class JmixPlugin implements Plugin<Project> {
         } catch (UnknownTaskException ignored) {
             project.logger.debug("Unable to setup output directory for Kotlin. " + ignored.message)
         }
+    }
+
+    private static void registerGeneratedDescriptors(Project project, String sourceSetName, enhanceTask) {
+        def sourceSet = project.sourceSets.getByName(sourceSetName)
+        def generatedDir = project.file(EnhancingAction.generatedDescriptorsDir(project, sourceSetName))
+
+        // Generated persistence.xml/orm.xml are registered as a first-class generated output of the source
+        // set: they reach the runtime classpath and the jar without being reprocessed by processResources.
+        sourceSet.output.dir([builtBy: enhanceTask], generatedDir)
+    }
+
+    /**
+     * The Kotlin JVM plugin adds the raw compile output directory to archive tasks (e.g. 'jar')
+     * through a source path that bypasses sourceSet.output. Since enhancement produces a separate
+     * enhanced output directory, that raw path would put un-enhanced (and duplicate) classes into
+     * the archive. Redirect any archive source that points at the raw compiled-classes directory
+     * to the enhanced directory.
+     */
+    private static void redirectKotlinArchiveOutput(Project project, String sourceSetName, File enhancedDir) {
+        def sourceSet = project.sourceSets.getByName(sourceSetName)
+        def rawDir = sourceSet.java.classesDirectory.get().asFile
+
+        def archiveTaskNames = [sourceSet.jarTaskName]
+        if (project.plugins.hasPlugin('org.springframework.boot')) {
+            archiveTaskNames.add('bootJar')
+        }
+
+        archiveTaskNames.each { taskName ->
+            try {
+                project.tasks.named(taskName).configure { task ->
+                    redirectArchiveSources(task, rawDir, enhancedDir)
+                }
+            } catch (UnknownTaskException ignored) {
+                // No such archive task in this project.
+            }
+        }
+    }
+
+    private static void redirectArchiveSources(task, File rawDir, File enhancedDir) {
+        // Walk the archive's CopySpec tree and redirect directory sources pointing at the raw dir.
+        // Relies on the internal CopySpec structure (rootSpec/children/sourcePaths); guarded so that
+        // a non-directory or read-only source is skipped rather than failing the build.
+        def walk
+        walk = { spec ->
+            spec.sourcePaths.each { sourcePath ->
+                try {
+                    if (sourcePath.respondsTo('getOrNull') && sourcePath.getOrNull()?.asFile == rawDir) {
+                        sourcePath.set(enhancedDir)
+                    }
+                } catch (ignored) {
+                    // Source path is not a redirectable directory property.
+                }
+            }
+            spec.children.each { child -> walk(child) }
+        }
+        walk(task.rootSpec)
     }
 
     private static void dependsOnClasspathArtifacts(Project project, task, String sourceSetName) {

--- a/jmix-gradle-plugin/src/main/java/io/jmix/gradle/EclipselinkEnhancing.java
+++ b/jmix-gradle-plugin/src/main/java/io/jmix/gradle/EclipselinkEnhancing.java
@@ -21,6 +21,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.tasks.SourceSet;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -28,7 +29,7 @@ import java.util.Set;
 
 public class EclipselinkEnhancing implements PersistenceProviderEnhancing {
 
-    public void run(Project project, SourceSet sourceSet, Set<String> allStores) {
+    public void run(Project project, SourceSet sourceSet, String enhancedDir, Set<String> allStores) {
         for (String storeName : allStores) {
             Configuration conf = project.getConfigurations().findByName(sourceSet.getCompileClasspathConfigurationName());
             if (!findJpaDependencies(conf.getResolvedConfiguration().getFirstLevelModuleDependencies(), new HashSet<>())) {
@@ -44,12 +45,12 @@ public class EclipselinkEnhancing implements PersistenceProviderEnhancing {
                 javaExecSpec.setClasspath(project.files(
                         project.getConfigurations().getByName("enhancing").getAsFileTree(),
                         sourceSet.getCompileClasspath().getFiles(),
-                        sourceSet.getJava().getDestinationDirectory().get().getAsFileTree()));
+                        project.files(new File(enhancedDir)).getAsFileTree()));
 
                 javaExecSpec.args("-loglevel", "INFO", "-persistenceinfo",
                         project.getBuildDir() + "/tmp/entitiesEnhancing/" + sourceSet.getName() + "/" + (("main".equals(storeName) ? "" : (storeName + '-')) + "persistence"),
-                        sourceSet.getJava().getDestinationDirectory().get().getAsFile().getAbsolutePath(),
-                        sourceSet.getJava().getDestinationDirectory().get().getAsFile().getAbsolutePath()
+                        enhancedDir,
+                        enhancedDir
                 );
                 javaExecSpec.setDebug(project.hasProperty("debugEnhancing") && Boolean.parseBoolean((String) project.property("debugEnhancing")));
             });

--- a/jmix-gradle-plugin/src/main/java/io/jmix/gradle/PersistenceProviderEnhancing.java
+++ b/jmix-gradle-plugin/src/main/java/io/jmix/gradle/PersistenceProviderEnhancing.java
@@ -25,5 +25,5 @@ import java.util.Set;
  * Used in {@link EnhancingAction} to run provider-specific enhancing logic.
  */
 public interface PersistenceProviderEnhancing {
-    void run(Project project, SourceSet sourceSet, Set<String> allStores);
+    void run(Project project, SourceSet sourceSet, String enhancedDir, Set<String> allStores);
 }

--- a/jmix-gradle-plugin/src/test/groovy/io/jmix/gradle/BuildReliabilityFunctionalTest.groovy
+++ b/jmix-gradle-plugin/src/test/groovy/io/jmix/gradle/BuildReliabilityFunctionalTest.groovy
@@ -1,0 +1,298 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+import java.nio.file.StandardOpenOption
+import java.util.zip.ZipFile
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+class BuildReliabilityFunctionalTest {
+
+    @TempDir
+    Path testProjectDir
+
+    private GradleRunner runner(String... args) {
+        def all = (args.toList() + ["-PjmixBomVersion=${System.getProperty('jmixBomVersion')}".toString(), '--stacktrace'])
+        return GradleRunner.create()
+                .withProjectDir(testProjectDir.toFile())
+                .withArguments(all)
+                .withPluginClasspath()
+                .forwardOutput()
+    }
+
+    private Path persistenceXml() {
+        // Descriptors are a generated source-set output, not reprocessed by processResources.
+        return testProjectDir.resolve('build/generated/jmix-descriptors/main/sample/app/persistence.xml')
+    }
+
+    private Path entityClassFile() {
+        // Enhancement writes to the dedicated enhanced output dir, not compileJava's output dir.
+        return testProjectDir.resolve('build/classes/jmix/main/sample/app/AppEntity.class')
+    }
+
+    private static boolean isEnhanced(Path classFile) {
+        return isEnhanced(Files.readAllBytes(classFile))
+    }
+
+    private static boolean isEnhanced(byte[] classBytes) {
+        String asLatin1 = new String(classBytes, StandardCharsets.ISO_8859_1)
+        // Jmix enhancing adds the io.jmix.core.Entity interface; EclipseLink weaving adds _persistence_ members.
+        return asLatin1.contains('io/jmix/core/Entity') || asLatin1.contains('_persistence_')
+    }
+
+    @Test
+    @Tag('slowTests')
+    void entitiesEnhancedWhenClassesCompiledInEarlierInvocation() {
+        copyFixture('single-project-enhancing', testProjectDir)
+
+        // Simulate an IDE/partial build: compile WITHOUT running the enhance task.
+        runner('clean', 'compileJava').build()
+
+        // Next invocation finds compileJava UP-TO-DATE. Enhancement must still ensure the
+        // on-disk classes are enhanced, regardless of whether compile did work in this invocation.
+        runner('classes').build()
+
+        assertTrue(isEnhanced(entityClassFile()),
+                "Entity left un-enhanced when classes were compiled in an earlier invocation")
+    }
+
+    @Test
+    @Tag('slowTests')
+    void descriptorsSurviveResourceOnlyRebuild() {
+        copyFixture('single-project-enhancing', testProjectDir)
+
+        runner('clean', 'classes').build()
+        assertTrue(Files.exists(persistenceXml()), "persistence.xml missing after first build")
+
+        // Change ONLY a resource; entity sources untouched -> compileJava UP-TO-DATE, enhance skipped.
+        Path props = testProjectDir.resolve('src/main/resources/application.properties')
+        Files.write(props, '\nsample.app.greeting2=world\n'.bytes, StandardOpenOption.APPEND)
+
+        runner('classes').build()
+
+        assertTrue(Files.exists(persistenceXml()),
+                "persistence.xml was lost after a resource-only incremental rebuild")
+        String xml = Files.readString(persistenceXml())
+        assertTrue(xml.contains('<class>sample.app.AppEntity</class>'), "Expected entity in:\n${xml}")
+    }
+
+    @Test
+    @Tag('slowTests')
+    void descriptorsProducedByEnhanceTask() {
+        copyFixture('single-project-enhancing', testProjectDir)
+
+        // Descriptors are produced by the enhance task as a generated source-set output, independently of
+        // processResources, so they don't force processResources to run after compileJava (which would
+        // create a circular dependency in modules that order compileJava after processResources).
+        runner('clean', 'enhanceJmixMain').build()
+
+        assertTrue(Files.exists(persistenceXml()),
+                "persistence.xml must be produced by the enhance task into the generated descriptors dir")
+        String xml = Files.readString(persistenceXml())
+        assertTrue(xml.contains('<class>sample.app.AppEntity</class>'), "Expected entity in:\n${xml}")
+    }
+
+    @Test
+    @Tag('slowTests')
+    void descriptorsPresentAfterCleanWithBuildCache() {
+        copyFixture('single-project-enhancing', testProjectDir)
+
+        // Populate the cache.
+        runner('--build-cache', 'classes').build()
+        assertTrue(Files.exists(persistenceXml()), "persistence.xml missing after first cached build")
+
+        // Clean and rebuild from cache only.
+        runner('--build-cache', 'clean').build()
+        runner('--build-cache', 'classes').build()
+
+        assertTrue(Files.exists(persistenceXml()),
+                "persistence.xml missing after clean + build-cache restore")
+    }
+
+    @Test
+    @Tag('slowTests')
+    void enhancedClassesWrittenToSeparateDirectory() {
+        copyFixture('single-project-enhancing', testProjectDir)
+
+        runner('clean', 'classes').build()
+
+        Path compiled = testProjectDir.resolve('build/classes/java/main/sample/app/AppEntity.class')
+        Path enhanced = testProjectDir.resolve('build/classes/jmix/main/sample/app/AppEntity.class')
+
+        // compileJava must own its output dir exclusively: the class it produces stays un-enhanced.
+        assertTrue(Files.exists(compiled), "compiled class must exist in build/classes/java/main")
+        assertTrue(!isEnhanced(compiled),
+                "class in build/classes/java/main must NOT be enhanced (compileJava owns the dir exclusively)")
+
+        // Enhancement writes to a separate, dedicated output dir.
+        assertTrue(Files.exists(enhanced), "enhanced class must exist in build/classes/jmix/main")
+        assertTrue(isEnhanced(enhanced), "class in build/classes/jmix/main must be enhanced")
+    }
+
+    @Test
+    @Tag('slowTests')
+    void compileJavaUpToDateOnSecondBuild() {
+        copyFixture('single-project-enhancing', testProjectDir)
+
+        runner('clean', 'classes').build()
+        def result = runner('classes').build()
+
+        assertEquals(TaskOutcome.UP_TO_DATE, result.task(':compileJava').outcome,
+                "compileJava must be UP-TO-DATE on a no-change rebuild; in-place enhancement modifying its " +
+                        "output dir makes Gradle recompile every build (overlapping outputs)")
+    }
+
+    @Test
+    @Tag('slowTests')
+    void kotlinEntityEnhancedAndNotDuplicatedInJar() {
+        copyFixture('single-project-enhancing-kotlin', testProjectDir)
+
+        runner('clean', 'jar').build()
+
+        Path jar = builtJar()
+
+        // The Kotlin plugin adds the raw compile dir to the jar separately from sourceSet.output.
+        // Without the enhanced-output redirect, each class is packaged twice (and the raw, un-enhanced
+        // copy may win), which also breaks the build with a duplicate-entry error.
+        assertEquals(1, classEntryCount(jar, 'sample/app/AppEntity.class'),
+                "Kotlin entity class must appear exactly once in the jar")
+        assertEquals(1, classEntryCount(jar, 'sample/app/AppConfiguration.class'),
+                "Kotlin @JmixModule class must appear exactly once in the jar")
+
+        assertTrue(isEnhanced(readJarEntry(jar, 'sample/app/AppEntity.class')),
+                "The entity class shipped in the jar must be the enhanced copy")
+    }
+
+    @Test
+    @Tag('slowTests')
+    void enhancedDirSelfHealsWhenClearedWithChecksumKept() {
+        copyFixture('single-project-enhancing', testProjectDir)
+
+        runner('clean', 'classes').build()
+        assertTrue(isEnhanced(entityClassFile()), "entity must be enhanced after the first build")
+
+        // Clear the enhanced output while the saved checksum survives (e.g. `rm -rf build/classes`,
+        // an IDE rebuild, or a partial clean). The enhanced dir and the checksum live in different
+        // build subtrees, so they can get out of sync.
+        deleteRecursively(testProjectDir.resolve('build/classes/jmix/main'))
+        Path checksum = testProjectDir.resolve('build/tmp/entitiesEnhancing/main/entities.checksum')
+        assertTrue(Files.exists(checksum), "precondition: the checksum file must survive")
+        assertTrue(!Files.exists(entityClassFile()), "precondition: the enhanced class must be removed")
+
+        runner('classes').build()
+
+        assertTrue(isEnhanced(entityClassFile()),
+                "enhanced dir must self-heal: enhancement must re-run when an enhanced entity is missing, " +
+                        "even when the checksum is unchanged")
+    }
+
+    @Test
+    @Tag('slowTests')
+    void testEnhancementIsNoOpWithoutTestSources() {
+        copyFixture('single-project-enhancing', testProjectDir)
+
+        // The fixture has main entities but no test sources. enhanceJmixTest must be a harmless no-op,
+        // not fail by invoking the persistence weaver with no compiled test classes.
+        def result = runner('clean', 'testClasses').build()
+
+        assertEquals(TaskOutcome.SUCCESS, result.task(':enhanceJmixMain').outcome,
+                "main enhancement must still run")
+        assertTrue(isEnhanced(entityClassFile()), "main entity must be enhanced")
+        // The test enhance task must not fail the build when there are no compiled test classes.
+        TaskOutcome testEnhanceOutcome = result.task(':enhanceJmixTest')?.outcome
+        assertTrue(testEnhanceOutcome == null || testEnhanceOutcome == TaskOutcome.SUCCESS,
+                "enhanceJmixTest must not fail without test sources (was ${testEnhanceOutcome})")
+    }
+
+    @Test
+    @Tag('slowTests')
+    void generatedEntityClassesSurviveNonEntityRebuild() {
+        copyFixture('single-project-enhancing', testProjectDir)
+
+        runner('clean', 'classes').build()
+        Path generatedInner = testProjectDir.resolve('build/classes/jmix/main/sample/app/AppEntity$JmixEntityEntry.class')
+        assertTrue(Files.exists(generatedInner),
+                'precondition: the enhancer must generate AppEntity$JmixEntityEntry')
+
+        // Change a NON-entity class so the enhance task re-runs (compiled input changed) but skips weaving
+        // (entity checksum unchanged). Stale-removal must not drop the enhancer-generated inner classes.
+        Path config = testProjectDir.resolve('src/main/java/sample/app/AppConfiguration.java')
+        String src = Files.readString(config)
+                .replace('public class AppConfiguration {',
+                        'public class AppConfiguration {\n    @SuppressWarnings("unused") private void probe() {}')
+        Files.writeString(config, src)
+
+        runner('classes').build()
+
+        assertTrue(Files.exists(generatedInner),
+                'enhancer-generated classes must survive an incremental rebuild that changes only a non-entity class')
+    }
+
+    private static void deleteRecursively(Path dir) {
+        if (!Files.exists(dir)) {
+            return
+        }
+        Files.walk(dir).sorted(Comparator.reverseOrder()).forEach { Files.delete(it) }
+    }
+
+    private Path builtJar() {
+        Path libs = testProjectDir.resolve('build/libs')
+        Files.list(libs).withCloseable { stream ->
+            return stream.filter { it.fileName.toString().endsWith('.jar') }
+                    .findFirst()
+                    .orElseThrow { new AssertionError("No jar produced in ${libs}".toString()) }
+        }
+    }
+
+    private static int classEntryCount(Path jar, String entryName) {
+        new ZipFile(jar.toFile()).withCloseable { zip ->
+            return Collections.list(zip.entries())*.name.count { it == entryName }
+        }
+    }
+
+    private static byte[] readJarEntry(Path jar, String entryName) {
+        new ZipFile(jar.toFile()).withCloseable { zip ->
+            def entry = zip.getEntry(entryName)
+            assertTrue(entry != null, "Entry ${entryName} not found in ${jar}".toString())
+            return zip.getInputStream(entry).bytes
+        }
+    }
+
+    private static void copyFixture(String name, Path target) {
+        Path source = Path.of(BuildReliabilityFunctionalTest.getResource("/fixtures/${name}").toURI())
+        Files.walk(source).forEach { sourcePath ->
+            Path targetPath = target.resolve(source.relativize(sourcePath).toString())
+            if (Files.isDirectory(sourcePath)) {
+                Files.createDirectories(targetPath)
+            } else {
+                Files.copy(sourcePath, targetPath, StandardCopyOption.REPLACE_EXISTING)
+            }
+        }
+    }
+}

--- a/jmix-gradle-plugin/src/test/groovy/io/jmix/gradle/EnhancingClasspathFunctionalTest.groovy
+++ b/jmix-gradle-plugin/src/test/groovy/io/jmix/gradle/EnhancingClasspathFunctionalTest.groovy
@@ -44,7 +44,7 @@ class EnhancingClasspathFunctionalTest {
                 .forwardOutput()
                 .build()
 
-        Path persistenceXml = testProjectDir.resolve('feature/build/resources/main/sample/feature/persistence.xml')
+        Path persistenceXml = testProjectDir.resolve('feature/build/generated/jmix-descriptors/main/sample/feature/persistence.xml')
         assertTrue(Files.exists(persistenceXml), "Expected generated persistence.xml at ${persistenceXml}")
 
         String xml = Files.readString(persistenceXml)

--- a/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing-kotlin/build.gradle
+++ b/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing-kotlin/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+    id 'java-library'
+    id 'org.jetbrains.kotlin.jvm' version '2.1.10'
+    id 'io.jmix'
+}
+
+group = 'sample'
+version = '1.0-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+jmix {
+    bomVersion = findProperty('jmixBomVersion')
+}
+
+dependencies {
+    implementation 'io.jmix.core:jmix-core'
+    implementation 'io.jmix.data:jmix-eclipselink'
+}

--- a/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing-kotlin/settings.gradle
+++ b/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing-kotlin/settings.gradle
@@ -1,0 +1,21 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        maven {
+            url = 'https://nexus.jmix.io/repository/public'
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        maven {
+            url = 'https://nexus.jmix.io/repository/public'
+        }
+    }
+}
+
+rootProject.name = 'single-project-enhancing-kotlin'

--- a/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing-kotlin/src/main/kotlin/sample/app/AppConfiguration.kt
+++ b/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing-kotlin/src/main/kotlin/sample/app/AppConfiguration.kt
@@ -1,0 +1,9 @@
+package sample.app
+
+import io.jmix.core.annotation.JmixModule
+import io.jmix.eclipselink.EclipselinkConfiguration
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@JmixModule(id = "sample-app", dependsOn = [EclipselinkConfiguration::class])
+open class AppConfiguration

--- a/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing-kotlin/src/main/kotlin/sample/app/AppEntity.kt
+++ b/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing-kotlin/src/main/kotlin/sample/app/AppEntity.kt
@@ -1,0 +1,18 @@
+package sample.app
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue
+import io.jmix.core.metamodel.annotation.JmixEntity
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.util.UUID
+
+@JmixEntity
+@Entity(name = "sample_AppEntity")
+@Table(name = "SAMPLE_APP_ENTITY")
+open class AppEntity {
+
+    @Id
+    @JmixGeneratedValue
+    var id: UUID? = null
+}

--- a/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing-kotlin/src/main/resources/application.properties
+++ b/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing-kotlin/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+sample.app.greeting=hello

--- a/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing/build.gradle
+++ b/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+    id 'java-library'
+    id 'io.jmix'
+}
+
+group = 'sample'
+version = '1.0-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+jmix {
+    bomVersion = findProperty('jmixBomVersion')
+}
+
+dependencies {
+    implementation 'io.jmix.core:jmix-core'
+    implementation 'io.jmix.data:jmix-eclipselink'
+}

--- a/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing/settings.gradle
+++ b/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing/settings.gradle
@@ -1,0 +1,21 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+        maven {
+            url = 'https://nexus.jmix.io/repository/public'
+        }
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        mavenCentral()
+        maven {
+            url = 'https://nexus.jmix.io/repository/public'
+        }
+    }
+}
+
+rootProject.name = 'single-project-enhancing'

--- a/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing/src/main/java/sample/app/AppConfiguration.java
+++ b/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing/src/main/java/sample/app/AppConfiguration.java
@@ -1,0 +1,10 @@
+package sample.app;
+
+import io.jmix.core.annotation.JmixModule;
+import io.jmix.eclipselink.EclipselinkConfiguration;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@JmixModule(id = "sample-app", dependsOn = EclipselinkConfiguration.class)
+public class AppConfiguration {
+}

--- a/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing/src/main/java/sample/app/AppEntity.java
+++ b/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing/src/main/java/sample/app/AppEntity.java
@@ -1,0 +1,27 @@
+package sample.app;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.util.UUID;
+
+@JmixEntity
+@Entity(name = "sample_AppEntity")
+@Table(name = "SAMPLE_APP_ENTITY")
+public class AppEntity {
+
+    @Id
+    @JmixGeneratedValue
+    private UUID id;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+}

--- a/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing/src/main/resources/application.properties
+++ b/jmix-gradle-plugin/src/test/resources/fixtures/single-project-enhancing/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+sample.app.greeting=hello


### PR DESCRIPTION
Root cause: enhancement runs in place in `build/classes/java/main`, gated by an `onlyIf` that keys on the compile task's transient "did work" state, and descriptors are copied by a separate task that overlaps `processResources`.

## Description of changes

Reworked entity enhancing so each step has a single, well-defined output, and removed the fragile gating.

- Separate enhanced output dir. `enhanceJmix{Main,Test}` now reads compiled classes from `build/classes/java/<set>` and writes enhanced classes to a dedicated `build/classes/jmix/<set>`. The source set's output (`classesDirs`) is redirected there. `compileJava` regains exclusive ownership of its dir → up-to-date checking and the build cache work; the enhance task declares proper inputs/outputs and is cacheable.
- Removed the `onlyIf` compile-gate. Enhancement reliability now relies on a checksum of entity classes plus an idempotent reconcile, so classes compiled in an earlier invocation still get enhanced.
- Descriptors as a generated output. `persistence.xml/orm.xml` are generated into `build/generated/jmix-descriptors/<set>` and registered via `sourceSet.output.dir(...)` instead of being funneled through `processResources` — fixes a circular dependency (`compileJava` → `processResources` → `enhanceJmixMain` → `compileJava`) in modules whose `compileJava` consumes `processResources`.
- Kotlin support. Redirect the raw compile dir the Kotlin plugin adds to jar/bootJar to the enhanced dir, preventing duplicate (Entry … is a duplicate) and un-enhanced classes in archives.
- Robustness fixes: self-heal the enhanced dir when it is cleared but the checksum survives; keep enhancer-generated `$JmixEntityEntry` classes during reconcile (key staleness on the outer class); skip enhancement for source sets with no compiled classes; load the correct compiled dir when collecting main entities during test enhancement.
- `framework-test-support` now disables enhancing via `jmix { entitiesEnhancing { enabled = false } }` (the supported switch) instead of disabling the task.
