### PR TITLE
Regression TabSheet content is not initialized in UI integration tests #5367

### DIFF
--- a/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/JmixUiTestExtension.java
+++ b/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/JmixUiTestExtension.java
@@ -39,6 +39,7 @@ import io.jmix.flowui.testassist.dialog.OpenedDialogs;
 import io.jmix.flowui.testassist.notification.OpenedNotifications;
 import io.jmix.flowui.testassist.vaadin.TestServletContext;
 import io.jmix.flowui.testassist.vaadin.TestSpringServlet;
+import io.jmix.flowui.testassist.vaadin.TestUI;
 import io.jmix.flowui.testassist.vaadin.TestVaadinRequest;
 import io.jmix.flowui.testassist.vaadin.TestVaadinSession;
 import io.jmix.flowui.testassist.view.initial.InitialView;
@@ -245,7 +246,10 @@ public class JmixUiTestExtension implements TestInstancePostProcessor, BeforeEac
 
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
-        ui = new UI();
+        // TestUI emulates the client response cycle, so components that defer initialization until
+        // 'beforeClientResponse' (e.g. JmixTabSheet attaching the selected tab content) get fully
+        // initialized in tests, where there is no client-server communication.
+        ui = new TestUI();
         ui.getInternals().setSession(vaadinSession);
 
         // ExtendedClientDetails is not available since we don't have client-side here.

--- a/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/vaadin/TestUI.java
+++ b/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/vaadin/TestUI.java
@@ -34,19 +34,28 @@ import com.vaadin.flow.server.VaadinRequest;
  * <p>
  * This UI emulates the cycle in two phases:
  * <ul>
- *     <li>while a navigation is in progress, callbacks are only collected, then executed as one
+ *     <li>while a navigation is being handled, callbacks are only collected, then executed as one
  *     batch once the navigation finishes — exactly as a real request behaves;</li>
- *     <li>afterwards the UI acts as if the client has responded: each subsequently registered
- *     callback runs immediately, so programmatic changes or dialogs opened after navigation (with
- *     no further navigation) are handled without any explicit flush.</li>
+ *     <li>at any other time there is no response to wait for, so each callback registered via
+ *     {@link #beforeClientResponse(Component, SerializableConsumer)} runs immediately, and
+ *     programmatic changes or dialogs opened without navigation are handled without any explicit
+ *     flush.</li>
+ * </ul>
+ * Known deviations from a running application:
+ * <ul>
+ *     <li>only registrations made through {@link UI#beforeClientResponse} trigger the immediate
+ *     run; code that registers directly on the {@code StateTree} (e.g. {@code Element#executeJs}
+ *     or data communicator flushes) is collected and executed at the next flush — the next
+ *     navigation or {@code beforeClientResponse} call — or explicitly via
+ *     {@link #runExecutionsBeforeClientResponse()};</li>
+ *     <li>the immediate run happens synchronously inside the registering call, whereas in a
+ *     running application the callback runs at the end of the request — caller code following the
+ *     registration that the callback depends on (e.g.
+ *     {@code field = ui.beforeClientResponse(owner, ctx -> field = null)}) observes the inverted
+ *     order.</li>
  * </ul>
  */
 public class TestUI extends UI {
-
-    // True once a navigation has finished: the UI then behaves as if the client responded, running
-    // each newly registered callback immediately. Reset when a new navigation starts, so every
-    // navigation is handled as its own request (collect during, flush at the end).
-    protected boolean clientResponded;
 
     protected boolean runningExecutions;
 
@@ -54,20 +63,21 @@ public class TestUI extends UI {
     public void doInit(VaadinRequest request, int uiId, String appId) {
         super.doInit(request, uiId, appId);
 
-        // Listeners are registered here, not in the constructor, because they require the UI
+        // The listener is registered here, not in the constructor, because it requires the UI
         // session, which is set after instantiation.
-        addBeforeEnterListener(event -> clientResponded = false);
-        addAfterNavigationListener(event -> {
-            runExecutionsBeforeClientResponse();
-            clientResponded = true;
-        });
+        addAfterNavigationListener(event -> runExecutionsBeforeClientResponse());
     }
 
     @Override
     public ExecutionRegistration beforeClientResponse(Component component,
                                                       SerializableConsumer<ExecutionContext> execution) {
         ExecutionRegistration registration = super.beforeClientResponse(component, execution);
-        if (clientResponded) {
+        // 'lastHandledNavigation' is non-null exactly while the Router is handling a navigation
+        // ('Router#navigate' clears it in 'finally' even if the navigation fails), so callbacks
+        // registered during navigation are left to the AfterNavigationListener batch, and at any
+        // other time they run at once. Unlike a mutable phase flag, this cannot get stuck after a
+        // failed navigation and requires no initial navigation to activate.
+        if (!getInternals().hasLastHandledLocation()) {
             runExecutionsBeforeClientResponse();
         }
         return registration;

--- a/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/vaadin/TestUI.java
+++ b/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/vaadin/TestUI.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.testassist.vaadin;
+
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.component.UI;
+import com.vaadin.flow.function.SerializableConsumer;
+import com.vaadin.flow.internal.ExecutionContext;
+import com.vaadin.flow.internal.StateTree.ExecutionRegistration;
+import com.vaadin.flow.server.VaadinRequest;
+
+/**
+ * {@link UI} for integration tests that emulates the client response cycle.
+ * <p>
+ * In a running application, tasks registered via {@link UI#beforeClientResponse} are collected by
+ * the {@code StateTree} during request handling and executed as a single batch before the response
+ * is sent to the client. There is no client-server communication in tests, so these tasks would
+ * never run, leaving components that defer initialization partially initialized — e.g.
+ * {@code JmixTabSheet} attaches the selected tab content to the component tree in such a callback.
+ * <p>
+ * This UI emulates the cycle in two phases:
+ * <ul>
+ *     <li>while a navigation is in progress, callbacks are only collected, then executed as one
+ *     batch once the navigation finishes — exactly as a real request behaves;</li>
+ *     <li>afterwards the UI acts as if the client has responded: each subsequently registered
+ *     callback runs immediately, so programmatic changes or dialogs opened after navigation (with
+ *     no further navigation) are handled without any explicit flush.</li>
+ * </ul>
+ */
+public class TestUI extends UI {
+
+    // True once a navigation has finished: the UI then behaves as if the client responded, running
+    // each newly registered callback immediately. Reset when a new navigation starts, so every
+    // navigation is handled as its own request (collect during, flush at the end).
+    protected boolean clientResponded;
+
+    protected boolean runningExecutions;
+
+    @Override
+    public void doInit(VaadinRequest request, int uiId, String appId) {
+        super.doInit(request, uiId, appId);
+
+        // Listeners are registered here, not in the constructor, because they require the UI
+        // session, which is set after instantiation.
+        addBeforeEnterListener(event -> clientResponded = false);
+        addAfterNavigationListener(event -> {
+            runExecutionsBeforeClientResponse();
+            clientResponded = true;
+        });
+    }
+
+    @Override
+    public ExecutionRegistration beforeClientResponse(Component component,
+                                                      SerializableConsumer<ExecutionContext> execution) {
+        ExecutionRegistration registration = super.beforeClientResponse(component, execution);
+        if (clientResponded) {
+            runExecutionsBeforeClientResponse();
+        }
+        return registration;
+    }
+
+    /**
+     * Runs the tasks collected via {@link UI#beforeClientResponse}, emulating the batch the
+     * framework executes before a client response.
+     */
+    public void runExecutionsBeforeClientResponse() {
+        // Guard against reentrancy: an execution may register new tasks, but those are picked up by
+        // the loop inside StateTree#runExecutionsBeforeClientResponse, so no nested call is needed.
+        if (runningExecutions) {
+            return;
+        }
+        runningExecutions = true;
+        try {
+            getInternals().getStateTree().runExecutionsBeforeClientResponse();
+        } finally {
+            runningExecutions = false;
+        }
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/editor/DataGridEditorImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/grid/editor/DataGridEditorImpl.java
@@ -244,8 +244,7 @@ public class DataGridEditorImpl<T> extends AbstractGridExtension<T>
                 editItemRequest = null;
             };
             getGrid().getElement().getNode().runWhenAttached(
-                    ui -> ui.getInternals().getStateTree().beforeClientResponse(
-                            getGrid().getElement().getNode(), editItemRequest));
+                    ui -> ui.beforeClientResponse(getGrid(), editItemRequest));
         }
     }
 

--- a/jmix-flowui/flowui/src/test/groovy/component/tabsheet/TabSheetTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/tabsheet/TabSheetTest.groovy
@@ -16,8 +16,8 @@
 
 package component.tabsheet
 
-import component.image.view.JmixImageTestView
 import component.tabsheet.view.TabSheetTestView
+import io.jmix.flowui.component.UiComponentUtils
 import org.springframework.boot.test.context.SpringBootTest
 import test_support.spec.FlowuiTestSpecification
 
@@ -46,5 +46,24 @@ class TabSheetTest extends FlowuiTestSpecification {
         screen.tabSheet.findComponent("tab4Span").isEmpty()
         screen.tabSheet.setSelectedTab(screen.tab4)
         screen.tabSheet.findComponent("tab4Span").isPresent()
+    }
+
+    def "Selected tab content is attached to the view after navigation"() {
+        when: "Open a view with TabSheet"
+        def screen = navigateToView(TabSheetTestView)
+
+        then: "Content of the selected tab is attached to the view"
+        UiComponentUtils.findView(screen.tab1Span) == screen
+    }
+
+    def "Selected tab content is attached to the view after switching tabs without navigation"() {
+        given: "An open view with a TabSheet"
+        def screen = navigateToView(TabSheetTestView)
+
+        when: "Switching to another tab programmatically, with no navigation happening"
+        screen.tabSheet.setSelectedIndex(2)
+
+        then: "Content of the newly selected tab is attached to the view"
+        UiComponentUtils.findView(screen.tab3Checkbox) == screen
     }
 }

--- a/jmix-flowui/flowui/src/test/groovy/data_context/view/OrderView.java
+++ b/jmix-flowui/flowui/src/test/groovy/data_context/view/OrderView.java
@@ -20,6 +20,7 @@ import com.vaadin.flow.router.BeforeEvent;
 import com.vaadin.flow.router.HasUrlParameter;
 import com.vaadin.flow.router.Route;
 import io.jmix.core.DataManager;
+import io.jmix.core.FetchPlan;
 import io.jmix.core.Metadata;
 import io.jmix.flowui.DialogWindows;
 import io.jmix.flowui.component.grid.DataGrid;
@@ -77,7 +78,7 @@ public class OrderView extends StandardView implements HasUrlParameter<String> {
     @Override
     public void setParameter(BeforeEvent event, String parameter) {
         Object orderId = urlParamSerializer.deserialize(UUID.class, parameter);
-        order = dataManager.load(Order.class).id(orderId).fetchPlan(b->b.add("orderLines")).one();
+        order = dataManager.load(Order.class).id(orderId).fetchPlan(b->b.add("orderLines", FetchPlan.BASE)).one();
     }
 
     @Subscribe

--- a/jmix-flowui/flowui/src/test/groovy/test_support/spec/FlowuiTestSpecification.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/test_support/spec/FlowuiTestSpecification.groovy
@@ -42,6 +42,7 @@ import io.jmix.flowui.testassist.dialog.OpenedDialogs
 import io.jmix.flowui.testassist.notification.OpenedNotifications
 import io.jmix.flowui.testassist.vaadin.TestServletContext
 import io.jmix.flowui.testassist.vaadin.TestSpringServlet
+import io.jmix.flowui.testassist.vaadin.TestUI
 import io.jmix.flowui.testassist.vaadin.TestVaadinRequest
 import io.jmix.flowui.testassist.vaadin.TestVaadinSession
 import io.jmix.flowui.view.View
@@ -159,7 +160,10 @@ class FlowuiTestSpecification extends Specification {
 
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request))
 
-        ui = new UI()
+        // TestUI emulates the client response cycle, so components that defer initialization until
+        // 'beforeClientResponse' (e.g. JmixTabSheet attaching the selected tab content) get fully
+        // initialized in tests, where there is no client-server communication.
+        ui = new TestUI()
         ui.getInternals().setSession(vaadinSession)
 
         // ExtendedClientDetails is not available since we don't have client-side here.

--- a/jmix-flowui/flowui/src/test/java/component/tabsheet/TabSheetEditActionUiTest.java
+++ b/jmix-flowui/flowui/src/test/java/component/tabsheet/TabSheetEditActionUiTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.tabsheet;
+
+import component.tabsheet.view.TabSheetEditActionListView;
+import io.jmix.core.DataManager;
+import io.jmix.flowui.component.grid.DataGrid;
+import io.jmix.flowui.testassist.FlowuiTestAssistConfiguration;
+import io.jmix.flowui.testassist.UiTest;
+import io.jmix.flowui.testassist.UiTestUtils;
+import io.jmix.flowui.view.navigation.ViewNavigationSupport;
+import navigation.view.BackwardNavigationDetailView;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import test_support.FlowuiTestConfiguration;
+import test_support.entity.sales.Customer;
+
+@UiTest(viewBasePackages = {"navigation.view", "component.tabsheet.view"})
+@SpringBootTest(classes = {FlowuiTestConfiguration.class, FlowuiTestAssistConfiguration.class})
+public class TabSheetEditActionUiTest {
+
+    @Autowired
+    ViewNavigationSupport navigationSupport;
+    @Autowired
+    DataManager dataManager;
+
+    @Test
+    @DisplayName("Edit action on a data grid inside a TabSheet opens the detail view")
+    public void editActionOnDataGridInsideTabSheetOpensDetailView() {
+        // given: a persisted customer
+        Customer customer = dataManager.create(Customer.class);
+        customer.setName("Joe Doe");
+        dataManager.save(customer);
+
+        // and: a list view whose data grid is placed inside a TabSheet tab
+        navigationSupport.navigate(TabSheetEditActionListView.class);
+        TabSheetEditActionListView listView = UiTestUtils.getCurrentView();
+
+        DataGrid<Customer> dataGrid = UiTestUtils.getComponent(listView, "customersDataGrid");
+        Customer loadedCustomer = dataGrid.getItems().getItems().iterator().next();
+
+        // when: selecting the customer and performing the edit action;
+        // EditAction resolves the owner view of the grid, which previously failed for a grid
+        // inside a TabSheet tab with "A component 'DataGrid' is not attached to a view"
+        dataGrid.select(loadedCustomer);
+        dataGrid.getAction("edit").actionPerform(null);
+
+        // then: the detail view is opened for the selected entity
+        BackwardNavigationDetailView detailView = UiTestUtils.getCurrentView();
+        Assertions.assertEquals(loadedCustomer, detailView.getEditedEntity());
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/component/tabsheet/TabSheetEditActionUiTest.java
+++ b/jmix-flowui/flowui/src/test/java/component/tabsheet/TabSheetEditActionUiTest.java
@@ -25,10 +25,12 @@ import io.jmix.flowui.testassist.UiTestUtils;
 import io.jmix.flowui.view.navigation.ViewNavigationSupport;
 import navigation.view.BackwardNavigationDetailView;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import test_support.FlowuiTestConfiguration;
 import test_support.entity.sales.Customer;
 
@@ -40,6 +42,13 @@ public class TabSheetEditActionUiTest {
     ViewNavigationSupport navigationSupport;
     @Autowired
     DataManager dataManager;
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    public void afterEach() {
+        jdbcTemplate.execute("delete from TEST_CUSTOMER");
+    }
 
     @Test
     @DisplayName("Edit action on a data grid inside a TabSheet opens the detail view")

--- a/jmix-flowui/flowui/src/test/java/component/tabsheet/view/TabSheetEditActionListView.java
+++ b/jmix-flowui/flowui/src/test/java/component/tabsheet/view/TabSheetEditActionListView.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.tabsheet.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.view.LookupComponent;
+import io.jmix.flowui.view.StandardListView;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import test_support.entity.sales.Customer;
+
+@Route(value = "tab-sheet-edit-action-list-view")
+@ViewController("test_TabSheetEditActionListView")
+@ViewDescriptor("tab-sheet-edit-action-list-view.xml")
+@LookupComponent("customersDataGrid")
+public class TabSheetEditActionListView extends StandardListView<Customer> {
+}

--- a/jmix-flowui/flowui/src/test/resources/component/tabsheet/view/tab-sheet-edit-action-list-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/tabsheet/view/tab-sheet-edit-action-list-view.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data readOnly="true">
+        <collection id="customersDc"
+                    class="test_support.entity.sales.Customer">
+            <fetchPlan extends="_base"/>
+            <loader id="customersDl">
+                <query>
+                    <![CDATA[select e from test_Customer e]]>
+                </query>
+            </loader>
+        </collection>
+    </data>
+    <facets>
+        <dataLoadCoordinator auto="true"/>
+    </facets>
+    <layout>
+        <tabSheet id="tabSheet" width="100%" height="100%">
+            <tab id="listTab" label="List">
+                <vbox padding="false" height="100%">
+                    <hbox id="buttonsPanel" classNames="buttons-panel">
+                        <button id="editBtn" action="customersDataGrid.edit"/>
+                    </hbox>
+                    <dataGrid id="customersDataGrid"
+                              width="100%"
+                              minHeight="20em"
+                              dataContainer="customersDc">
+                        <actions>
+                            <action id="edit" type="list_edit"/>
+                        </actions>
+                        <columns>
+                            <column property="name"/>
+                        </columns>
+                    </dataGrid>
+                </vbox>
+            </tab>
+        </tabSheet>
+    </layout>
+</view>

--- a/jmix-pivottable/pivottable-flowui/src/test/groovy/test_support/PivotTableFlowuiTestSpecification.groovy
+++ b/jmix-pivottable/pivottable-flowui/src/test/groovy/test_support/PivotTableFlowuiTestSpecification.groovy
@@ -40,6 +40,7 @@ import io.jmix.flowui.sys.event.UiEventsManager
 import io.jmix.flowui.testassist.FlowuiTestAssistConfiguration
 import io.jmix.flowui.testassist.vaadin.TestServletContext
 import io.jmix.flowui.testassist.vaadin.TestSpringServlet
+import io.jmix.flowui.testassist.vaadin.TestUI
 import io.jmix.flowui.testassist.vaadin.TestVaadinRequest
 import io.jmix.flowui.testassist.vaadin.TestVaadinSession
 import io.jmix.flowui.view.View
@@ -153,7 +154,10 @@ class PivotTableFlowuiTestSpecification extends Specification {
 
         RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request))
 
-        ui = new UI()
+        // TestUI emulates the client response cycle, so components that defer initialization until
+        // 'beforeClientResponse' (e.g. JmixTabSheet attaching the selected tab content) get fully
+        // initialized in tests, where there is no client-server communication.
+        ui = new TestUI()
         ui.getInternals().setSession(vaadinSession)
 
         // ExtendedClientDetails is not available since we don't have client-side here.


### PR DESCRIPTION
See: #5367

### What was done

- Added `TestUI` (module `flowui-test-assist`) — a `UI` subclass that runs the `beforeClientResponse` callbacks collected in the `StateTree`. Both test harnesses (`JmixUiTestExtension` for `@UiTest` and the internal Spock `FlowuiTestSpecification`, plus the copy in `pivottable-flowui`) now create `TestUI` instead of plain `UI`.
- `DataGridEditorImpl.editItem` now registers its callback via the public `UI.beforeClientResponse` instead of going to the `StateTree` directly — identical behavior in production, but the editor request is now executed in tests too.
- Added regression tests for both harnesses: a `@UiTest` performing the `list_edit` action on a `dataGrid` inside a `tabSheet` tab (the exact scenario from the issue), and Spock features asserting that selected tab content is attached after navigation and after a programmatic tab switch.

### How it works

In a running application, `beforeClientResponse` tasks are executed as a single batch before the response is sent to the client; in tests there is no client-server communication, so they never ran. `TestUI` distinguishes two phases using Vaadin's own navigation tracking (`UIInternals.hasLastHandledLocation()`, set and cleared in `finally` by the `Router`): while a navigation is being handled, callbacks are only collected and then executed as one batch in an `AfterNavigationListener` — exactly as a real request behaves; at any other time (dialogs, programmatic changes, tests that never navigate) each callback registered via `UI.beforeClientResponse` runs immediately. Since the phase is derived from router state rather than a mutable flag, it cannot get stuck after a failed navigation and needs no initial navigation to activate. Known deviations (registrations made directly on the `StateTree`, e.g. `Element.executeJs`, and the synchronous execution order) are documented in the `TestUI` javadoc; `TestUI.runExecutionsBeforeClientResponse()` is public for explicit flushing in edge cases.

### Compatibility

No API changes, but test behavior changes for applications using `flowui-test-assist`: callbacks that previously never ran in tests now do. In particular, a `dataGrid` now loads and renders its first page during navigation, so tests with grid columns outside the loader's fetch plan may start failing (one such fixture, `OrderView` in `flowui` tests, was fixed in this change). This brings tests closer to production behavior but is worth a release-note entry.