### PR TITLE
Resource roles grid optimization

### DIFF
--- a/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/role/provider/BaseDatabaseRoleProvider.java
+++ b/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/role/provider/BaseDatabaseRoleProvider.java
@@ -44,12 +44,18 @@ public abstract class BaseDatabaseRoleProvider<T extends BaseRole> implements Ro
     @Override
     @NonNull
     public Collection<T> getAllRoles() {
+        return getAllRoles(true);
+    }
+
+    @Override
+    @NonNull
+    public Collection<T> getAllRoles(boolean includePolicies) {
         return dataManager.load(getRoleClass())
                 .all()
-                .fetchPlan(this::buildFetchPlan)
+                .fetchPlan(fetchPlanBuilder -> buildFetchPlan(fetchPlanBuilder, includePolicies))
                 .list()
                 .stream()
-                .map(this::buildRole)
+                .map(entity -> buildRole(entity, includePolicies))
                 .collect(Collectors.toList());
     }
 
@@ -102,9 +108,17 @@ public abstract class BaseDatabaseRoleProvider<T extends BaseRole> implements Ro
 
     protected abstract T buildRole(Object entity);
 
+    protected T buildRole(Object entity, boolean includePolicies) {
+        return buildRole(entity);
+    }
+
     protected abstract Class<?> getRoleClass();
 
     protected abstract void buildFetchPlan(FetchPlanBuilder fetchPlanBuilder);
+
+    protected void buildFetchPlan(FetchPlanBuilder fetchPlanBuilder, boolean includePolicies) {
+        buildFetchPlan(fetchPlanBuilder);
+    }
 
     protected String buildFindByCodeQuery() {
         return "where e.code = :code";

--- a/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/role/provider/DatabaseResourceRoleProvider.java
+++ b/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/role/provider/DatabaseResourceRoleProvider.java
@@ -48,12 +48,24 @@ public class DatabaseResourceRoleProvider extends BaseDatabaseRoleProvider<Resou
 
     @Override
     protected void buildFetchPlan(FetchPlanBuilder fetchPlanBuilder) {
-        fetchPlanBuilder
-                .addAll("name", "code", "description", "childRoles", "scopes", "sysTenantId")
-                .add("resourcePolicies", FetchPlan.BASE);
+        buildFetchPlan(fetchPlanBuilder, true);
     }
 
+    @Override
+    protected void buildFetchPlan(FetchPlanBuilder fetchPlanBuilder, boolean includePolicies) {
+        fetchPlanBuilder.addAll("name", "code", "description", "childRoles", "scopes", "sysTenantId");
+        if (includePolicies) {
+            fetchPlanBuilder.add("resourcePolicies", FetchPlan.BASE);
+        }
+    }
+
+    @Override
     protected ResourceRole buildRole(Object entity) {
+        return buildRole(entity, true);
+    }
+
+    @Override
+    protected ResourceRole buildRole(Object entity, boolean includePolicies) {
         ResourceRoleEntity roleEntity = (ResourceRoleEntity) entity;
 
         ResourceRole role = new ResourceRole();
@@ -66,21 +78,23 @@ public class DatabaseResourceRoleProvider extends BaseDatabaseRoleProvider<Resou
         role.setScopes(roleEntity.getScopes() == null ? Collections.emptySet() : roleEntity.getScopes());
         role.setTenantId(roleEntity.getSysTenantId());
 
-        List<ResourcePolicyEntity> resourcePolicyEntities = roleEntity.getResourcePolicies();
-        if (resourcePolicyEntities != null) {
-            List<ResourcePolicy> resourcePolicies = resourcePolicyEntities.stream()
-                    .map(e -> {
-                        Map<String, String> customProperties = new HashMap<>();
-                        customProperties.put("databaseId", e.getId().toString());
-                        return ResourcePolicy.builder(e.getType(), e.getResource())
-                                .withAction(e.getAction())
-                                .withEffect(e.getEffect())
-                                .withPolicyGroup(e.getPolicyGroup())
-                                .withCustomProperties(customProperties)
-                                .build();
-                    })
-                    .collect(Collectors.toList());
-            role.setResourcePolicies(resourcePolicies);
+        if (includePolicies) {
+            List<ResourcePolicyEntity> resourcePolicyEntities = roleEntity.getResourcePolicies();
+            if (resourcePolicyEntities != null) {
+                List<ResourcePolicy> resourcePolicies = resourcePolicyEntities.stream()
+                        .map(e -> {
+                            Map<String, String> customProperties = new HashMap<>();
+                            customProperties.put("databaseId", e.getId().toString());
+                            return ResourcePolicy.builder(e.getType(), e.getResource())
+                                    .withAction(e.getAction())
+                                    .withEffect(e.getEffect())
+                                    .withPolicyGroup(e.getPolicyGroup())
+                                    .withCustomProperties(customProperties)
+                                    .build();
+                        })
+                        .collect(Collectors.toList());
+                role.setResourcePolicies(resourcePolicies);
+            }
         }
 
         return role;

--- a/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/role/provider/DatabaseRowLevelRoleProvider.java
+++ b/jmix-security/security-data/src/main/java/io/jmix/securitydata/impl/role/provider/DatabaseRowLevelRoleProvider.java
@@ -55,12 +55,24 @@ public class DatabaseRowLevelRoleProvider extends BaseDatabaseRoleProvider<RowLe
 
     @Override
     protected void buildFetchPlan(FetchPlanBuilder fetchPlanBuilder) {
-        fetchPlanBuilder
-                .addAll("name", "code", "description", "childRoles", "sysTenantId")
-                .add("rowLevelPolicies", FetchPlan.BASE);
+        buildFetchPlan(fetchPlanBuilder, true);
     }
 
+    @Override
+    protected void buildFetchPlan(FetchPlanBuilder fetchPlanBuilder, boolean includePolicies) {
+        fetchPlanBuilder.addAll("name", "code", "description", "childRoles", "sysTenantId");
+        if (includePolicies) {
+            fetchPlanBuilder.add("rowLevelPolicies", FetchPlan.BASE);
+        }
+    }
+
+    @Override
     protected RowLevelRole buildRole(Object entity) {
+        return buildRole(entity, true);
+    }
+
+    @Override
+    protected RowLevelRole buildRole(Object entity, boolean includePolicies) {
         RowLevelRoleEntity roleEntity = (RowLevelRoleEntity) entity;
 
         RowLevelRole role = new RowLevelRole();
@@ -72,32 +84,34 @@ public class DatabaseRowLevelRoleProvider extends BaseDatabaseRoleProvider<RowLe
         role.getCustomProperties().put("databaseId", roleEntity.getId().toString());
         role.setTenantId(roleEntity.getSysTenantId());
 
-        List<RowLevelPolicyEntity> rowLevelPolicyEntities = roleEntity.getRowLevelPolicies();
-        if (rowLevelPolicyEntities != null) {
-            List<RowLevelPolicy> rowLevelPolicies = rowLevelPolicyEntities.stream()
-                    .map(policyEntity -> {
-                                String id = policyEntity.getId().toString();
-                                Map<String, String> customProperties = new HashMap<>();
-                                customProperties.put("databaseId", id);
-                                switch (policyEntity.getType()) {
-                                    case JPQL:
-                                        return new RowLevelPolicy(policyEntity.getEntityName(),
-                                                policyEntity.getWhereClause(),
-                                                policyEntity.getJoinClause(),
-                                                customProperties);
-                                    case PREDICATE:
-                                        return new RowLevelPolicy(policyEntity.getEntityName(),
-                                                policyEntity.getAction(),
-                                                policyEntity.getScript(),
-                                                createPredicateFromScript(policyEntity.getScript()),
-                                                customProperties);
-                                    default:
-                                        throw new RuntimeException("Unknown row level policy type " + policyEntity.getType());
+        if (includePolicies) {
+            List<RowLevelPolicyEntity> rowLevelPolicyEntities = roleEntity.getRowLevelPolicies();
+            if (rowLevelPolicyEntities != null) {
+                List<RowLevelPolicy> rowLevelPolicies = rowLevelPolicyEntities.stream()
+                        .map(policyEntity -> {
+                                    String id = policyEntity.getId().toString();
+                                    Map<String, String> customProperties = new HashMap<>();
+                                    customProperties.put("databaseId", id);
+                                    switch (policyEntity.getType()) {
+                                        case JPQL:
+                                            return new RowLevelPolicy(policyEntity.getEntityName(),
+                                                    policyEntity.getWhereClause(),
+                                                    policyEntity.getJoinClause(),
+                                                    customProperties);
+                                        case PREDICATE:
+                                            return new RowLevelPolicy(policyEntity.getEntityName(),
+                                                    policyEntity.getAction(),
+                                                    policyEntity.getScript(),
+                                                    createPredicateFromScript(policyEntity.getScript()),
+                                                    customProperties);
+                                        default:
+                                            throw new RuntimeException("Unknown row level policy type " + policyEntity.getType());
+                                    }
                                 }
-                            }
-                    )
-                    .collect(Collectors.toList());
-            role.setRowLevelPolicies(rowLevelPolicies);
+                        )
+                        .collect(Collectors.toList());
+                role.setRowLevelPolicies(rowLevelPolicies);
+            }
         }
         return role;
     }

--- a/jmix-security/security-data/src/test/groovy/database_role_provider/DatabaseRoleProviderTest.groovy
+++ b/jmix-security/security-data/src/test/groovy/database_role_provider/DatabaseRoleProviderTest.groovy
@@ -153,6 +153,43 @@ class DatabaseRoleProviderTest extends SecurityDataSpecification {
 
     }
 
+    def "get all resource roles without policies"() {
+        when:
+        def roles = databaseResourceRoleProvider.getAllRoles(false)
+
+        then:
+        roles.size() == 1
+        def role1 = roles.find { it.code == 'role1' }
+        role1 != null
+        role1.resourcePolicies.isEmpty()
+    }
+
+    def "get all resource roles with policies via flag"() {
+        when:
+        def roles = databaseResourceRoleProvider.getAllRoles(true)
+
+        then:
+        def role1 = roles.find { it.code == 'role1' }
+        role1.resourcePolicies.size() == 2
+    }
+
+    def "get all row level roles without policies"() {
+        when:
+        def roles = databaseRowLevelRoleProvider.getAllRoles(false)
+
+        then:
+        roles.size() == 2
+        roles.every { it.rowLevelPolicies.isEmpty() }
+    }
+
+    def "find resource role by code still loads policies"() {
+        when:
+        def role = databaseResourceRoleProvider.getRoleByCode('role1')
+
+        then:
+        role.resourcePolicies.size() == 2
+    }
+
     private void prepareTestData() {
         ResourceRoleEntity role1 = metadata.create(ResourceRoleEntity)
         role1.code = 'role1'

--- a/jmix-security/security-data/src/test/groovy/role_persistence/RolePersistenceTest.groovy
+++ b/jmix-security/security-data/src/test/groovy/role_persistence/RolePersistenceTest.groovy
@@ -33,6 +33,8 @@ import org.springframework.security.core.userdetails.UserDetails
 import test_support.SecurityDataSpecification
 import test_support.role.TestFullAccessRole
 
+import java.nio.charset.StandardCharsets
+
 class RolePersistenceTest extends SecurityDataSpecification {
 
     @Autowired
@@ -205,5 +207,36 @@ class RolePersistenceTest extends SecurityDataSpecification {
             policy.entityName == 'User' &&
                     policy.whereClause == 'other query'
         }
+    }
+
+    def "export includes policies even for models loaded without policies"() {
+        given: "a saved role with one entity policy"
+        def policyModel = dataManager.create(ResourcePolicyModel)
+        policyModel.type = ResourcePolicyType.ENTITY
+        policyModel.resource = 'User'
+        policyModel.action = EntityPolicyAction.READ.id
+        policyModel.effect = ResourcePolicyEffect.ALLOW
+
+        def roleModel = dataManager.create(ResourceRoleModel)
+        roleModel.name = 'Export Role'
+        roleModel.code = 'export-role'
+        roleModel.resourcePolicies = [policyModel]
+        rolePersistence.save(roleModel)
+
+        and: "a light model as produced by the list view (no policies, id from databaseId)"
+        def lightModel = roleModelConverter.createResourceRoleModel(
+                resourceRoleProvider.getRoleByCode('export-role'), false)
+
+        expect: "the light model carries no policies but has the database id"
+        lightModel.resourcePolicies == null
+        lightModel.id != null
+
+        when:
+        def json = new String(rolePersistence.exportResourceRoles([lightModel], false),
+                StandardCharsets.UTF_8)
+
+        then: "exported JSON still contains the policy reloaded from the database"
+        json.contains('resourcePolicies')
+        json.contains('User')
     }
 }

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcerole/ResourceRoleModelListView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcerole/ResourceRoleModelListView.java
@@ -123,9 +123,9 @@ public class ResourceRoleModelListView extends StandardListView<ResourceRoleMode
     }
 
     private void loadRoles(@Nullable RoleFilterChangeEvent event) {
-        List<ResourceRoleModel> roleModels = roleRepository.getAllRoles().stream()
+        List<ResourceRoleModel> roleModels = roleRepository.getAllRoles(false).stream()
                 .filter(role -> event == null || event.matches(role))
-                .map(roleModelConverter::createResourceRoleModel)
+                .map(role -> roleModelConverter.createResourceRoleModel(role, false))
                 .sorted(Comparator.comparing(ResourceRoleModel::getName))
                 .collect(Collectors.toList());
         roleModelsDc.setItems(roleModels);

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcerole/ResourceRoleModelLookupView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/resourcerole/ResourceRoleModelLookupView.java
@@ -101,7 +101,7 @@ public class ResourceRoleModelLookupView extends StandardListView<ResourceRoleMo
     }
 
     protected void loadRoles(@Nullable RoleFilterChangeEvent event) {
-        List<ResourceRoleModel> roleModels = roleRepository.getAllRoles().stream()
+        List<ResourceRoleModel> roleModels = roleRepository.getAllRoles(false).stream()
                 .filter(role -> (event == null || event.matches(role))
                         && !excludedRolesCodes.contains(role.getCode())
                 )
@@ -123,7 +123,7 @@ public class ResourceRoleModelLookupView extends StandardListView<ResourceRoleMo
                     }
                     return allowed;
                 })
-                .map(roleModelConverter::createResourceRoleModel)
+                .map(role -> roleModelConverter.createResourceRoleModel(role, false))
                 .sorted(Comparator.comparing(ResourceRoleModel::getName))
                 .collect(Collectors.toList());
 

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/rowlevelrole/RowLevelRoleModelListView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/rowlevelrole/RowLevelRoleModelListView.java
@@ -124,9 +124,9 @@ public class RowLevelRoleModelListView extends StandardListView<RowLevelRoleMode
     }
 
     private void loadRoles(@Nullable RoleFilterChangeEvent event) {
-        List<RowLevelRoleModel> roleModels = roleRepository.getAllRoles().stream()
+        List<RowLevelRoleModel> roleModels = roleRepository.getAllRoles(false).stream()
                 .filter(role -> event == null || event.matches(role))
-                .map(roleModelConverter::createRowLevelRoleModel)
+                .map(role -> roleModelConverter.createRowLevelRoleModel(role, false))
                 .sorted(Comparator.comparing(RowLevelRoleModel::getName))
                 .collect(Collectors.toList());
         roleModelsDc.setItems(roleModels);

--- a/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/rowlevelrole/RowLevelRoleModelLookupView.java
+++ b/jmix-security/security-flowui/src/main/java/io/jmix/securityflowui/view/rowlevelrole/RowLevelRoleModelLookupView.java
@@ -101,7 +101,7 @@ public class RowLevelRoleModelLookupView extends StandardListView<RowLevelRoleMo
     }
 
     private void loadRoles(@Nullable RoleFilterChangeEvent event) {
-        List<RowLevelRoleModel> roleModels = roleRepository.getAllRoles().stream()
+        List<RowLevelRoleModel> roleModels = roleRepository.getAllRoles(false).stream()
                 .filter(role -> (event == null || event.matches(role))
                         && !excludedRolesCodes.contains(role.getCode())
                 )
@@ -123,7 +123,7 @@ public class RowLevelRoleModelLookupView extends StandardListView<RowLevelRoleMo
                     }
                     return allowed;
                 })
-                .map(roleModelConverter::createRowLevelRoleModel)
+                .map(role -> roleModelConverter.createRowLevelRoleModel(role, false))
                 .sorted(Comparator.comparing(RowLevelRoleModel::getName))
                 .collect(Collectors.toList());
         roleModelsDc.setItems(roleModels);

--- a/jmix-security/security/src/main/java/io/jmix/security/impl/role/ResourceRoleRepositoryImpl.java
+++ b/jmix-security/security/src/main/java/io/jmix/security/impl/role/ResourceRoleRepositoryImpl.java
@@ -93,6 +93,11 @@ public class ResourceRoleRepositoryImpl implements ResourceRoleRepository {
     }
 
     @Override
+    public Collection<ResourceRole> getAllRoles(boolean includePolicies) {
+        return roleRepositoryProviderUtils.getAllRoles(includePolicies);
+    }
+
+    @Override
     public void invalidateCache() {
         rolesCache.clear();
     }

--- a/jmix-security/security/src/main/java/io/jmix/security/impl/role/RoleRepositoryProviderUtils.java
+++ b/jmix-security/security/src/main/java/io/jmix/security/impl/role/RoleRepositoryProviderUtils.java
@@ -61,6 +61,14 @@ public class RoleRepositoryProviderUtils<T extends BaseRole> {
         return roles;
     }
 
+    public Collection<T> getAllRoles(boolean includePolicies) {
+        Collection<T> roles = new ArrayList<>();
+        for (RoleProvider<T> roleProvider : roleProviders) {
+            roles.addAll(roleProvider.getAllRoles(includePolicies));
+        }
+        return roles;
+    }
+
     @Nullable
     public T findRoleByCodeExcludeVisited(String roleCode, Set<String> visited, BiConsumer<T, T> roleMergingOperation) {
         visited.add(roleCode);

--- a/jmix-security/security/src/main/java/io/jmix/security/impl/role/RowLevelRoleRepositoryImpl.java
+++ b/jmix-security/security/src/main/java/io/jmix/security/impl/role/RowLevelRoleRepositoryImpl.java
@@ -91,6 +91,11 @@ public class RowLevelRoleRepositoryImpl implements RowLevelRoleRepository {
     }
 
     @Override
+    public Collection<RowLevelRole> getAllRoles(boolean includePolicies) {
+        return roleRepositoryProviderUtils.getAllRoles(includePolicies);
+    }
+
+    @Override
     public void invalidateCache() {
         rolesCache.clear();
     }

--- a/jmix-security/security/src/main/java/io/jmix/security/model/RoleModelConverter.java
+++ b/jmix-security/security/src/main/java/io/jmix/security/model/RoleModelConverter.java
@@ -46,11 +46,17 @@ public class RoleModelConverter {
     }
 
     public ResourceRoleModel createResourceRoleModel(ResourceRole role) {
+        return createResourceRoleModel(role, true);
+    }
+
+    public ResourceRoleModel createResourceRoleModel(ResourceRole role, boolean withPolicies) {
         ResourceRoleModel roleModel = metadata.create(ResourceRoleModel.class);
 
         initBaseParameters(roleModel, role);
         roleModel.setScopes(role.getScopes());
-        roleModel.setResourcePolicies(createResourcePolicyModels(role.getResourcePolicies()));
+        if (withPolicies) {
+            roleModel.setResourcePolicies(createResourcePolicyModels(role.getResourcePolicies()));
+        }
 
         entityStates.setNew(roleModel, false);
 
@@ -59,11 +65,17 @@ public class RoleModelConverter {
 
 
     public RowLevelRoleModel createRowLevelRoleModel(RowLevelRole role) {
+        return createRowLevelRoleModel(role, true);
+    }
+
+    public RowLevelRoleModel createRowLevelRoleModel(RowLevelRole role, boolean withPolicies) {
         RowLevelRoleModel roleModel = metadata.create(RowLevelRoleModel.class);
 
         initBaseParameters(roleModel, role);
 
-        roleModel.setRowLevelPolicies(createRowLevelPolicyModels(role.getRowLevelPolicies()));
+        if (withPolicies) {
+            roleModel.setRowLevelPolicies(createRowLevelPolicyModels(role.getRowLevelPolicies()));
+        }
 
         entityStates.setNew(roleModel, false);
 

--- a/jmix-security/security/src/main/java/io/jmix/security/role/RoleProvider.java
+++ b/jmix-security/security/src/main/java/io/jmix/security/role/RoleProvider.java
@@ -42,4 +42,12 @@ public interface RoleProvider<T extends BaseRole> {
     boolean deleteRole(T role);
 
     Collection<T> getAllRoles();
+
+    /**
+     * Returns all roles. When {@code includePolicies} is {@code false}, implementations may skip
+     * loading role policies to speed up listing scenarios that do not need them.
+     */
+    default Collection<T> getAllRoles(boolean includePolicies) {
+        return getAllRoles();
+    }
 }

--- a/jmix-security/security/src/main/java/io/jmix/security/role/RoleRepository.java
+++ b/jmix-security/security/src/main/java/io/jmix/security/role/RoleRepository.java
@@ -40,6 +40,14 @@ public interface RoleRepository<T extends BaseRole> {
     Collection<T> getAllRoles();
 
     /**
+     * Returns all roles. When {@code includePolicies} is {@code false}, implementations may skip
+     * loading role policies to speed up listing scenarios that do not need them.
+     */
+    default Collection<T> getAllRoles(boolean includePolicies) {
+        return getAllRoles();
+    }
+
+    /**
      * Invalidates role cache. The method must be invoked after each role modification, for example, when database role
      * is changed with the UI or annotated role is hot deployed.
      */

--- a/jmix-security/security/src/test/groovy/role_model_converter/RoleModelConverterTest.groovy
+++ b/jmix-security/security/src/test/groovy/role_model_converter/RoleModelConverterTest.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package role_model_converter
+
+import io.jmix.security.model.ResourcePolicy
+import io.jmix.security.model.ResourcePolicyType
+import io.jmix.security.model.ResourceRole
+import io.jmix.security.model.RoleModelConverter
+import io.jmix.security.model.RowLevelPolicy
+import io.jmix.security.model.RowLevelRole
+import org.springframework.beans.factory.annotation.Autowired
+import test_support.SecuritySpecification
+
+class RoleModelConverterTest extends SecuritySpecification {
+
+    @Autowired
+    RoleModelConverter roleModelConverter
+
+    def "resource role model includes policies by default"() {
+        when:
+        def model = roleModelConverter.createResourceRoleModel(resourceRoleWithOnePolicy())
+
+        then:
+        model.code == 'role1'
+        model.resourcePolicies.size() == 1
+    }
+
+    def "resource role model excludes policies when withPolicies is false"() {
+        when:
+        def model = roleModelConverter.createResourceRoleModel(resourceRoleWithOnePolicy(), false)
+
+        then:
+        model.code == 'role1'
+        model.resourcePolicies == null
+    }
+
+    def "row level role model excludes policies when withPolicies is false"() {
+        when:
+        def model = roleModelConverter.createRowLevelRoleModel(rowLevelRoleWithOnePolicy(), false)
+
+        then:
+        model.code == 'role2'
+        model.rowLevelPolicies == null
+    }
+
+    private static ResourceRole resourceRoleWithOnePolicy() {
+        def role = new ResourceRole()
+        role.name = 'Role1'
+        role.code = 'role1'
+        role.setResourcePolicies([
+                ResourcePolicy.builder(ResourcePolicyType.SCREEN, 'screen1').build()
+        ])
+        return role
+    }
+
+    private static RowLevelRole rowLevelRoleWithOnePolicy() {
+        def role = new RowLevelRole()
+        role.name = 'Role2'
+        role.code = 'role2'
+        role.setRowLevelPolicies([
+                new RowLevelPolicy('test_Order', 'where1', 'join1', [:])
+        ])
+        return role
+    }
+}


### PR DESCRIPTION
### Summary

Resource roles and row-level roles list/lookup screens no longer load or materialize role policies.

### What was done

- Added a `getAllRoles(boolean includePolicies)` overload to `RoleRepository` and `RoleProvider` (module `security`) as a `default` method; the existing no-arg `getAllRoles()` is unchanged and delegates to the policy-including path.
- Database role providers (`security-data`) skip both the policy fetch and the per-policy object construction when `includePolicies` is `false`: the fetch plan no longer pulls `resourcePolicies` / `rowLevelPolicies`, and `buildRole` does not build policy objects.
- Added `createResourceRoleModel(role, boolean withPolicies)` / `createRowLevelRoleModel(role, boolean withPolicies)` to `RoleModelConverter` (`security`); with `false` the converter skips creating `ResourcePolicyModel` / `RowLevelPolicyModel` instances.
- The resource and row-level list and lookup Views (`security-flowui`, 4 Views) now load via the light path — `getAllRoles(false)` plus `createXxxRoleModel(role, false)`.

### How it works

Opening a roles list/lookup View calls `getAllRoles(false)`, so database roles are read with a fetch plan that omits the policy collection and no `ResourcePolicy` / `RowLevelPolicy` objects are built. The grids only show role-level columns (name, code, source, scopes), so nothing on these screens needs policies. Paths that do need policies are untouched: `findRoleByCode` and runtime access evaluation use the full path, the role detail View reloads the role by code with policies, and JSON/ZIP export reloads roles by its own fetch plan from the database (it never relied on the grid models' policies).

### How to use

No configuration required; the built-in roles screens use the light path automatically. The new `getAllRoles(boolean)` overload is available for custom code that needs to enumerate roles without their policies.

### Compatibility

Fully backward compatible. The new methods are additive — `getAllRoles()` and `createXxxRoleModel(role)` keep their current behavior, and the `default` interface methods let custom `RoleProvider` / `RoleRepository` / `BaseDatabaseRoleProvider` implementations keep working unchanged (they return full roles unless they opt in). No breaking changes.

### Tested

ResourceRoleListView loading emulation

Before fix:
<img width="420" height="127" alt="image" src="https://github.com/user-attachments/assets/96816565-7a3c-4a82-abaa-14f28de9f082" />

After fix:
<img width="432" height="110" alt="image" src="https://github.com/user-attachments/assets/97a39f00-f615-4e69-843c-704e32dc3587" />
