### PR TITLE
GenericFilter: add convenience API for programmatic filter configuration #5351

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/action/genericfilter/GenericFilterRemoveAction.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/action/genericfilter/GenericFilterRemoveAction.java
@@ -26,6 +26,7 @@ import io.jmix.flowui.action.DialogAction;
 import io.jmix.flowui.component.genericfilter.Configuration;
 import io.jmix.flowui.component.genericfilter.GenericFilterSupport;
 import io.jmix.flowui.component.genericfilter.configuration.DesignTimeConfiguration;
+import io.jmix.flowui.component.genericfilter.configuration.RunTimeConfiguration;
 import io.jmix.flowui.component.genericfilter.model.FilterConfigurationModel;
 import io.jmix.flowui.icon.Icons;
 import io.jmix.flowui.kit.icon.JmixFontIcon;
@@ -91,6 +92,8 @@ public class GenericFilterRemoveAction extends GenericFilterAction<GenericFilter
         return super.isApplicable()
                 && target.getCurrentConfiguration() != target.getEmptyConfiguration()
                 && !(target.getCurrentConfiguration() instanceof DesignTimeConfiguration)
+                && !(target.getCurrentConfiguration() instanceof RunTimeConfiguration rc
+                        && rc.isProtectedFromUserDeletion())
                 && (globalConfigurationModificationPermitted || !isCurrentConfigurationAvailableForAll());
     }
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/FilterComponentBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/FilterComponentBuilder.java
@@ -242,7 +242,6 @@ public class FilterComponentBuilder {
                 throw new IllegalStateException(
                         "PropertyFilterBuilder.build() must not be called more than once; create a new instance per PropertyFilter");
             }
-            built = true;
             if (property == null) {
                 throw new IllegalStateException(
                         "PropertyFilterBuilder: 'property' is required — call .property(\"...\") before .build()");
@@ -269,6 +268,7 @@ public class FilterComponentBuilder {
             if (defaultValue != null) {
                 propertyFilter.setValue(defaultValue);
             }
+            built = true;
             return propertyFilter;
         }
     }
@@ -376,7 +376,6 @@ public class FilterComponentBuilder {
                 throw new IllegalStateException(
                         "JpqlFilterBuilder.build() must not be called more than once; create a new instance per JpqlFilter");
             }
-            built = true;
             if (where == null) {
                 throw new IllegalStateException(
                         "JpqlFilterBuilder: 'where' is required — call .where(\"...\") before .build()");
@@ -401,6 +400,7 @@ public class FilterComponentBuilder {
             if (defaultValue != null) {
                 jpqlFilter.setValue(defaultValue);
             }
+            built = true;
             return jpqlFilter;
         }
     }
@@ -447,9 +447,6 @@ public class FilterComponentBuilder {
 
         /**
          * Adds several filter components to this group at once.
-         * <p>
-         * Named {@code addAll} (rather than overloading {@code add}) for consistency with
-         * {@link RunTimeConfigurationBuilder#addAll(FilterComponent...)}.
          */
         public GroupFilterBuilder addAll(FilterComponent... filterComponents) {
             checkNotNullArgument(filterComponents, "filterComponents must not be null");
@@ -470,7 +467,6 @@ public class FilterComponentBuilder {
                 throw new IllegalStateException(
                         "GroupFilterBuilder.build() must not be called more than once; create a new instance per GroupFilter");
             }
-            built = true;
             checkDataLoaderPresent(filter);
 
             GroupFilter groupFilter = uiComponents.create(GroupFilter.class);
@@ -481,6 +477,7 @@ public class FilterComponentBuilder {
             for (FilterComponent component : components) {
                 groupFilter.add(component);
             }
+            built = true;
             return groupFilter;
         }
     }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/FilterComponentBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/FilterComponentBuilder.java
@@ -1,0 +1,492 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.component.genericfilter;
+
+import io.jmix.core.Metadata;
+import io.jmix.core.annotation.Experimental;
+import io.jmix.core.querycondition.PropertyConditionUtils;
+import io.jmix.flowui.UiComponents;
+import io.jmix.flowui.component.filter.FilterComponent;
+import io.jmix.flowui.component.genericfilter.converter.FilterConverter;
+import io.jmix.flowui.component.genericfilter.registration.FilterComponents;
+import io.jmix.flowui.component.jpqlfilter.JpqlFilter;
+import io.jmix.flowui.component.jpqlfilter.JpqlFilterSupport;
+import io.jmix.flowui.component.logicalfilter.GroupFilter;
+import io.jmix.flowui.component.logicalfilter.LogicalFilterComponent;
+import io.jmix.flowui.component.propertyfilter.PropertyFilter;
+import io.jmix.flowui.entity.filter.FilterValueComponent;
+import io.jmix.flowui.entity.filter.JpqlFilterCondition;
+import io.jmix.flowui.entity.filter.PropertyFilterCondition;
+import org.jspecify.annotations.Nullable;
+import org.springframework.context.ApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.jmix.core.common.util.Preconditions.checkNotNullArgument;
+
+/**
+ * A factory for creating filter components ({@link PropertyFilter}, {@link JpqlFilter},
+ * {@link GroupFilter}) that are pre-configured for use inside a specific {@link GenericFilter}.
+ * <p>
+ * Single filter components are built by assembling a condition model from the fluent parameters
+ * and delegating to the same converter the framework uses when loading a filter from XML or
+ * adding a condition through the UI. The converter is the single source of truth for component
+ * initialisation, so a programmatically built component behaves exactly like a declarative one.
+ * <p>
+ * The owning {@link GenericFilter} must have a {@code DataLoader}; otherwise {@code build()}
+ * throws an {@link IllegalStateException}.
+ * <p>
+ * This factory and its nested builders are designed for extension: their constructors and
+ * fields are {@code protected}. To customise behaviour, subclass {@code FilterComponentBuilder}
+ * and override the relevant factory method ({@link #propertyFilter()}, {@link #jpqlFilter()},
+ * {@link #groupFilter()}) to return your own builder subclass, then return your factory from a
+ * {@link GenericFilter} subclass that overrides {@link GenericFilter#filterComponentBuilder()}.
+ * <p>
+ * Obtain an instance via {@link GenericFilter#filterComponentBuilder()}:
+ * <pre>{@code
+ * FilterComponentBuilder builder = filter.filterComponentBuilder();
+ *
+ * PropertyFilter<String> nameFilter = builder.propertyFilter()
+ *         .property("name")
+ *         .operation(PropertyFilter.Operation.CONTAINS)
+ *         .defaultValue("Acme")
+ *         .build();
+ *
+ * // void (checkbox) filter: toggles a fixed condition on/off
+ * JpqlFilter<Boolean> activeFilter = builder.jpqlFilter()
+ *         .where("{E}.status = 'ACTIVE'")
+ *         .defaultValue(true)
+ *         .build();
+ *
+ * // typed filter: a user-supplied value is bound to the query parameter
+ * JpqlFilter<String> codeFilter = builder.jpqlFilter(String.class)
+ *         .where("{E}.code = ?")
+ *         .build();
+ * }</pre>
+ */
+@Experimental
+public class FilterComponentBuilder {
+
+    protected final GenericFilter filter;
+    protected final UiComponents uiComponents;
+    protected final Metadata metadata;
+    protected final FilterComponents filterComponents;
+    protected final JpqlFilterSupport jpqlFilterSupport;
+
+    protected FilterComponentBuilder(GenericFilter filter, ApplicationContext applicationContext) {
+        this.filter = filter;
+        this.uiComponents = applicationContext.getBean(UiComponents.class);
+        this.metadata = applicationContext.getBean(Metadata.class);
+        this.filterComponents = applicationContext.getBean(FilterComponents.class);
+        this.jpqlFilterSupport = applicationContext.getBean(JpqlFilterSupport.class);
+    }
+
+    /**
+     * Returns a builder for a {@link PropertyFilter} bound to the owning filter.
+     *
+     * @param <V> the value type inferred from the entity property
+     * @return a new {@link PropertyFilterBuilder}
+     */
+    public <V> PropertyFilterBuilder<V> propertyFilter() {
+        return new PropertyFilterBuilder<>(filter, metadata, filterComponents);
+    }
+
+    /**
+     * Returns a builder for a <em>void</em> (checkbox) {@link JpqlFilter}.
+     * <p>
+     * Use this variant for a condition with a fixed WHERE clause that carries no user-supplied
+     * value, e.g. {@code {E}.status = 'ACTIVE'}. The filter is rendered as a checkbox: when
+     * checked the WHERE clause is applied, when unchecked it is omitted. The value type is
+     * therefore {@link Boolean}; use {@code defaultValue(true)} to make the condition active by
+     * default.
+     *
+     * @return a new {@link JpqlFilterBuilder} that produces a checkbox filter
+     */
+    public JpqlFilterBuilder<Boolean> jpqlFilter() {
+        return new JpqlFilterBuilder<>(filter, metadata, filterComponents, jpqlFilterSupport, Void.class);
+    }
+
+    /**
+     * Returns a builder for a <em>typed</em> {@link JpqlFilter} whose user-supplied value is
+     * bound to the query parameter.
+     *
+     * @param parameterClass the Java class of the query parameter
+     * @param <V>            the value type
+     * @return a new {@link JpqlFilterBuilder}
+     */
+    public <V> JpqlFilterBuilder<V> jpqlFilter(Class<V> parameterClass) {
+        checkNotNullArgument(parameterClass, "parameterClass must not be null");
+        return new JpqlFilterBuilder<>(filter, metadata, filterComponents, jpqlFilterSupport, parameterClass);
+    }
+
+    /**
+     * Returns a builder for a {@link GroupFilter} bound to the owning filter.
+     *
+     * @return a new {@link GroupFilterBuilder}
+     */
+    public GroupFilterBuilder groupFilter() {
+        return new GroupFilterBuilder(filter, uiComponents);
+    }
+
+    protected static void checkDataLoaderPresent(GenericFilter filter) {
+        if (filter.getDataLoader() == null) {
+            throw new IllegalStateException(
+                    "GenericFilter has no DataLoader. Filter components cannot be built without a DataLoader; " +
+                            "set it before using the builder (the 'dataLoader' attribute in XML, or " +
+                            "GenericFilter.setDataLoader(...)).");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // PropertyFilterBuilder
+    // -------------------------------------------------------------------------
+
+    /**
+     * Fluent builder for {@link PropertyFilter}.
+     *
+     * @param <V> the value type
+     */
+    public static class PropertyFilterBuilder<V> {
+
+        protected final GenericFilter filter;
+        protected final Metadata metadata;
+        protected final FilterComponents filterComponents;
+
+        protected String property;
+        protected PropertyFilter.Operation operation;
+        protected V defaultValue;
+        protected String label;
+        protected boolean operationEditable = false;
+        protected boolean operationTextVisible = true;
+        protected boolean built = false;
+
+        protected PropertyFilterBuilder(GenericFilter filter, Metadata metadata, FilterComponents filterComponents) {
+            this.filter = filter;
+            this.metadata = metadata;
+            this.filterComponents = filterComponents;
+        }
+
+        /**
+         * Sets the entity property path (e.g. {@code "name"} or {@code "customer.city.name"}).
+         * Required.
+         */
+        public PropertyFilterBuilder<V> property(String property) {
+            checkNotNullArgument(property, "property must not be null");
+            this.property = property;
+            return this;
+        }
+
+        /**
+         * Sets the filtering operation (e.g. {@link PropertyFilter.Operation#EQUAL}).
+         * Required.
+         */
+        public PropertyFilterBuilder<V> operation(PropertyFilter.Operation operation) {
+            checkNotNullArgument(operation, "operation must not be null");
+            this.operation = operation;
+            return this;
+        }
+
+        /**
+         * Sets the default (pre-filled) value for the filter condition. Optional.
+         */
+        public PropertyFilterBuilder<V> defaultValue(@Nullable V defaultValue) {
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        /**
+         * Overrides the auto-generated label text. Optional.
+         */
+        public PropertyFilterBuilder<V> label(@Nullable String label) {
+            this.label = label;
+            return this;
+        }
+
+        /**
+         * Controls whether the user can change the filter operation at runtime via a
+         * dropdown selector. Defaults to {@code false}.
+         */
+        public PropertyFilterBuilder<V> operationEditable(boolean operationEditable) {
+            this.operationEditable = operationEditable;
+            return this;
+        }
+
+        /**
+         * Controls whether the operation label (e.g. "contains", "=") is shown next to
+         * the value field. Defaults to {@code true}.
+         */
+        public PropertyFilterBuilder<V> operationTextVisible(boolean operationTextVisible) {
+            this.operationTextVisible = operationTextVisible;
+            return this;
+        }
+
+        /**
+         * Builds and returns the configured {@link PropertyFilter}.
+         *
+         * @throws IllegalStateException if {@code property} or {@code operation} was not set,
+         *         if the owning filter has no DataLoader, or if this builder instance has
+         *         already been used
+         */
+        @SuppressWarnings("unchecked")
+        public PropertyFilter<V> build() {
+            if (built) {
+                throw new IllegalStateException(
+                        "PropertyFilterBuilder.build() must not be called more than once; create a new instance per PropertyFilter");
+            }
+            built = true;
+            if (property == null) {
+                throw new IllegalStateException(
+                        "PropertyFilterBuilder: 'property' is required — call .property(\"...\") before .build()");
+            }
+            if (operation == null) {
+                throw new IllegalStateException(
+                        "PropertyFilterBuilder: 'operation' is required — call .operation(...) before .build()");
+            }
+            checkDataLoaderPresent(filter);
+
+            PropertyFilterCondition model = metadata.create(PropertyFilterCondition.class);
+            model.setProperty(property);
+            model.setOperation(operation);
+            model.setParameterName(PropertyConditionUtils.generateParameterName(property));
+            model.setOperationEditable(operationEditable);
+            model.setOperationTextVisible(operationTextVisible);
+            model.setLabel(label);
+            model.setValueComponent(metadata.create(FilterValueComponent.class));
+
+            FilterConverter<PropertyFilter<V>, PropertyFilterCondition> converter =
+                    (FilterConverter<PropertyFilter<V>, PropertyFilterCondition>) filterComponents
+                            .getConverterByModelClass(PropertyFilterCondition.class, filter);
+            PropertyFilter<V> propertyFilter = converter.convertToComponent(model);
+            if (defaultValue != null) {
+                propertyFilter.setValue(defaultValue);
+            }
+            return propertyFilter;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // JpqlFilterBuilder
+    // -------------------------------------------------------------------------
+
+    /**
+     * Fluent builder for {@link JpqlFilter}.
+     *
+     * @param <V> the value type ({@link Boolean} for a void/checkbox filter, or the parameter type)
+     */
+    public static class JpqlFilterBuilder<V> {
+
+        protected final GenericFilter filter;
+        protected final Metadata metadata;
+        protected final FilterComponents filterComponents;
+        protected final JpqlFilterSupport jpqlFilterSupport;
+        protected final Class<?> parameterClass;
+
+        protected String where;
+        protected String join;
+        protected String parameterName;
+        protected V defaultValue;
+        protected String label;
+        protected boolean hasInExpression;
+        protected boolean built = false;
+
+        protected JpqlFilterBuilder(GenericFilter filter, Metadata metadata, FilterComponents filterComponents,
+                          JpqlFilterSupport jpqlFilterSupport, Class<?> parameterClass) {
+            this.filter = filter;
+            this.metadata = metadata;
+            this.filterComponents = filterComponents;
+            this.jpqlFilterSupport = jpqlFilterSupport;
+            this.parameterClass = parameterClass;
+        }
+
+        /**
+         * Sets the JPQL WHERE clause fragment (use {@code {E}} as the entity alias and
+         * {@code ?} as the parameter placeholder). Required.
+         */
+        public JpqlFilterBuilder<V> where(String where) {
+            checkNotNullArgument(where, "where must not be null");
+            this.where = where;
+            return this;
+        }
+
+        /**
+         * Sets the optional JPQL JOIN clause fragment (e.g. {@code "join {E}.tags t"}).
+         */
+        public JpqlFilterBuilder<V> join(@Nullable String join) {
+            this.join = join;
+            return this;
+        }
+
+        /**
+         * Sets the query parameter name. Optional — if not set, a name is generated
+         * automatically (matching the behaviour of the XML loader). Set it explicitly only
+         * when the WHERE clause uses a named bind parameter ({@code :paramName}) that must
+         * match a specific name.
+         */
+        public JpqlFilterBuilder<V> parameterName(String parameterName) {
+            checkNotNullArgument(parameterName, "parameterName must not be null");
+            this.parameterName = parameterName;
+            return this;
+        }
+
+        /**
+         * Sets the default (pre-filled) value. Optional.
+         * <p>
+         * For a void (checkbox) filter the value type is {@link Boolean}: {@code defaultValue(true)}
+         * makes the condition active by default.
+         */
+        public JpqlFilterBuilder<V> defaultValue(@Nullable V defaultValue) {
+            this.defaultValue = defaultValue;
+            return this;
+        }
+
+        /**
+         * Overrides the auto-generated label text. Optional.
+         */
+        public JpqlFilterBuilder<V> label(@Nullable String label) {
+            this.label = label;
+            return this;
+        }
+
+        /**
+         * Marks the condition as having an IN expression (the value is a collection).
+         */
+        public JpqlFilterBuilder<V> hasInExpression(boolean hasInExpression) {
+            this.hasInExpression = hasInExpression;
+            return this;
+        }
+
+        /**
+         * Builds and returns the configured {@link JpqlFilter}.
+         *
+         * @throws IllegalStateException if {@code where} was not set, if the owning filter has
+         *         no DataLoader, or if this builder instance has already been used
+         */
+        @SuppressWarnings("unchecked")
+        public JpqlFilter<V> build() {
+            if (built) {
+                throw new IllegalStateException(
+                        "JpqlFilterBuilder.build() must not be called more than once; create a new instance per JpqlFilter");
+            }
+            built = true;
+            if (where == null) {
+                throw new IllegalStateException(
+                        "JpqlFilterBuilder: 'where' is required — call .where(\"...\") before .build()");
+            }
+            checkDataLoaderPresent(filter);
+
+            JpqlFilterCondition model = metadata.create(JpqlFilterCondition.class);
+            model.setParameterClass(parameterClass.getName());
+            model.setParameterName(parameterName != null
+                    ? parameterName
+                    : jpqlFilterSupport.generateParameterName(null, parameterClass.getSimpleName()));
+            model.setWhere(where);
+            model.setJoin(join);
+            model.setHasInExpression(hasInExpression);
+            model.setLabel(label);
+            model.setValueComponent(metadata.create(FilterValueComponent.class));
+
+            FilterConverter<JpqlFilter<V>, JpqlFilterCondition> converter =
+                    (FilterConverter<JpqlFilter<V>, JpqlFilterCondition>) filterComponents
+                            .getConverterByModelClass(JpqlFilterCondition.class, filter);
+            JpqlFilter<V> jpqlFilter = converter.convertToComponent(model);
+            if (defaultValue != null) {
+                jpqlFilter.setValue(defaultValue);
+            }
+            return jpqlFilter;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GroupFilterBuilder
+    // -------------------------------------------------------------------------
+
+    /**
+     * Fluent builder for {@link GroupFilter}.
+     */
+    public static class GroupFilterBuilder {
+
+        protected final GenericFilter filter;
+        protected final UiComponents uiComponents;
+
+        protected LogicalFilterComponent.Operation operation = LogicalFilterComponent.Operation.AND;
+        protected final List<FilterComponent> components = new ArrayList<>();
+        protected boolean built = false;
+
+        protected GroupFilterBuilder(GenericFilter filter, UiComponents uiComponents) {
+            this.filter = filter;
+            this.uiComponents = uiComponents;
+        }
+
+        /**
+         * Sets the logical operation ({@code AND} or {@code OR}). Defaults to {@code AND}.
+         */
+        public GroupFilterBuilder operation(LogicalFilterComponent.Operation operation) {
+            checkNotNullArgument(operation, "operation must not be null");
+            this.operation = operation;
+            return this;
+        }
+
+        /**
+         * Adds a filter component to this group.
+         */
+        public GroupFilterBuilder add(FilterComponent filterComponent) {
+            checkNotNullArgument(filterComponent, "filterComponent must not be null");
+            components.add(filterComponent);
+            return this;
+        }
+
+        /**
+         * Adds several filter components to this group at once.
+         * <p>
+         * Named {@code addAll} (rather than overloading {@code add}) for consistency with
+         * {@link RunTimeConfigurationBuilder#addAll(FilterComponent...)}.
+         */
+        public GroupFilterBuilder addAll(FilterComponent... filterComponents) {
+            checkNotNullArgument(filterComponents, "filterComponents must not be null");
+            for (FilterComponent filterComponent : filterComponents) {
+                add(filterComponent);
+            }
+            return this;
+        }
+
+        /**
+         * Builds and returns the configured {@link GroupFilter}.
+         *
+         * @throws IllegalStateException if the owning filter has no DataLoader, or if this
+         *         builder instance has already been used
+         */
+        public GroupFilter build() {
+            if (built) {
+                throw new IllegalStateException(
+                        "GroupFilterBuilder.build() must not be called more than once; create a new instance per GroupFilter");
+            }
+            built = true;
+            checkDataLoaderPresent(filter);
+
+            GroupFilter groupFilter = uiComponents.create(GroupFilter.class);
+            groupFilter.setConditionModificationDelegated(true);
+            groupFilter.setAutoApply(filter.isAutoApply());
+            groupFilter.setDataLoader(filter.getDataLoader());
+            groupFilter.setOperation(operation);
+            for (FilterComponent component : components) {
+                groupFilter.add(component);
+            }
+            return groupFilter;
+        }
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/FilterComponentBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/FilterComponentBuilder.java
@@ -83,17 +83,11 @@ import static io.jmix.core.common.util.Preconditions.checkNotNullArgument;
 public class FilterComponentBuilder {
 
     protected final GenericFilter filter;
-    protected final UiComponents uiComponents;
-    protected final Metadata metadata;
-    protected final FilterComponents filterComponents;
-    protected final JpqlFilterSupport jpqlFilterSupport;
+    protected final ApplicationContext applicationContext;
 
     protected FilterComponentBuilder(GenericFilter filter, ApplicationContext applicationContext) {
         this.filter = filter;
-        this.uiComponents = applicationContext.getBean(UiComponents.class);
-        this.metadata = applicationContext.getBean(Metadata.class);
-        this.filterComponents = applicationContext.getBean(FilterComponents.class);
-        this.jpqlFilterSupport = applicationContext.getBean(JpqlFilterSupport.class);
+        this.applicationContext = applicationContext;
     }
 
     /**
@@ -103,7 +97,7 @@ public class FilterComponentBuilder {
      * @return a new {@link PropertyFilterBuilder}
      */
     public <V> PropertyFilterBuilder<V> propertyFilter() {
-        return new PropertyFilterBuilder<>(filter, metadata, filterComponents);
+        return new PropertyFilterBuilder<>(filter, applicationContext);
     }
 
     /**
@@ -118,7 +112,7 @@ public class FilterComponentBuilder {
      * @return a new {@link JpqlFilterBuilder} that produces a checkbox filter
      */
     public JpqlFilterBuilder<Boolean> jpqlFilter() {
-        return new JpqlFilterBuilder<>(filter, metadata, filterComponents, jpqlFilterSupport, Void.class);
+        return new JpqlFilterBuilder<>(filter, applicationContext, Void.class);
     }
 
     /**
@@ -131,7 +125,7 @@ public class FilterComponentBuilder {
      */
     public <V> JpqlFilterBuilder<V> jpqlFilter(Class<V> parameterClass) {
         checkNotNullArgument(parameterClass, "parameterClass must not be null");
-        return new JpqlFilterBuilder<>(filter, metadata, filterComponents, jpqlFilterSupport, parameterClass);
+        return new JpqlFilterBuilder<>(filter, applicationContext, parameterClass);
     }
 
     /**
@@ -140,32 +134,28 @@ public class FilterComponentBuilder {
      * @return a new {@link GroupFilterBuilder}
      */
     public GroupFilterBuilder groupFilter() {
-        return new GroupFilterBuilder(filter, uiComponents);
+        return new GroupFilterBuilder(filter, applicationContext);
     }
 
     protected static void checkDataLoaderPresent(GenericFilter filter) {
         if (filter.getDataLoader() == null) {
-            throw new IllegalStateException(
-                    "GenericFilter has no DataLoader. Filter components cannot be built without a DataLoader; " +
-                            "set it before using the builder (the 'dataLoader' attribute in XML, or " +
-                            "GenericFilter.setDataLoader(...)).");
+            throw new IllegalStateException(String.format(
+                    "%s has no DataLoader; set one before building filter components.",
+                    filter.getClass().getSimpleName()));
         }
     }
-
-    // -------------------------------------------------------------------------
-    // PropertyFilterBuilder
-    // -------------------------------------------------------------------------
 
     /**
      * Fluent builder for {@link PropertyFilter}.
      *
      * @param <V> the value type
      */
+    @Experimental
     public static class PropertyFilterBuilder<V> {
 
         protected final GenericFilter filter;
-        protected final Metadata metadata;
-        protected final FilterComponents filterComponents;
+        protected Metadata metadata;
+        protected FilterComponents filterComponents;
 
         protected String property;
         protected PropertyFilter.Operation operation;
@@ -175,10 +165,14 @@ public class FilterComponentBuilder {
         protected boolean operationTextVisible = true;
         protected boolean built = false;
 
-        protected PropertyFilterBuilder(GenericFilter filter, Metadata metadata, FilterComponents filterComponents) {
+        protected PropertyFilterBuilder(GenericFilter filter, ApplicationContext applicationContext) {
             this.filter = filter;
-            this.metadata = metadata;
-            this.filterComponents = filterComponents;
+            autowireDependencies(applicationContext);
+        }
+
+        protected void autowireDependencies(ApplicationContext applicationContext) {
+            this.metadata = applicationContext.getBean(Metadata.class);
+            this.filterComponents = applicationContext.getBean(FilterComponents.class);
         }
 
         /**
@@ -279,22 +273,19 @@ public class FilterComponentBuilder {
         }
     }
 
-    // -------------------------------------------------------------------------
-    // JpqlFilterBuilder
-    // -------------------------------------------------------------------------
-
     /**
      * Fluent builder for {@link JpqlFilter}.
      *
      * @param <V> the value type ({@link Boolean} for a void/checkbox filter, or the parameter type)
      */
+    @Experimental
     public static class JpqlFilterBuilder<V> {
 
         protected final GenericFilter filter;
-        protected final Metadata metadata;
-        protected final FilterComponents filterComponents;
-        protected final JpqlFilterSupport jpqlFilterSupport;
         protected final Class<?> parameterClass;
+        protected Metadata metadata;
+        protected FilterComponents filterComponents;
+        protected JpqlFilterSupport jpqlFilterSupport;
 
         protected String where;
         protected String join;
@@ -304,13 +295,16 @@ public class FilterComponentBuilder {
         protected boolean hasInExpression;
         protected boolean built = false;
 
-        protected JpqlFilterBuilder(GenericFilter filter, Metadata metadata, FilterComponents filterComponents,
-                          JpqlFilterSupport jpqlFilterSupport, Class<?> parameterClass) {
+        protected JpqlFilterBuilder(GenericFilter filter, ApplicationContext applicationContext, Class<?> parameterClass) {
             this.filter = filter;
-            this.metadata = metadata;
-            this.filterComponents = filterComponents;
-            this.jpqlFilterSupport = jpqlFilterSupport;
             this.parameterClass = parameterClass;
+            autowireDependencies(applicationContext);
+        }
+
+        protected void autowireDependencies(ApplicationContext applicationContext) {
+            this.metadata = applicationContext.getBean(Metadata.class);
+            this.filterComponents = applicationContext.getBean(FilterComponents.class);
+            this.jpqlFilterSupport = applicationContext.getBean(JpqlFilterSupport.class);
         }
 
         /**
@@ -411,25 +405,26 @@ public class FilterComponentBuilder {
         }
     }
 
-    // -------------------------------------------------------------------------
-    // GroupFilterBuilder
-    // -------------------------------------------------------------------------
-
     /**
      * Fluent builder for {@link GroupFilter}.
      */
+    @Experimental
     public static class GroupFilterBuilder {
 
         protected final GenericFilter filter;
-        protected final UiComponents uiComponents;
+        protected UiComponents uiComponents;
 
         protected LogicalFilterComponent.Operation operation = LogicalFilterComponent.Operation.AND;
         protected final List<FilterComponent> components = new ArrayList<>();
         protected boolean built = false;
 
-        protected GroupFilterBuilder(GenericFilter filter, UiComponents uiComponents) {
+        protected GroupFilterBuilder(GenericFilter filter, ApplicationContext applicationContext) {
             this.filter = filter;
-            this.uiComponents = uiComponents;
+            autowireDependencies(applicationContext);
+        }
+
+        protected void autowireDependencies(ApplicationContext applicationContext) {
+            this.uiComponents = applicationContext.getBean(UiComponents.class);
         }
 
         /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilter.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilter.java
@@ -26,9 +26,9 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.shared.Registration;
 import io.jmix.core.AccessManager;
-import io.jmix.core.annotation.Experimental;
 import io.jmix.core.Messages;
 import io.jmix.core.Metadata;
+import io.jmix.core.annotation.Experimental;
 import io.jmix.core.metamodel.model.MetaPropertyPath;
 import io.jmix.core.querycondition.Condition;
 import io.jmix.core.querycondition.LogicalCondition;
@@ -604,37 +604,16 @@ public class GenericFilter extends Composite<JmixDetails>
      * The configuration must already be registered with this filter via
      * {@link #addConfiguration(Configuration)}. If it is not registered, this method
      * logs a warning and does nothing.
-     * <p>
-     * To register and activate a configuration in one call, use
-     * {@link #addAndSetCurrentConfiguration(Configuration)}.
      *
      * @param currentConfiguration a configuration to activate
-     * @see #addAndSetCurrentConfiguration(Configuration)
      */
     public void setCurrentConfiguration(Configuration currentConfiguration) {
         if (!configurations.contains(currentConfiguration)
                 && !getEmptyConfiguration().equals(currentConfiguration)) {
-            log.warn("Configuration '{}' is not registered in this filter. " +
-                            "Call addConfiguration() first, or use addAndSetCurrentConfiguration().",
+            log.warn("Configuration '{}' is not registered in this filter; call addConfiguration() first.",
                     currentConfiguration.getId());
         }
         setCurrentConfigurationInternal(currentConfiguration, false);
-    }
-
-    /**
-     * Registers the given configuration with this filter and immediately sets it as the current
-     * configuration, in the correct order and in a single call.
-     * <p>
-     * This is a convenience alternative to calling {@link #addConfiguration(Configuration)}
-     * followed by {@link #setCurrentConfiguration(Configuration)}, which fails silently when
-     * the configuration is not yet registered at the time {@code setCurrentConfiguration} is
-     * invoked.
-     *
-     * @param configuration the configuration to register and activate
-     */
-    public void addAndSetCurrentConfiguration(Configuration configuration) {
-        addConfiguration(configuration);
-        setCurrentConfiguration(configuration);
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilter.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilter.java
@@ -26,6 +26,7 @@ import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.shared.HasTooltip;
 import com.vaadin.flow.shared.Registration;
 import io.jmix.core.AccessManager;
+import io.jmix.core.annotation.Experimental;
 import io.jmix.core.Messages;
 import io.jmix.core.Metadata;
 import io.jmix.core.metamodel.model.MetaPropertyPath;
@@ -69,6 +70,8 @@ import io.jmix.flowui.model.DataLoader;
 import io.jmix.flowui.theme.StyleUtility;
 import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -87,6 +90,8 @@ import static com.google.common.base.Preconditions.checkState;
 public class GenericFilter extends Composite<JmixDetails>
         implements SupportsResponsiveSteps, HasActions, HasEnabled, HasSize, HasStyle, HasTheme, HasTooltip,
         ApplicationContextAware, InitializingBean {
+
+    private static final Logger log = LoggerFactory.getLogger(GenericFilter.class);
 
     protected static final String CONDITION_REMOVE_BUTTON_ID_SUFFIX = "conditionRemoveButton";
 
@@ -594,13 +599,80 @@ public class GenericFilter extends Composite<JmixDetails>
     }
 
     /**
-     * Sets the given configuration as current and displays filter components from the current
-     * configuration.
+     * Sets the given configuration as current and displays its filter components.
+     * <p>
+     * The configuration must already be registered with this filter via
+     * {@link #addConfiguration(Configuration)}. If it is not registered, this method
+     * logs a warning and does nothing.
+     * <p>
+     * To register and activate a configuration in one call, use
+     * {@link #addAndSetCurrentConfiguration(Configuration)}.
      *
-     * @param currentConfiguration a configuration
+     * @param currentConfiguration a configuration to activate
+     * @see #addAndSetCurrentConfiguration(Configuration)
      */
     public void setCurrentConfiguration(Configuration currentConfiguration) {
+        if (!configurations.contains(currentConfiguration)
+                && !getEmptyConfiguration().equals(currentConfiguration)) {
+            log.warn("Configuration '{}' is not registered in this filter. " +
+                            "Call addConfiguration() first, or use addAndSetCurrentConfiguration().",
+                    currentConfiguration.getId());
+        }
         setCurrentConfigurationInternal(currentConfiguration, false);
+    }
+
+    /**
+     * Registers the given configuration with this filter and immediately sets it as the current
+     * configuration, in the correct order and in a single call.
+     * <p>
+     * This is a convenience alternative to calling {@link #addConfiguration(Configuration)}
+     * followed by {@link #setCurrentConfiguration(Configuration)}, which fails silently when
+     * the configuration is not yet registered at the time {@code setCurrentConfiguration} is
+     * invoked.
+     *
+     * @param configuration the configuration to register and activate
+     */
+    public void addAndSetCurrentConfiguration(Configuration configuration) {
+        addConfiguration(configuration);
+        setCurrentConfiguration(configuration);
+    }
+
+    /**
+     * Refreshes the layout of the current configuration.
+     * <p>
+     * Call this method after programmatically modifying the current configuration's filter
+     * components (e.g. adding a component to the root {@link LogicalFilterComponent}) to force
+     * the filter UI to re-render remove buttons and update the data-loader condition.
+     * <p>
+     * This is a stable public equivalent of the internal {@code refreshCurrentConfigurationLayout()}.
+     */
+    public void refreshCurrentConfiguration() {
+        refreshCurrentConfigurationLayout();
+    }
+
+    /**
+     * Creates a new {@link FilterComponentBuilder} bound to this filter.
+     * <p>
+     * The builder assembles a condition model from its fluent parameters and delegates to the
+     * framework's converter, so a programmatically built component is initialised exactly like
+     * one loaded from XML. This filter must have a {@code DataLoader}.
+     *
+     * @return a new {@code FilterComponentBuilder} instance
+     */
+    @Experimental
+    public FilterComponentBuilder filterComponentBuilder() {
+        return new FilterComponentBuilder(this, applicationContext);
+    }
+
+    /**
+     * Creates a new {@link RunTimeConfigurationBuilder} for building and registering
+     * a {@link io.jmix.flowui.component.genericfilter.configuration.RunTimeConfiguration}.
+     *
+     * @return a new {@code RunTimeConfigurationBuilder} instance
+     */
+    @Experimental
+    public RunTimeConfigurationBuilder runtimeConfigurationBuilder() {
+        return new RunTimeConfigurationBuilder(this, uiComponents);
     }
 
     protected void setCurrentConfigurationInternal(Configuration currentConfiguration, boolean fromClient) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/RunTimeConfigurationBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/RunTimeConfigurationBuilder.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.component.genericfilter;
+
+import io.jmix.core.annotation.Experimental;
+import io.jmix.flowui.UiComponents;
+import io.jmix.flowui.component.filter.FilterComponent;
+import io.jmix.flowui.component.filter.SingleFilterComponentBase;
+import io.jmix.flowui.component.genericfilter.configuration.RunTimeConfiguration;
+import io.jmix.flowui.component.logicalfilter.GroupFilter;
+import io.jmix.flowui.component.logicalfilter.LogicalFilterComponent;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.jmix.core.common.util.Preconditions.checkNotNullArgument;
+
+/**
+ * Fluent builder for {@link RunTimeConfiguration}.
+ * <p>
+ * Use this builder when you need a <em>dynamic</em> configuration whose filter components
+ * can be added or removed at runtime (e.g. via the per-condition remove button).
+ * <p>
+ * Encapsulates all required steps:
+ * <ul>
+ *   <li>Creating and configuring the root {@link GroupFilter}</li>
+ *   <li>Adding filter components and recording their default values in the configuration</li>
+ *   <li>Marking all added components as modified so remove buttons appear immediately</li>
+ *   <li>Registering the configuration via {@link GenericFilter#addConfiguration(Configuration)}</li>
+ *   <li>Optionally activating the configuration via
+ *       {@link GenericFilter#setCurrentConfiguration(Configuration)}</li>
+ * </ul>
+ * <p>
+ * Obtain an instance via {@link GenericFilter#runtimeConfigurationBuilder()}:
+ * <pre>{@code
+ * filter.runtimeConfigurationBuilder()
+ *       .id("dynamicSearch")
+ *       .name("Dynamic Search")
+ *       .add(nameFilter)
+ *       .add(statusFilter, "NEW")
+ *       .makeCurrent()
+ *       .buildAndRegister();
+ * }</pre>
+ */
+@Experimental
+public class RunTimeConfigurationBuilder {
+
+    protected final GenericFilter filter;
+    protected final UiComponents uiComponents;
+
+    protected String id;
+    protected String name;
+    protected LogicalFilterComponent.Operation operation = LogicalFilterComponent.Operation.AND;
+    protected boolean makeCurrent = false;
+    protected boolean allowDeletion = false;
+
+    protected final List<ComponentEntry> entries = new ArrayList<>();
+
+    protected RunTimeConfigurationBuilder(GenericFilter filter, UiComponents uiComponents) {
+        this.filter = filter;
+        this.uiComponents = uiComponents;
+    }
+
+    /**
+     * Sets the configuration id. Required.
+     *
+     * @param id unique configuration identifier within this filter
+     */
+    public RunTimeConfigurationBuilder id(String id) {
+        checkNotNullArgument(id, "id must not be null");
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Sets the configuration display name.
+     *
+     * @param name display name shown in the configuration selector
+     */
+    public RunTimeConfigurationBuilder name(@Nullable String name) {
+        this.name = name;
+        return this;
+    }
+
+    /**
+     * Sets the logical operation of the root filter component. Defaults to {@code AND}.
+     *
+     * @param operation logical operation
+     */
+    public RunTimeConfigurationBuilder operation(LogicalFilterComponent.Operation operation) {
+        checkNotNullArgument(operation, "operation must not be null");
+        this.operation = operation;
+        return this;
+    }
+
+    /**
+     * Adds a filter component using the component's current value (if any) as the default.
+     *
+     * @param filterComponent filter component to add
+     */
+    public RunTimeConfigurationBuilder add(FilterComponent filterComponent) {
+        checkNotNullArgument(filterComponent, "filterComponent must not be null");
+        entries.add(new ComponentEntry(filterComponent, null, false));
+        return this;
+    }
+
+    /**
+     * Adds several filter components at once, each using its current value (if any) as the default.
+     * <p>
+     * Named {@code addAll} rather than overloading {@code add} to avoid ambiguity with
+     * {@link #add(SingleFilterComponentBase, Object)} when two filter components are passed.
+     *
+     * @param filterComponents filter components to add
+     */
+    public RunTimeConfigurationBuilder addAll(FilterComponent... filterComponents) {
+        checkNotNullArgument(filterComponents, "filterComponents must not be null");
+        for (FilterComponent filterComponent : filterComponents) {
+            add(filterComponent);
+        }
+        return this;
+    }
+
+    /**
+     * Adds a filter component, overriding its default value.
+     * <p>
+     * The type parameter {@code V} ensures the {@code defaultValue} matches the
+     * component's own value type at compile time.
+     *
+     * @param filterComponent filter component to add
+     * @param defaultValue    value to apply and record as the configuration default
+     * @param <V>             the value type of the filter component
+     */
+    public <V> RunTimeConfigurationBuilder add(SingleFilterComponentBase<V> filterComponent,
+                                               @Nullable V defaultValue) {
+        checkNotNullArgument(filterComponent, "filterComponent must not be null");
+        entries.add(new ComponentEntry(filterComponent, defaultValue, true));
+        return this;
+    }
+
+    /**
+     * Makes this configuration the current (active) one immediately after it is registered.
+     * <p>
+     * This is not the persistent <em>default</em> configuration marker (set via the
+     * {@code genericFilter_makeDefault} action and stored per user): it simply activates this
+     * configuration now, equivalent to {@link GenericFilter#setCurrentConfiguration(Configuration)}.
+     */
+    public RunTimeConfigurationBuilder makeCurrent() {
+        this.makeCurrent = true;
+        return this;
+    }
+
+    /**
+     * Controls whether the user can delete this configuration through the UI.
+     * <p>
+     * By default, configurations created via this builder are protected from user deletion
+     * ({@link RunTimeConfiguration#setProtectedFromUserDeletion(boolean)}).
+     *
+     * @param allowDeletion {@code true} to allow the user to remove the configuration,
+     *                      {@code false} (default) to protect it
+     */
+    public RunTimeConfigurationBuilder allowDeletion(boolean allowDeletion) {
+        this.allowDeletion = allowDeletion;
+        return this;
+    }
+
+    /**
+     * Allows the user to delete this configuration through the UI.
+     * Convenience alias for {@code allowDeletion(true)}.
+     */
+    public RunTimeConfigurationBuilder allowDeletion() {
+        return allowDeletion(true);
+    }
+
+    /**
+     * Builds the {@link RunTimeConfiguration}, registers it with the filter, and
+     * optionally activates it.
+     * <p>
+     * Automatically:
+     * <ul>
+     *   <li>Creates the root {@link GroupFilter} with {@code setConditionModificationDelegated(true)}
+     *       and {@code setDataLoader(filter.getDataLoader())}</li>
+     *   <li>Adds each filter component to the root</li>
+     *   <li>Calls {@code setFilterComponentDefaultValue} for every component with a value</li>
+     *   <li>Calls {@link GenericFilter#addAndSetCurrentConfiguration(Configuration)} if
+     *       {@link #makeCurrent()} was requested, or {@link GenericFilter#addConfiguration(Configuration)}
+     *       otherwise</li>
+     * </ul>
+     *
+     * @return the newly created and registered {@link RunTimeConfiguration}
+     * @throws IllegalStateException if {@code id} was not set, if a configuration with the
+     *         same id is already registered in the filter, or if the filter has no DataLoader
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public RunTimeConfiguration buildAndRegister() {
+        if (id == null) {
+            throw new IllegalStateException(
+                    "RunTimeConfigurationBuilder: 'id' is required — call .id(\"...\") before .buildAndRegister()");
+        }
+        if (filter.getConfiguration(id) != null) {
+            throw new IllegalStateException(String.format(
+                    "RunTimeConfigurationBuilder: a configuration with id '%s' is already registered in this filter", id));
+        }
+        if (filter.getDataLoader() == null) {
+            throw new IllegalStateException(
+                    "RunTimeConfigurationBuilder: the filter has no DataLoader; set it before building a configuration");
+        }
+
+        // Build the root GroupFilter — mirrors GenericFilter.createConfigurationRootLogicalFilterComponent()
+        GroupFilter root = uiComponents.create(GroupFilter.class);
+        root.setConditionModificationDelegated(true);
+        root.setOperation(operation);
+        root.setOperationTextVisible(false);
+        root.setAutoApply(filter.isAutoApply());
+        root.setDataLoader(filter.getDataLoader());
+
+        RunTimeConfiguration config = new RunTimeConfiguration(id, root, filter);
+        config.setName(name);
+
+        for (ComponentEntry entry : entries) {
+            FilterComponent fc = entry.filterComponent;
+
+            if (entry.overrideDefault && fc instanceof SingleFilterComponentBase<?> sfc) {
+                ((SingleFilterComponentBase) sfc).setValue(entry.defaultValue);
+            }
+
+            root.add(fc);
+
+            // Persist the default value for reset/restore behaviour.
+            // Skip components without a parameter name (e.g. void JpqlFilter with Void parameterClass).
+            if (fc instanceof SingleFilterComponentBase<?> sfc) {
+                String paramName = sfc.getParameterName();
+                Object valueToStore = entry.overrideDefault ? entry.defaultValue : sfc.getValue();
+                if (paramName != null && valueToStore != null) {
+                    config.setFilterComponentDefaultValue(paramName, valueToStore);
+                }
+            }
+        }
+
+        // All components are added — mark them as modified so remove buttons appear.
+        config.setModified(true);
+        config.setProtectedFromUserDeletion(!allowDeletion);
+
+        if (makeCurrent) {
+            filter.addAndSetCurrentConfiguration(config);
+        } else {
+            filter.addConfiguration(config);
+        }
+
+        return config;
+    }
+
+    // -------------------------------------------------------------------------
+
+    protected static class ComponentEntry {
+        protected final FilterComponent filterComponent;
+        protected final Object defaultValue;
+        protected final boolean overrideDefault;
+
+        protected ComponentEntry(FilterComponent filterComponent, @Nullable Object defaultValue, boolean overrideDefault) {
+            this.filterComponent = filterComponent;
+            this.defaultValue = defaultValue;
+            this.overrideDefault = overrideDefault;
+        }
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/RunTimeConfigurationBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/RunTimeConfigurationBuilder.java
@@ -196,9 +196,9 @@ public class RunTimeConfigurationBuilder {
      *       and {@code setDataLoader(filter.getDataLoader())}</li>
      *   <li>Adds each filter component to the root</li>
      *   <li>Calls {@code setFilterComponentDefaultValue} for every component with a value</li>
-     *   <li>Calls {@link GenericFilter#addAndSetCurrentConfiguration(Configuration)} if
-     *       {@link #makeCurrent()} was requested, or {@link GenericFilter#addConfiguration(Configuration)}
-     *       otherwise</li>
+     *   <li>Registers the configuration via {@link GenericFilter#addConfiguration(Configuration)}, and
+     *       activates it via {@link GenericFilter#setCurrentConfiguration(Configuration)} if
+     *       {@link #makeCurrent()} was requested</li>
      * </ul>
      *
      * @return the newly created and registered {@link RunTimeConfiguration}
@@ -255,16 +255,13 @@ public class RunTimeConfigurationBuilder {
         config.setModified(true);
         config.setProtectedFromUserDeletion(!allowDeletion);
 
+        filter.addConfiguration(config);
         if (makeCurrent) {
-            filter.addAndSetCurrentConfiguration(config);
-        } else {
-            filter.addConfiguration(config);
+            filter.setCurrentConfiguration(config);
         }
 
         return config;
     }
-
-    // -------------------------------------------------------------------------
 
     protected static class ComponentEntry {
         protected final FilterComponent filterComponent;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/RunTimeConfigurationBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/RunTimeConfigurationBuilder.java
@@ -68,6 +68,7 @@ public class RunTimeConfigurationBuilder {
     protected LogicalFilterComponent.Operation operation = LogicalFilterComponent.Operation.AND;
     protected boolean makeCurrent = false;
     protected boolean allowDeletion = false;
+    protected boolean built = false;
 
     protected final List<ComponentEntry> entries = new ArrayList<>();
 
@@ -121,9 +122,6 @@ public class RunTimeConfigurationBuilder {
 
     /**
      * Adds several filter components at once, each using its current value (if any) as the default.
-     * <p>
-     * Named {@code addAll} rather than overloading {@code add} to avoid ambiguity with
-     * {@link #add(SingleFilterComponentBase, Object)} when two filter components are passed.
      *
      * @param filterComponents filter components to add
      */
@@ -202,11 +200,16 @@ public class RunTimeConfigurationBuilder {
      * </ul>
      *
      * @return the newly created and registered {@link RunTimeConfiguration}
-     * @throws IllegalStateException if {@code id} was not set, if a configuration with the
-     *         same id is already registered in the filter, or if the filter has no DataLoader
+     * @throws IllegalStateException if this builder instance has already been used, if {@code id}
+     *         was not set, if a configuration with the same id is already registered in the filter,
+     *         or if the filter has no DataLoader
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
     public RunTimeConfiguration buildAndRegister() {
+        if (built) {
+            throw new IllegalStateException(
+                    "RunTimeConfigurationBuilder.buildAndRegister() must not be called more than once; create a new instance per configuration");
+        }
         if (id == null) {
             throw new IllegalStateException(
                     "RunTimeConfigurationBuilder: 'id' is required — call .id(\"...\") before .buildAndRegister()");
@@ -234,8 +237,8 @@ public class RunTimeConfigurationBuilder {
         for (ComponentEntry entry : entries) {
             FilterComponent fc = entry.filterComponent;
 
-            if (entry.overrideDefault && fc instanceof SingleFilterComponentBase<?> sfc) {
-                ((SingleFilterComponentBase) sfc).setValue(entry.defaultValue);
+            if (entry.overrideDefault && fc instanceof SingleFilterComponentBase sfc) {
+                sfc.setValue(entry.defaultValue);
             }
 
             root.add(fc);
@@ -260,6 +263,7 @@ public class RunTimeConfigurationBuilder {
             filter.setCurrentConfiguration(config);
         }
 
+        built = true;
         return config;
     }
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/configuration/RunTimeConfiguration.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/configuration/RunTimeConfiguration.java
@@ -40,6 +40,7 @@ public class RunTimeConfiguration implements Configuration {
     protected LogicalFilterComponent<?> rootLogicalFilterComponent;
     protected Set<FilterComponent> modifiedFilterComponents = new HashSet<>();
     protected Map<String, Object> defaultValuesMap = new HashMap<>();
+    protected boolean protectedFromUserDeletion = false;
 
     public RunTimeConfiguration(String id, LogicalFilterComponent<?> rootLogicalFilterComponent, GenericFilter owner) {
         this.id = id;
@@ -185,5 +186,25 @@ public class RunTimeConfiguration implements Configuration {
     @Override
     public int hashCode() {
         return id.hashCode();
+    }
+
+    /**
+     * Returns whether this configuration is protected from deletion by the user through the UI.
+     * <p>
+     * When {@code true}, the Remove action in the filter toolbar is hidden for this configuration.
+     *
+     * @return whether this configuration is protected from user deletion
+     */
+    public boolean isProtectedFromUserDeletion() {
+        return protectedFromUserDeletion;
+    }
+
+    /**
+     * Sets whether this configuration is protected from deletion by the user through the UI.
+     *
+     * @param protectedFromUserDeletion {@code true} to prevent the user from deleting this configuration
+     */
+    public void setProtectedFromUserDeletion(boolean protectedFromUserDeletion) {
+        this.protectedFromUserDeletion = protectedFromUserDeletion;
     }
 }

--- a/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterBuilderApiTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterBuilderApiTest.groovy
@@ -1,0 +1,886 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.genericfilter
+
+import component.genericfilter.view.GenericFilterApiTestView
+import io.jmix.flowui.UiComponents
+import io.jmix.flowui.component.genericfilter.GenericFilter
+import io.jmix.flowui.component.genericfilter.configuration.RunTimeConfiguration
+import io.jmix.flowui.component.jpqlfilter.JpqlFilter
+import io.jmix.flowui.component.logicalfilter.GroupFilter
+import io.jmix.flowui.component.logicalfilter.LogicalFilterComponent
+import io.jmix.flowui.component.propertyfilter.PropertyFilter
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import test_support.spec.FlowuiTestSpecification
+
+/**
+ * Documents and verifies the programmatic API for GenericFilter builder classes.
+ *
+ * <p>These tests are intentionally written as usage examples so that reading them
+ * gives a developer a quick and accurate picture of how to configure a
+ * {@link GenericFilter} in Java/Groovy without relying on XML.
+ *
+ * <h2>Test classification: narrow integration tests</h2>
+ * <p>Although individual test methods are small and focused (resembling unit tests),
+ * this class is technically an <em>integration test suite</em>:
+ * <ul>
+ *   <li>{@code @SpringBootTest} brings up a full Spring application context
+ *       ({@link io.jmix.flowui.FlowuiConfiguration}, EclipseLink, Data, Core, …).</li>
+ *   <li>{@link test_support.spec.FlowuiTestSpecification#setup()} initialises a real
+ *       Vaadin {@code UI} and {@code VaadinSession} for every test method.</li>
+ *   <li>All Spring beans ({@link io.jmix.flowui.UiComponents}, {@code Messages},
+ *       {@code Metadata}, …) are the real production implementations — no mocks.</li>
+ * </ul>
+ *
+ * <h2>DataLoader requirement</h2>
+ * <p>{@code FilterComponentBuilder} delegates to the framework converter, which requires the
+ * owning {@link GenericFilter} to have a {@code DataLoader}. Tests therefore obtain the filter
+ * from {@code GenericFilterApiTestView} (bound to an {@code ordersDl} loader) via
+ * {@link #filterWithLoader()}. Tests that exercise only configuration registration — which does
+ * not build filter components — use a bare {@code GenericFilter} created via
+ * {@code uiComponents.create(...)}.
+ */
+@SpringBootTest
+class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
+
+    @Autowired
+    UiComponents uiComponents
+
+    void setup() {
+        registerViewBasePackages("component.genericfilter.view")
+    }
+
+    /**
+     * Returns a {@link GenericFilter} bound to a {@code DataLoader} (the {@code ordersDl} loader
+     * of {@code GenericFilterApiTestView}). Required for building filter components, since the
+     * builder delegates to a converter that needs the loader's entity meta class.
+     */
+    protected GenericFilter filterWithLoader() {
+        return navigateToView(GenericFilterApiTestView).genericFilter
+    }
+
+    // =========================================================================
+    // FilterComponentBuilder — PropertyFilter
+    // =========================================================================
+
+    /**
+     * Demonstrates building a {@link PropertyFilter} with {@code filter.filterComponentBuilder()}.
+     * The builder assembles a condition model and delegates to the framework converter, so the
+     * resulting component is initialised exactly like an XML-loaded one.
+     */
+    def "PropertyFilterBuilder creates PropertyFilter with correct property and operation"() {
+        given: "A GenericFilter bound to a DataLoader"
+        GenericFilter filter = filterWithLoader()
+
+        when: "Building a PropertyFilter via the builder"
+        def numberFilter = filter.filterComponentBuilder()
+                .propertyFilter()
+                .property("number")
+                .operation(PropertyFilter.Operation.CONTAINS)
+                .build() as PropertyFilter
+
+        then: "PropertyFilter has the expected property, operation, and delegated flag"
+        numberFilter.property == "number"
+        numberFilter.operation == PropertyFilter.Operation.CONTAINS
+        numberFilter.conditionModificationDelegated
+    }
+
+    def "PropertyFilterBuilder.build() throws IllegalStateException when 'property' is not set"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        filter.filterComponentBuilder()
+                .propertyFilter()
+                .operation(PropertyFilter.Operation.EQUAL)
+                .build()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "PropertyFilterBuilder.build() throws IllegalStateException when 'operation' is not set"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        filter.filterComponentBuilder()
+                .propertyFilter()
+                .property("number")
+                .build()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "PropertyFilterBuilder.build() generates a parameterName automatically"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        def pf = filter.filterComponentBuilder()
+                .propertyFilter()
+                .property("number")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .build() as PropertyFilter
+
+        then: "parameterName is set automatically and derived from the property name"
+        pf.parameterName != null
+        pf.parameterName.startsWith("number")
+    }
+
+    def "PropertyFilterBuilder.defaultValue() sets the initial value"() {
+        given: "A GenericFilter with a DataLoader"
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        PropertyFilter<String> pf = filter.filterComponentBuilder()
+                .propertyFilter()
+                .property("number")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .defaultValue("ORD-001")
+                .build()
+
+        then:
+        pf.getValue() == "ORD-001"
+    }
+
+    def "PropertyFilterBuilder.operationEditable(true) is reflected on the built PropertyFilter"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        PropertyFilter<String> pf = filter.filterComponentBuilder()
+                .propertyFilter()
+                .property("number")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .operationEditable(true)
+                .build()
+
+        then:
+        pf.isOperationEditable()
+    }
+
+    def "PropertyFilterBuilder.operationTextVisible(false) is reflected on the built PropertyFilter"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        PropertyFilter<String> pf = filter.filterComponentBuilder()
+                .propertyFilter()
+                .property("number")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .operationTextVisible(false)
+                .build()
+
+        then:
+        !pf.isOperationTextVisible()
+    }
+
+    def "PropertyFilterBuilder.build() throws when called twice on the same instance"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+        def builder = filter.filterComponentBuilder()
+                .propertyFilter()
+                .property("number")
+                .operation(PropertyFilter.Operation.EQUAL)
+        builder.build()
+
+        when:
+        builder.build()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    // =========================================================================
+    // FilterComponentBuilder — JpqlFilter
+    // =========================================================================
+
+    /**
+     * A <em>void</em> {@link JpqlFilter} has no query parameter — it is rendered as a checkbox
+     * that toggles a fixed condition on and off. Use {@code filter.filterComponentBuilder().jpqlFilter()}
+     * (no class argument) to obtain this variant; its value type is {@link Boolean}.
+     */
+    def "JpqlFilterBuilder creates a void JpqlFilter rendered as a checkbox"() {
+        given: "A GenericFilter bound to a DataLoader"
+        GenericFilter filter = filterWithLoader()
+
+        when: "Building a void JpqlFilter (no query parameter)"
+        JpqlFilter<Boolean> activeFilter = filter.filterComponentBuilder()
+                .jpqlFilter()
+                .where("{E}.status = 'ACTIVE'")
+                .label("Active only")
+                .build()
+
+        then: "parameterClass is Void, the where clause is stored, and a checkbox value component is generated"
+        activeFilter.parameterClass == Void.class
+        activeFilter.where == "{E}.status = 'ACTIVE'"
+        activeFilter.conditionModificationDelegated
+        activeFilter.dataLoader == filter.dataLoader
+        activeFilter.valueComponent != null
+    }
+
+    /**
+     * A void {@link JpqlFilter} applies its WHERE clause only while it is active (checked).
+     * {@code defaultValue(true)} makes it active by default.
+     */
+    def "void JpqlFilter applies its WHERE clause to the query condition when active"() {
+        given: "A GenericFilter bound to a DataLoader"
+        GenericFilter filter = filterWithLoader()
+
+        when: "Building an active-by-default void JpqlFilter"
+        JpqlFilter<Boolean> activeFilter = filter.filterComponentBuilder()
+                .jpqlFilter()
+                .where("{E}.number = 'ACTIVE'")
+                .defaultValue(true)
+                .build()
+
+        then: "the value is true and the WHERE clause is applied to the query condition"
+        activeFilter.value == Boolean.TRUE
+        activeFilter.queryCondition.where == "{E}.number = 'ACTIVE'"
+    }
+
+    /**
+     * Without {@code defaultValue(true)} a void {@link JpqlFilter} starts inactive (unchecked),
+     * so its WHERE clause is not applied.
+     */
+    def "void JpqlFilter does not apply its WHERE clause when inactive"() {
+        given: "A GenericFilter bound to a DataLoader"
+        GenericFilter filter = filterWithLoader()
+
+        when: "Building a void JpqlFilter without a default value"
+        JpqlFilter<Boolean> activeFilter = filter.filterComponentBuilder()
+                .jpqlFilter()
+                .where("{E}.number = 'ACTIVE'")
+                .build()
+
+        then: "the WHERE clause is not applied"
+        activeFilter.value != Boolean.TRUE
+        !activeFilter.queryCondition.where
+    }
+
+    /**
+     * A <em>typed</em> {@link JpqlFilter} takes a query parameter whose type is specified via
+     * {@code jpqlFilter(Class)}; the user-supplied value is bound to the parameter.
+     */
+    def "JpqlFilterBuilder creates a typed JpqlFilter with a named query parameter"() {
+        given: "A GenericFilter bound to a DataLoader"
+        GenericFilter filter = filterWithLoader()
+
+        when: "Building a typed JpqlFilter with a String parameter"
+        JpqlFilter<String> codeFilter = filter.filterComponentBuilder()
+                .jpqlFilter(String)
+                .parameterName("code")
+                .where("{E}.code = ?")
+                .build()
+
+        then: "JpqlFilter has the correct parameter class and name"
+        codeFilter.parameterClass == String.class
+        codeFilter.parameterName == "code"
+        codeFilter.conditionModificationDelegated
+    }
+
+    def "JpqlFilterBuilder.build() throws IllegalStateException when 'where' is not set"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        filter.filterComponentBuilder()
+                .jpqlFilter()
+                .build()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "JpqlFilterBuilder.build() generates a valueComponent"() {
+        given: "A GenericFilter bound to a DataLoader"
+        GenericFilter filter = filterWithLoader()
+
+        when: "Building a typed JpqlFilter"
+        JpqlFilter<String> jf = filter.filterComponentBuilder()
+                .jpqlFilter(String)
+                .parameterName("number")
+                .where("{E}.number = ?")
+                .build()
+
+        then: "valueComponent is non-null, mirroring what the XML loader produces"
+        jf.valueComponent != null
+    }
+
+    def "JpqlFilterBuilder.hasInExpression(true) is reflected on the built JpqlFilter"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        JpqlFilter<String> jf = filter.filterComponentBuilder()
+                .jpqlFilter(String)
+                .parameterName("tags")
+                .where("{E}.tags in ?")
+                .hasInExpression(true)
+                .build()
+
+        then:
+        jf.hasInExpression
+    }
+
+    /**
+     * A {@code parameterName} is optional: when omitted it is generated automatically, matching
+     * the behaviour of the XML loader. Set it explicitly only for a named bind parameter.
+     */
+    def "JpqlFilterBuilder typed without parameterName generates one automatically"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        JpqlFilter<String> jf = filter.filterComponentBuilder()
+                .jpqlFilter(String)
+                .where("{E}.number = ?")
+                .build()
+
+        then:
+        jf.parameterName != null
+        !jf.parameterName.isEmpty()
+    }
+
+    def "JpqlFilterBuilder.build() throws when called twice on the same instance"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+        def builder = filter.filterComponentBuilder()
+                .jpqlFilter(String)
+                .parameterName("code")
+                .where("{E}.code = ?")
+        builder.build()
+
+        when:
+        builder.build()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    // =========================================================================
+    // FilterComponentBuilder — GroupFilter
+    // =========================================================================
+
+    /**
+     * {@link GroupFilter} bundles several conditions under a single logical operator
+     * (AND or OR).  Use {@code filter.filterComponentBuilder().groupFilter()} to create one.
+     */
+    def "GroupFilterBuilder creates a GroupFilter with specified operation and child components"() {
+        given: "A GenericFilter bound to a DataLoader"
+        GenericFilter filter = filterWithLoader()
+        def builder = filter.filterComponentBuilder()
+
+        and: "Two void JpqlFilter conditions"
+        def activeFilter = builder.jpqlFilter().where("{E}.status = 'ACTIVE'").build()
+        def verifiedFilter = filter.filterComponentBuilder().jpqlFilter().where("{E}.verified = true").build()
+
+        when: "Building an OR group that contains both conditions"
+        GroupFilter group = filter.filterComponentBuilder().groupFilter()
+                .operation(LogicalFilterComponent.Operation.OR)
+                .add(activeFilter)
+                .add(verifiedFilter)
+                .build()
+
+        then: "GroupFilter has the expected operation and children"
+        group.operation == LogicalFilterComponent.Operation.OR
+        group.filterComponents.size() == 2
+        group.filterComponents.contains(activeFilter)
+        group.filterComponents.contains(verifiedFilter)
+        group.conditionModificationDelegated
+    }
+
+    def "GroupFilterBuilder.addAll() adds multiple components at once"() {
+        given: "A GenericFilter bound to a DataLoader and two conditions"
+        GenericFilter filter = filterWithLoader()
+        def f1 = filter.filterComponentBuilder().jpqlFilter().where("{E}.status = 'A'").build()
+        def f2 = filter.filterComponentBuilder().jpqlFilter().where("{E}.status = 'B'").build()
+
+        when: "Adding both via the addAll vararg"
+        GroupFilter group = filter.filterComponentBuilder().groupFilter()
+                .addAll(f1, f2)
+                .build()
+
+        then:
+        group.filterComponents.size() == 2
+        group.filterComponents.contains(f1)
+        group.filterComponents.contains(f2)
+    }
+
+    def "GroupFilterBuilder defaults to AND when no operation is specified"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        GroupFilter group = filter.filterComponentBuilder()
+                .groupFilter()
+                .build()
+
+        then:
+        group.operation == LogicalFilterComponent.Operation.AND
+    }
+
+    def "GroupFilterBuilder copies autoApply from the owning filter"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+        filter.setAutoApply(false)
+
+        when:
+        GroupFilter group = filter.filterComponentBuilder()
+                .groupFilter()
+                .build()
+
+        then:
+        !group.isAutoApply()
+    }
+
+    def "GroupFilterBuilder propagates the DataLoader to the built GroupFilter"() {
+        given: "A GenericFilter with a DataLoader"
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        GroupFilter group = filter.filterComponentBuilder()
+                .groupFilter()
+                .build()
+
+        then:
+        group.dataLoader != null
+        group.dataLoader == filter.dataLoader
+    }
+
+    def "GroupFilterBuilder.build() throws when called twice on the same instance"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+        def builder = filter.filterComponentBuilder().groupFilter()
+        builder.build()
+
+        when:
+        builder.build()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    // =========================================================================
+    // FilterComponentBuilder — DataLoader requirement
+    // =========================================================================
+
+    /**
+     * The builder delegates to the framework converter, which needs the owning filter's
+     * {@code DataLoader}. Building a component without one fails fast.
+     */
+    def "FilterComponentBuilder requires the owning filter to have a DataLoader"() {
+        given: "A GenericFilter created without a DataLoader"
+        GenericFilter filter = uiComponents.create(GenericFilter)
+
+        when:
+        filter.filterComponentBuilder()
+                .propertyFilter()
+                .property("number")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .build()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    // =========================================================================
+    // RunTimeConfigurationBuilder
+    // =========================================================================
+
+    /**
+     * {@link io.jmix.flowui.component.genericfilter.RunTimeConfigurationBuilder}
+     * creates a {@link RunTimeConfiguration} — a dynamic configuration whose
+     * conditions can be added or removed by the user at runtime.
+     * <p>
+     * Obtain one with {@code filter.runtimeConfigurationBuilder()}.
+     */
+    def "RunTimeConfigurationBuilder creates and registers a RunTimeConfiguration"() {
+        given: "A GenericFilter bound to a DataLoader"
+        GenericFilter filter = filterWithLoader()
+
+        and: "A void JpqlFilter condition"
+        def activeFilter = filter.filterComponentBuilder()
+                .jpqlFilter()
+                .where("{E}.status = 'ACTIVE'")
+                .build()
+
+        when: "Creating a RunTimeConfiguration via the builder"
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("dynamic")
+                .name("Dynamic Search")
+                .add(activeFilter)
+                .buildAndRegister()
+
+        then: "Configuration is registered and contains the added condition"
+        filter.configurations.any { it.id == "dynamic" }
+        config instanceof RunTimeConfiguration
+        config.id == "dynamic"
+        config.name == "Dynamic Search"
+        config.rootLogicalFilterComponent.filterComponents.contains(activeFilter)
+    }
+
+    def "RunTimeConfigurationBuilder.addAll() adds multiple components at once"() {
+        given: "A GenericFilter bound to a DataLoader and two conditions"
+        GenericFilter filter = filterWithLoader()
+        def f1 = filter.filterComponentBuilder().jpqlFilter().where("{E}.status = 'A'").build()
+        def f2 = filter.filterComponentBuilder().jpqlFilter().where("{E}.status = 'B'").build()
+
+        when: "Adding both via the addAll vararg"
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("multi")
+                .addAll(f1, f2)
+                .buildAndRegister()
+
+        then:
+        config.rootLogicalFilterComponent.filterComponents.contains(f1)
+        config.rootLogicalFilterComponent.filterComponents.contains(f2)
+    }
+
+    def "RunTimeConfigurationBuilder.makeCurrent() activates the configuration immediately"() {
+        given: "A GenericFilter bound to a DataLoader"
+        GenericFilter filter = filterWithLoader()
+
+        when: "Creating a RunTimeConfiguration and making it current"
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("active")
+                .makeCurrent()
+                .buildAndRegister()
+
+        then: "The configuration is the filter's current configuration"
+        filter.currentConfiguration == config
+    }
+
+    def "RunTimeConfigurationBuilder respects the specified logical operation"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("orRuntime")
+                .operation(LogicalFilterComponent.Operation.OR)
+                .buildAndRegister()
+
+        then:
+        config.rootLogicalFilterComponent.operation == LogicalFilterComponent.Operation.OR
+    }
+
+    def "RunTimeConfigurationBuilder.buildAndRegister() throws when 'id' is not set"() {
+        given:
+        GenericFilter filter = uiComponents.create(GenericFilter)
+
+        when:
+        filter.runtimeConfigurationBuilder()
+                .buildAndRegister()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "RunTimeConfigurationBuilder.buildAndRegister() throws when id is already registered"() {
+        given: "A filter that already has a configuration with id 'dup'"
+        GenericFilter filter = filterWithLoader()
+        filter.runtimeConfigurationBuilder()
+                .id("dup")
+                .buildAndRegister()
+
+        when: "Registering another configuration with the same id"
+        filter.runtimeConfigurationBuilder()
+                .id("dup")
+                .buildAndRegister()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    /**
+     * {@link RunTimeConfiguration} stores the default value in the configuration map so the
+     * value can be restored on reset.
+     */
+    def "RunTimeConfigurationBuilder stores the default value for reset support"() {
+        given: "A GenericFilter and a typed JpqlFilter"
+        GenericFilter filter = filterWithLoader()
+        JpqlFilter<String> codeFilter = filter.filterComponentBuilder()
+                .jpqlFilter(String)
+                .parameterName("code")
+                .where("{E}.code = ?")
+                .build()
+
+        when: "Registering the filter component with an explicit default value"
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("byCode")
+                .add(codeFilter, "DEFAULT")
+                .buildAndRegister()
+
+        then: "The default value is retrievable from the configuration"
+        config.getFilterComponentDefaultValue("code") == "DEFAULT"
+    }
+
+    def "RunTimeConfigurationBuilder.add(fc, value) calls setValue on the component"() {
+        given: "A GenericFilter with a DataLoader so the JpqlFilter gets a value component"
+        GenericFilter filter = filterWithLoader()
+
+        and: "A typed JpqlFilter built with a value component"
+        JpqlFilter<String> jf = filter.filterComponentBuilder()
+                .jpqlFilter(String)
+                .parameterName("number")
+                .where("{E}.number = ?")
+                .build()
+
+        when: "Adding the filter with an explicit default value"
+        filter.runtimeConfigurationBuilder()
+                .id("byNumber")
+                .add(jf, "ORD-999")
+                .buildAndRegister()
+
+        then: "setValue was called on the component"
+        jf.getValue() == "ORD-999"
+    }
+
+    // =========================================================================
+    // RunTimeConfiguration — modified state
+    // =========================================================================
+
+    /**
+     * Components added through the builder are marked as modified by the builder
+     * itself (via {@code config.setModified(true)}) so the per-condition remove
+     * button is visible immediately — no extra boilerplate needed.
+     */
+    def "Components added via RunTimeConfigurationBuilder are marked as modified"() {
+        given: "A void JpqlFilter condition"
+        GenericFilter filter = filterWithLoader()
+        def fc = filter.filterComponentBuilder()
+                .jpqlFilter()
+                .where("{E}.active = true")
+                .build()
+
+        when: "Creating a RunTimeConfiguration with the condition via the builder"
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("with-condition")
+                .add(fc)
+                .buildAndRegister()
+
+        then: "The condition is marked as modified (remove button visible)"
+        config.isFilterComponentModified(fc)
+        config.isModified()
+    }
+
+    def "RunTimeConfigurationBuilder copies autoApply from the filter"() {
+        given: "A GenericFilter with autoApply explicitly set to false"
+        GenericFilter filter = filterWithLoader()
+        filter.setAutoApply(false)
+
+        and: "A condition that will be added to the configuration"
+        def fc = filter.filterComponentBuilder()
+                .jpqlFilter()
+                .where("{E}.active = true")
+                .build()
+
+        when: "Building a RunTimeConfiguration"
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("noAutoApply")
+                .add(fc)
+                .buildAndRegister()
+
+        then: "Root GroupFilter inherits autoApply=false from the filter"
+        !config.rootLogicalFilterComponent.isAutoApply()
+
+        and: "Child filter component also has autoApply=false (GroupFilter.add() propagates it)"
+        !fc.isAutoApply()
+    }
+
+    def "Empty RunTimeConfiguration built without components is not modified"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("empty")
+                .buildAndRegister()
+
+        then:
+        !config.isModified()
+    }
+
+    // =========================================================================
+    // RunTimeConfiguration — protection from user deletion
+    // =========================================================================
+
+    def "RunTimeConfigurationBuilder creates configuration protected from user deletion by default"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("protected")
+                .buildAndRegister()
+
+        then:
+        config.isProtectedFromUserDeletion()
+    }
+
+    def "RunTimeConfigurationBuilder.allowDeletion() disables user-deletion protection"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("deletable")
+                .allowDeletion()
+                .buildAndRegister()
+
+        then:
+        !config.isProtectedFromUserDeletion()
+    }
+
+    def "RunTimeConfigurationBuilder.allowDeletion(true) disables protection"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("deletable2")
+                .allowDeletion(true)
+                .buildAndRegister()
+
+        then:
+        !config.isProtectedFromUserDeletion()
+    }
+
+    def "RunTimeConfigurationBuilder.allowDeletion(false) keeps protection enabled"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+
+        when:
+        RunTimeConfiguration config = filter.runtimeConfigurationBuilder()
+                .id("protected2")
+                .allowDeletion(false)
+                .buildAndRegister()
+
+        then:
+        config.isProtectedFromUserDeletion()
+    }
+
+    /**
+     * {@code protectedFromUserDeletion} only hides the Remove action in the UI
+     * ({@code GenericFilterRemoveAction#isApplicable}). Programmatic removal via
+     * {@code removeConfiguration()} must still work — it is used internally,
+     * e.g. by the configuration renaming flow.
+     */
+    def "removeConfiguration() removes a configuration protected from user deletion"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+        filter.runtimeConfigurationBuilder()
+                .id("protected")
+                .buildAndRegister()
+
+        when:
+        filter.removeConfiguration(filter.getConfigurations().find { it.id == "protected" })
+
+        then:
+        !filter.getConfigurations().any { it.id == "protected" }
+    }
+
+    def "removeConfiguration() removes a configuration created with allowDeletion()"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+        filter.runtimeConfigurationBuilder()
+                .id("deletable")
+                .allowDeletion()
+                .buildAndRegister()
+
+        when:
+        filter.removeConfiguration(filter.getConfigurations().find { it.id == "deletable" })
+
+        then:
+        !filter.getConfigurations().any { it.id == "deletable" }
+    }
+
+    // =========================================================================
+    // GenericFilter helper methods
+    // =========================================================================
+
+    /**
+     * {@link GenericFilter#addAndSetCurrentConfiguration} registers a configuration
+     * <em>and</em> makes it current in a single atomic call — avoiding the silent
+     * no-op of calling {@link GenericFilter#setCurrentConfiguration} on an
+     * unregistered configuration.
+     */
+    def "addAndSetCurrentConfiguration registers and activates an unregistered configuration"() {
+        given: "A GenericFilter and a RunTimeConfiguration that has NOT been registered yet"
+        GenericFilter filter = uiComponents.create(GenericFilter)
+        def initialConfig = filter.currentConfiguration
+        GroupFilter root = uiComponents.create(GroupFilter)
+        root.setConditionModificationDelegated(true)
+        root.setOperation(LogicalFilterComponent.Operation.AND)
+        RunTimeConfiguration config = new RunTimeConfiguration("new", root, filter)
+
+        expect: "configuration is not registered"
+        !filter.configurations.contains(config)
+
+        when: "addAndSetCurrentConfiguration registers and activates it atomically"
+        filter.addAndSetCurrentConfiguration(config)
+
+        then: "configuration is now registered and active"
+        filter.configurations.contains(config)
+        filter.currentConfiguration == config
+        filter.currentConfiguration != initialConfig
+    }
+
+    /**
+     * {@link GenericFilter#setCurrentConfiguration} silently ignores a configuration
+     * that has not been registered with the filter.  This is a known limitation of
+     * the existing API; use {@link GenericFilter#addAndSetCurrentConfiguration} to
+     * avoid it.
+     */
+    def "setCurrentConfiguration silently ignores an unregistered configuration"() {
+        given: "A GenericFilter with its initial current configuration"
+        GenericFilter filter = uiComponents.create(GenericFilter)
+        def initialConfig = filter.currentConfiguration
+
+        and: "A RunTimeConfiguration that has NOT been registered with this filter"
+        GroupFilter root = uiComponents.create(GroupFilter)
+        root.setConditionModificationDelegated(true)
+        root.setOperation(LogicalFilterComponent.Operation.AND)
+        RunTimeConfiguration unregistered = new RunTimeConfiguration("unregistered", root, filter)
+
+        when: "Trying to activate the unregistered configuration"
+        filter.setCurrentConfiguration(unregistered)
+
+        then: "Current configuration is unchanged — no exception, no switch"
+        filter.currentConfiguration == initialConfig
+    }
+
+    /**
+     * {@link GenericFilter#refreshCurrentConfiguration} forces the filter UI to
+     * re-render the current configuration's conditions.  It is a public shorthand
+     * for the otherwise protected {@code refreshCurrentConfigurationLayout()}.
+     */
+    def "refreshCurrentConfiguration does not throw for a filter without conditions"() {
+        given:
+        GenericFilter filter = uiComponents.create(GenericFilter)
+
+        when:
+        filter.refreshCurrentConfiguration()
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterBuilderApiTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterBuilderApiTest.groovy
@@ -74,9 +74,7 @@ class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
         return navigateToView(GenericFilterApiTestView).genericFilter
     }
 
-    // =========================================================================
     // FilterComponentBuilder — PropertyFilter
-    // =========================================================================
 
     /**
      * Demonstrates building a {@link PropertyFilter} with {@code filter.filterComponentBuilder()}.
@@ -208,9 +206,7 @@ class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
         thrown(IllegalStateException)
     }
 
-    // =========================================================================
     // FilterComponentBuilder — JpqlFilter
-    // =========================================================================
 
     /**
      * A <em>void</em> {@link JpqlFilter} has no query parameter — it is rendered as a checkbox
@@ -375,9 +371,7 @@ class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
         thrown(IllegalStateException)
     }
 
-    // =========================================================================
     // FilterComponentBuilder — GroupFilter
-    // =========================================================================
 
     /**
      * {@link GroupFilter} bundles several conditions under a single logical operator
@@ -478,9 +472,7 @@ class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
         thrown(IllegalStateException)
     }
 
-    // =========================================================================
     // FilterComponentBuilder — DataLoader requirement
-    // =========================================================================
 
     /**
      * The builder delegates to the framework converter, which needs the owning filter's
@@ -501,9 +493,7 @@ class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
         thrown(IllegalStateException)
     }
 
-    // =========================================================================
     // RunTimeConfigurationBuilder
-    // =========================================================================
 
     /**
      * {@link io.jmix.flowui.component.genericfilter.RunTimeConfigurationBuilder}
@@ -654,9 +644,7 @@ class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
         jf.getValue() == "ORD-999"
     }
 
-    // =========================================================================
     // RunTimeConfiguration — modified state
-    // =========================================================================
 
     /**
      * Components added through the builder are marked as modified by the builder
@@ -719,9 +707,7 @@ class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
         !config.isModified()
     }
 
-    // =========================================================================
     // RunTimeConfiguration — protection from user deletion
-    // =========================================================================
 
     def "RunTimeConfigurationBuilder creates configuration protected from user deletion by default"() {
         given:
@@ -813,60 +799,7 @@ class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
         !filter.getConfigurations().any { it.id == "deletable" }
     }
 
-    // =========================================================================
     // GenericFilter helper methods
-    // =========================================================================
-
-    /**
-     * {@link GenericFilter#addAndSetCurrentConfiguration} registers a configuration
-     * <em>and</em> makes it current in a single atomic call — avoiding the silent
-     * no-op of calling {@link GenericFilter#setCurrentConfiguration} on an
-     * unregistered configuration.
-     */
-    def "addAndSetCurrentConfiguration registers and activates an unregistered configuration"() {
-        given: "A GenericFilter and a RunTimeConfiguration that has NOT been registered yet"
-        GenericFilter filter = uiComponents.create(GenericFilter)
-        def initialConfig = filter.currentConfiguration
-        GroupFilter root = uiComponents.create(GroupFilter)
-        root.setConditionModificationDelegated(true)
-        root.setOperation(LogicalFilterComponent.Operation.AND)
-        RunTimeConfiguration config = new RunTimeConfiguration("new", root, filter)
-
-        expect: "configuration is not registered"
-        !filter.configurations.contains(config)
-
-        when: "addAndSetCurrentConfiguration registers and activates it atomically"
-        filter.addAndSetCurrentConfiguration(config)
-
-        then: "configuration is now registered and active"
-        filter.configurations.contains(config)
-        filter.currentConfiguration == config
-        filter.currentConfiguration != initialConfig
-    }
-
-    /**
-     * {@link GenericFilter#setCurrentConfiguration} silently ignores a configuration
-     * that has not been registered with the filter.  This is a known limitation of
-     * the existing API; use {@link GenericFilter#addAndSetCurrentConfiguration} to
-     * avoid it.
-     */
-    def "setCurrentConfiguration silently ignores an unregistered configuration"() {
-        given: "A GenericFilter with its initial current configuration"
-        GenericFilter filter = uiComponents.create(GenericFilter)
-        def initialConfig = filter.currentConfiguration
-
-        and: "A RunTimeConfiguration that has NOT been registered with this filter"
-        GroupFilter root = uiComponents.create(GroupFilter)
-        root.setConditionModificationDelegated(true)
-        root.setOperation(LogicalFilterComponent.Operation.AND)
-        RunTimeConfiguration unregistered = new RunTimeConfiguration("unregistered", root, filter)
-
-        when: "Trying to activate the unregistered configuration"
-        filter.setCurrentConfiguration(unregistered)
-
-        then: "Current configuration is unchanged — no exception, no switch"
-        filter.currentConfiguration == initialConfig
-    }
 
     /**
      * {@link GenericFilter#refreshCurrentConfiguration} forces the filter UI to

--- a/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterBuilderApiTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterBuilderApiTest.groovy
@@ -206,6 +206,30 @@ class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
         thrown(IllegalStateException)
     }
 
+    /**
+     * The one-shot guard is set only after a successful build, so a build that fails validation
+     * does not "burn" the builder — the caller can fix the input and build again.
+     */
+    def "PropertyFilterBuilder.build() failing validation does not consume the builder"() {
+        given:
+        GenericFilter filter = filterWithLoader()
+        def builder = filter.filterComponentBuilder()
+                .propertyFilter()
+                .operation(PropertyFilter.Operation.EQUAL)   // 'property' not set yet
+
+        when: "first build fails validation"
+        builder.build()
+
+        then:
+        thrown(IllegalStateException)
+
+        when: "the missing property is set and build is retried on the same instance"
+        PropertyFilter<String> pf = builder.property("number").build()
+
+        then: "it builds successfully"
+        pf.property == "number"
+    }
+
     // FilterComponentBuilder — JpqlFilter
 
     /**
@@ -595,6 +619,19 @@ class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
         filter.runtimeConfigurationBuilder()
                 .id("dup")
                 .buildAndRegister()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
+    def "RunTimeConfigurationBuilder.buildAndRegister() throws when called twice on the same instance"() {
+        given: "A DataLoader-bound filter so the first build succeeds and sets the one-shot flag"
+        GenericFilter filter = filterWithLoader()
+        def builder = filter.runtimeConfigurationBuilder().id("once")
+        builder.buildAndRegister()
+
+        when:
+        builder.buildAndRegister()
 
         then:
         thrown(IllegalStateException)

--- a/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GenericFilterApiTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GenericFilterApiTestView.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.genericfilter.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.component.genericfilter.GenericFilter;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+
+@Route(value = "generic-filter-api-test-view")
+@ViewController("GenericFilterApiTestView")
+@ViewDescriptor("generic-filter-api-test-view.xml")
+public class GenericFilterApiTestView extends StandardView {
+
+    @ViewComponent
+    public GenericFilter genericFilter;
+}

--- a/jmix-flowui/flowui/src/test/resources/component/genericfilter/view/generic-filter-api-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/genericfilter/view/generic-filter-api-test-view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <collection id="ordersDc"
+                    class="test_support.entity.sales.Order">
+            <fetchPlan extends="_base"/>
+            <loader id="ordersDl">
+                <query>
+                    <![CDATA[select e from test_Order e]]>
+                </query>
+            </loader>
+        </collection>
+    </data>
+    <layout>
+        <genericFilter id="genericFilter" dataLoader="ordersDl"/>
+    </layout>
+</view>


### PR DESCRIPTION
# GenericFilter: fluent builder API for programmatic filter configuration

Closes #5351.

## Problem

Configuring a `GenericFilter` programmatically today requires manually reproducing
the initialisation the framework performs internally (delegating condition
modification, wiring the `DataLoader`, generating the value component and parameter
name, ordering `setProperty → setOperation → setValue`), plus manual wiring of
`RunTimeConfiguration`. Missing any step silently produces wrong behaviour.

## Solution

Two new `@Experimental` fluent builders. Single filter components are built by
assembling a condition model from the fluent parameters and delegating to the same
`FilterConverter` the framework uses for XML loading and the add-condition UI — the
converter is the single source of truth, so a programmatically built component is
initialised exactly like a declarative one.

The owning `GenericFilter` must have a `DataLoader` (as it always does in practice);
`build()` / `buildAndRegister()` fail fast otherwise.

### `FilterComponentBuilder`

Obtained via `filter.filterComponentBuilder()`.

```java
// PropertyFilter — auto-generates parameterName
PropertyFilter<String> nameFilter = filter.filterComponentBuilder()
        .propertyFilter()
        .property("name")
        .operation(PropertyFilter.Operation.CONTAINS)
        .defaultValue("Acme")
        .operationEditable(true)
        .build();

// JpqlFilter (void) — a checkbox that toggles a fixed condition on/off.
// Value type is Boolean; defaultValue(true) makes it active by default.
JpqlFilter<Boolean> activeFilter = filter.filterComponentBuilder()
        .jpqlFilter()
        .where("{E}.status = 'ACTIVE'")
        .defaultValue(true)
        .label("Active only")
        .build();

// JpqlFilter (typed) — a user-supplied value is bound to the query parameter.
// parameterName is optional (auto-generated); set it only for a named bind parameter.
JpqlFilter<String> codeFilter = filter.filterComponentBuilder()
        .jpqlFilter(String.class)
        .where("{E}.code = ?")
        .build();

// GroupFilter — copies autoApply from the owning GenericFilter; addAll() for many at once
GroupFilter group = filter.filterComponentBuilder()
        .groupFilter()
        .operation(LogicalFilterComponent.Operation.OR)
        .addAll(nameFilter, activeFilter)
        .build();
```

All three builders are **one-shot**: calling `build()` twice on the same instance
throws `IllegalStateException`.

### `RunTimeConfigurationBuilder`

Obtained via `filter.runtimeConfigurationBuilder()`.

```java
filter.runtimeConfigurationBuilder()
        .id("dynamicSearch")
        .name("Dynamic Search")
        .addAll(nameFilter, activeFilter)
        .add(codeFilter, "DEFAULT-CODE")   // typed default — compile-time safe
        .makeCurrent()
        .buildAndRegister();
```

Key behaviours:
- Configurations are **protected from user deletion by default**; opt out with
  `allowDeletion()` or `allowDeletion(boolean)`. This only hides the Remove action
  in the UI — programmatic `removeConfiguration()` still works (e.g. for renaming).
- `add(SingleFilterComponentBase<V>, @Nullable V)` — typed overload catches
  type mismatches between a filter and its default value at compile time.
  `addAll(FilterComponent...)` adds several components without defaults.
- A duplicate configuration `id` is rejected with `IllegalStateException`.
- `makeCurrent()` activates the configuration immediately (it is **not** the
  persistent default-configuration marker set by the `genericFilter_makeDefault`
  action).

### `GenericFilter` additions

| Method | Description |
|---|---|
| `filterComponentBuilder()` | Returns a new `FilterComponentBuilder` |
| `runtimeConfigurationBuilder()` | Returns a new `RunTimeConfigurationBuilder` |
| `refreshCurrentConfiguration()` | Public, stable equivalent of the protected `refreshCurrentConfigurationLayout()` — re-renders the current configuration after programmatic changes |
| `setCurrentConfiguration(Configuration)` | Now logs a warning when the configuration is not registered, instead of silently doing nothing |

## API design notes

- **`jpqlFilter()` returns `JpqlFilterBuilder<Boolean>`** — a void filter has no
  query parameter and is rendered as a checkbox that toggles its fixed WHERE clause.
  Its value type is therefore `Boolean`; `defaultValue(true)` makes the condition
  active by default. (Use `jpqlFilter(Boolean.class)` instead when a boolean value
  must be *bound* to a query parameter, e.g. `{E}.closed = :isClosed`.)

- **`parameterName` is optional** for `JpqlFilter` — auto-generated like the XML
  loader; set it explicitly only for a named bind parameter.

- **`addAll(FilterComponent...)`** is named distinctly rather than overloading
  `add` to avoid an ambiguous overload with `add(SingleFilterComponentBase, V)`.

- **`allowDeletion(boolean)`** — symmetrical with `hasInExpression(boolean)`;
  `allowDeletion()` is a no-arg convenience alias for `allowDeletion(true)`.

- **The builders and their nested types are extensible** — `protected`
  constructors/fields and overridable factory methods.

- **All new public API is annotated `@Experimental`** — may be changed or
  removed in a future minor version.

## What is not in scope

- XML loader changes — the builders are a purely programmatic API on top of
  the existing component model.
- `DesignTimeConfiguration` builders — design-time configs are managed via
  the Studio XML editor.

## Tests

`GenericFilterBuilderApiTest` — integration tests covering:

- `PropertyFilterBuilder`: property/operation, auto parameterName, defaultValue,
  operationEditable, operationTextVisible, one-shot guard
- `JpqlFilterBuilder`: void (checkbox) and typed variants, void WHERE applied only
  when active, hasInExpression, value-component generation, auto parameterName,
  one-shot guard
- DataLoader requirement (build fails fast without a loader)
- `GroupFilterBuilder`: operation, children, `addAll`, autoApply propagation,
  DataLoader propagation, one-shot guard
- `RunTimeConfigurationBuilder`: registration, `addAll`, `makeCurrent`, operation,
  id guard, duplicate-id guard, one-shot guard, typed add, default value map,
  setValue on component, modified state, allowDeletion variants,
  protectedFromUserDeletion (and that programmatic removal still works)
- One-shot guard: a build that fails validation does not consume the builder
- `GenericFilter` helpers: `refreshCurrentConfiguration`
