### PR TITLE
Search: clean up Javadoc in search strategy interfaces and SearchSecurityDecorator #4200

### DIFF
--- a/jmix-search/search-elasticsearch/src/main/java/io/jmix/searchelasticsearch/searching/strategy/ElasticsearchSearchStrategy.java
+++ b/jmix-search/search-elasticsearch/src/main/java/io/jmix/searchelasticsearch/searching/strategy/ElasticsearchSearchStrategy.java
@@ -5,9 +5,7 @@ import io.jmix.search.searching.SearchStrategy;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Represents a search strategy specifically designed for Elasticsearch integration.
- * An implementation of this interface configures an Elasticsearch {@link SearchRequest}
- * based on the provided search context.
+ * Elasticsearch-specific {@link SearchStrategy} that builds an Elasticsearch {@link SearchRequest}.
  */
 @NullMarked
 public interface ElasticsearchSearchStrategy extends SearchStrategy<SearchRequest.Builder> {

--- a/jmix-search/search-opensearch/src/main/java/io/jmix/searchopensearch/searching/strategy/OpenSearchSearchStrategy.java
+++ b/jmix-search/search-opensearch/src/main/java/io/jmix/searchopensearch/searching/strategy/OpenSearchSearchStrategy.java
@@ -5,7 +5,7 @@ import org.jspecify.annotations.NullMarked;
 import org.opensearch.client.opensearch.core.SearchRequest;
 
 /**
- * A OpenSearch-specific extension of the common {link @SearchStrategy} interface
+ * OpenSearch-specific {@link SearchStrategy} that builds an OpenSearch {@link SearchRequest}.
  */
 @NullMarked
 public interface OpenSearchSearchStrategy extends SearchStrategy<SearchRequest.Builder> {

--- a/jmix-search/search/src/main/java/io/jmix/search/searching/SearchSecurityDecorator.java
+++ b/jmix-search/search/src/main/java/io/jmix/search/searching/SearchSecurityDecorator.java
@@ -28,7 +28,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Decorates CurrentUserSecurityFacade and adds functionality that is necessary for the Search Engine.
+ * Provides entity- and attribute-level read permission checks required by the search engine,
+ * delegating to {@link SecureOperations} and {@link PolicyStore}.
  */
 @Component("search_SearchSecurityDecorator")
 public class SearchSecurityDecorator {


### PR DESCRIPTION
Minor Javadoc-only cleanup of classes introduced in #4200. No behavior or API changes.

  - OpenSearchSearchStrategy — fix broken {@link} tag ({link @SearchStrategy}) that produced a Javadoc warning, and replace the imprecise description.
  - ElasticsearchSearchStrategy — replace the imprecise "based on the provided search context" wording (the context is the SearchRequestContext argument of the inherited configureRequest, not something the interface provides).
  - SearchSecurityDecorator — replace the inaccurate "Decorates CurrentUserSecurityFacade" description (the class decorates nothing) with an accurate one: entity- and attribute-level read permission checks, delegating to SecureOperations / PolicyStore.
