### PR TITLE
DataContext: attribute-level change tracking and merge hardening

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/DataContext.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/DataContext.java
@@ -183,6 +183,15 @@ public interface DataContext {
     Set<Object> getModified();
 
     /**
+     * Returns the names of attributes of the given managed entity that were modified by the user
+     * and not yet saved. Empty for unknown or unmodified instances, and for instances registered
+     * only via {@link #setModified(Object, boolean)}.
+     */
+    default Set<String> getModifiedAttributes(Object entity) {
+        return Set.of();
+    }
+
+    /**
      * Returns true if the context has registered removal of the given entity.
      */
     boolean isRemoved(Object entity);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextChangeTracker.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextChangeTracker.java
@@ -37,6 +37,13 @@ class DataContextChangeTracker {
     // (e.g. a collection snapshot taken before mutation) without being dirty yet.
     private final Map<Object, Set<String>> dirtyAttrs = new IdentityHashMap<>();
 
+    // entity -> attributes made loaded by a user set or a non-null merge-install (increment 04's markLoaded).
+    // A fresh merge of a narrower copy replaces the loaded-state cache with the source's, whose negative for
+    // such an attribute shadows the (correct) fetch-group state; this registry lets reapplySetLoaded restore it
+    // afterwards (DataContextImpl.reapplySetLoaded). Dropped when an entity leaves the context (drop), NOT by
+    // clear(): clear() resets dirty state (clearChanges, and inside save()) while the value stays present.
+    private final Map<Object, Set<String>> setLoadedAttrs = new IdentityHashMap<>();
+
     private final Consumer<Object> onEntityDirty;
     private final Consumer<Object> onEntityClean;
 
@@ -147,8 +154,17 @@ class DataContextChangeTracker {
         putDirty(entity, attribute, baseline);
     }
 
+    void markSetLoaded(Object entity, String attribute) {
+        setLoadedAttrs.computeIfAbsent(entity, e -> new HashSet<>()).add(attribute);
+    }
+
+    Set<String> setLoadedAttributes(Object entity) {
+        return setLoadedAttrs.getOrDefault(entity, Collections.emptySet());
+    }
+
     void drop(Object entity) {
         baselines.remove(entity);
+        setLoadedAttrs.remove(entity);
         Set<String> dirty = dirtyAttrs.remove(entity);
         if (dirty != null && !dirty.isEmpty()) {
             onEntityClean.accept(entity);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextChangeTracker.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextChangeTracker.java
@@ -28,7 +28,7 @@ import java.util.function.Consumer;
  * Baselines exist only for dirty attributes; an attribute whose current value returns to its
  * baseline is removed. Entity-level dirty membership is signalled through the two callbacks.
  */
-class DataContextChangeTracker {
+public class DataContextChangeTracker {
 
     // entity -> attribute -> baseline (scalar value, reference id, or membership bag for collections)
     private final Map<Object, Map<String, Object>> baselines = new IdentityHashMap<>();
@@ -37,11 +37,9 @@ class DataContextChangeTracker {
     // (e.g. a collection snapshot taken before mutation) without being dirty yet.
     private final Map<Object, Set<String>> dirtyAttrs = new IdentityHashMap<>();
 
-    // entity -> attributes made loaded by a user set or a non-null merge-install (increment 04's markLoaded).
-    // A fresh merge of a narrower copy replaces the loaded-state cache with the source's, whose negative for
-    // such an attribute shadows the (correct) fetch-group state; this registry lets reapplySetLoaded restore it
-    // afterwards (DataContextImpl.reapplySetLoaded). Dropped when an entity leaves the context (drop), NOT by
-    // clear(): clear() resets dirty state (clearChanges, and inside save()) while the value stays present.
+    // entity -> attributes made loaded by a user set or a non-null merge-install. Lets
+    // DataContextImpl.reapplySetLoaded restore the loaded flag after a fresh merge installs a narrower
+    // loaded-state cache. Dropped when an entity leaves the context (drop), but NOT by clear().
     private final Map<Object, Set<String>> setLoadedAttrs = new IdentityHashMap<>();
 
     private final Consumer<Object> onEntityDirty;
@@ -71,14 +69,10 @@ class DataContextChangeTracker {
 
     void snapshotCollectionBaseline(Object entity, String attribute, Collection<?> baselineContents) {
         if (!isAttributeDirty(entity, attribute)) {
-            // A clean attribute's baseline must always track what merge just installed: merge
-            // legitimately replaces a clean collection's contents (e.g. a fresh reload bringing in
-            // DB-side changes), so if the baseline were left stale, later mutations would be
-            // compared against membership that no longer reflects reality (spurious dirty, or a
-            // false clean when a removed-then-re-added item happens to restore the stale bag).
-            // A dirty attribute keeps its existing baseline: mergeFromChild relies on the child's
-            // own baseline surviving the merge (see isOverriding), and putDirty overwrites it
-            // anyway whenever the tracked value actually changes.
+            // A clean attribute's baseline must track what merge just installed (merge legitimately
+            // replaces a clean collection's contents), otherwise later mutations would be compared
+            // against stale membership. A dirty attribute keeps its baseline: mergeFromChild relies on
+            // the child's baseline surviving, and putDirty overwrites it when the value actually changes.
             baselines.computeIfAbsent(entity, e -> new HashMap<>())
                     .put(attribute, membershipBag(baselineContents));
         }
@@ -135,19 +129,6 @@ class DataContextChangeTracker {
         } else if (DataContextDiagnostics.log.isDebugEnabled()) {
             DataContextDiagnostics.log.debug(DataContextDiagnostics.baselineRebased(entity, attribute, bag));
         }
-    }
-
-    Map<String, Object> dirtyBaselines(Object entity) {
-        Map<String, Object> entityBaselines = baselines.get(entity);
-        Set<String> dirty = dirtyAttrs.get(entity);
-        if (entityBaselines == null || dirty == null || dirty.isEmpty()) {
-            return Collections.emptyMap();
-        }
-        Map<String, Object> result = new LinkedHashMap<>();
-        for (String attribute : dirty) {
-            result.put(attribute, entityBaselines.get(attribute));
-        }
-        return result;
     }
 
     void markDirty(Object entity, String attribute, @Nullable Object baseline) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextChangeTracker.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextChangeTracker.java
@@ -45,12 +45,24 @@ public class DataContextChangeTracker {
     private final Consumer<Object> onEntityDirty;
     private final Consumer<Object> onEntityClean;
 
-    DataContextChangeTracker(Consumer<Object> onEntityDirty, Consumer<Object> onEntityClean) {
+    /**
+     * @param onEntityDirty callback invoked when an entity becomes dirty (gains its first dirty attribute)
+     * @param onEntityClean callback invoked when an entity becomes clean again (loses its last dirty attribute)
+     */
+    public DataContextChangeTracker(Consumer<Object> onEntityDirty, Consumer<Object> onEntityClean) {
         this.onEntityDirty = onEntityDirty;
         this.onEntityClean = onEntityClean;
     }
 
-    void trackChange(Object entity, String attribute, @Nullable Object prevValue,
+    /**
+     * Records a scalar or single-reference attribute change against its baseline. If a baseline already
+     * exists for the attribute, the change is measured against it: the attribute is un-dirtied when the
+     * current value returns to the baseline, and nothing else happens otherwise. With no baseline yet,
+     * the attribute becomes dirty (with {@code prevValue} as baseline) only when the value actually changed.
+     *
+     * @param reference {@code true} to compare by entity id / identity rather than by value
+     */
+    public void trackChange(Object entity, String attribute, @Nullable Object prevValue,
                       @Nullable Object newValue, boolean reference) {
         Object prev = reference ? refKey(prevValue) : prevValue;
         Object curr = reference ? refKey(newValue) : newValue;
@@ -67,7 +79,13 @@ public class DataContextChangeTracker {
         putDirty(entity, attribute, prev);
     }
 
-    void snapshotCollectionBaseline(Object entity, String attribute, Collection<?> baselineContents) {
+    /**
+     * Snapshots the membership of a to-many attribute as its baseline, so a later mutation can be
+     * compared against it (see {@link #trackCollectionChange}). Called by the merge when it installs a
+     * collection. Only a clean attribute's baseline is (re)snapshotted; a dirty attribute keeps its
+     * existing baseline so an unsaved user edit is not measured against freshly merged contents.
+     */
+    public void snapshotCollectionBaseline(Object entity, String attribute, Collection<?> baselineContents) {
         if (!isAttributeDirty(entity, attribute)) {
             // A clean attribute's baseline must track what merge just installed (merge legitimately
             // replaces a clean collection's contents), otherwise later mutations would be compared
@@ -78,7 +96,13 @@ public class DataContextChangeTracker {
         }
     }
 
-    void trackCollectionChange(Object entity, String attribute, Collection<?> current) {
+    /**
+     * Records the current membership of a to-many attribute against its snapshotted baseline: the
+     * attribute is un-dirtied when the membership matches the baseline again, and marked dirty when it
+     * differs. When no baseline was snapshotted the attribute is marked dirty conservatively (the change
+     * cannot be reconstructed). Called from the observable-collection mutation callback.
+     */
+    public void trackCollectionChange(Object entity, String attribute, Collection<?> current) {
         Map<String, Object> entityBaselines = baselines.get(entity);
         Object baseline = entityBaselines == null ? null : entityBaselines.get(attribute);
         if (baseline == null) {
@@ -96,16 +120,31 @@ public class DataContextChangeTracker {
         }
     }
 
-    boolean isAttributeDirty(Object entity, String attribute) {
+    /**
+     * Whether the given attribute of the entity currently carries an unsaved change.
+     */
+    public boolean isAttributeDirty(Object entity, String attribute) {
         return dirtyAttributes(entity).contains(attribute);
     }
 
-    Set<String> getModifiedAttributes(Object entity) {
+    /**
+     * The names of the entity's currently-dirty attributes (embedded sub-attributes as dotted paths),
+     * as an unmodifiable snapshot; empty if the entity is clean.
+     */
+    public Set<String> getModifiedAttributes(Object entity) {
         Set<String> attrs = dirtyAttrs.get(entity);
         return attrs == null || attrs.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(new LinkedHashSet<>(attrs));
     }
 
-    void rebaseline(Object entity, String attribute, @Nullable Object incomingValue,
+    /**
+     * Moves a dirty scalar or single-reference attribute's baseline to an incoming (merged) value, so the
+     * user's edit is henceforth measured against it; the attribute is un-dirtied if it now equals that
+     * value. No-op when the attribute is not dirty. Used by a fresh merge, which rebaselines protected
+     * user edits rather than overwriting them.
+     *
+     * @param reference {@code true} to compare by entity id / identity rather than by value
+     */
+    public void rebaseline(Object entity, String attribute, @Nullable Object incomingValue,
                      @Nullable Object currentValue, boolean reference) {
         if (!isAttributeDirty(entity, attribute)) return;
         Object incoming = reference ? refKey(incomingValue) : incomingValue;
@@ -118,7 +157,12 @@ public class DataContextChangeTracker {
         }
     }
 
-    void rebaselineCollection(Object entity, String attribute, Collection<?> incoming, Collection<?> current) {
+    /**
+     * The to-many counterpart of {@link #rebaseline}: moves a dirty collection attribute's baseline to the
+     * membership of an incoming (merged) collection, un-dirtying it if the current membership now matches.
+     * No-op when the attribute is not dirty.
+     */
+    public void rebaselineCollection(Object entity, String attribute, Collection<?> incoming, Collection<?> current) {
         if (!isAttributeDirty(entity, attribute)) return;
         Map<Object, Integer> bag = membershipBag(incoming);
         baselines.get(entity).put(attribute, bag);
@@ -131,19 +175,36 @@ public class DataContextChangeTracker {
         }
     }
 
-    void markDirty(Object entity, String attribute, @Nullable Object baseline) {
+    /**
+     * Marks an attribute dirty with an explicit baseline, without a value comparison. Used to import
+     * dirty state from a child context (see {@code DataContextImpl.mergeFromChild}).
+     */
+    public void markDirty(Object entity, String attribute, @Nullable Object baseline) {
         putDirty(entity, attribute, baseline);
     }
 
-    void markSetLoaded(Object entity, String attribute) {
+    /**
+     * Remembers that an attribute was made loaded by a user set or a non-null merge-install, so the loaded
+     * flag can be re-asserted after a fresh merge installs a narrower loaded-state cache (see
+     * {@link #setLoadedAttributes} and {@code DataContextImpl.reapplySetLoaded}).
+     */
+    public void markSetLoaded(Object entity, String attribute) {
         setLoadedAttrs.computeIfAbsent(entity, e -> new HashSet<>()).add(attribute);
     }
 
-    Set<String> setLoadedAttributes(Object entity) {
+    /**
+     * The attributes previously recorded by {@link #markSetLoaded} for the entity; empty if none. Survives
+     * {@link #clear}, and is dropped only when the entity leaves the context (see {@link #drop}).
+     */
+    public Set<String> setLoadedAttributes(Object entity) {
         return setLoadedAttrs.getOrDefault(entity, Collections.emptySet());
     }
 
-    void drop(Object entity) {
+    /**
+     * Forgets all tracked state (baselines, dirty attributes and set-loaded markers) for an entity that is
+     * leaving the context, firing the clean callback if it was dirty.
+     */
+    public void drop(Object entity) {
         baselines.remove(entity);
         setLoadedAttrs.remove(entity);
         Set<String> dirty = dirtyAttrs.remove(entity);
@@ -152,22 +213,26 @@ public class DataContextChangeTracker {
         }
     }
 
-    void clear() {
+    /**
+     * Drops all baselines and dirty attributes for every entity (e.g. on save or clear-changes). Set-loaded
+     * markers are intentionally kept, unlike {@link #drop}.
+     */
+    public void clear() {
         baselines.clear();
         dirtyAttrs.clear();
     }
 
-    private Set<String> dirtyAttributes(Object entity) {
+    protected Set<String> dirtyAttributes(Object entity) {
         Set<String> attrs = dirtyAttrs.get(entity);
         return attrs == null ? Collections.emptySet() : attrs;
     }
 
-    private void putDirty(Object entity, String attribute, @Nullable Object baseline) {
+    protected void putDirty(Object entity, String attribute, @Nullable Object baseline) {
         baselines.computeIfAbsent(entity, e -> new HashMap<>()).put(attribute, baseline);
         markAttributeDirty(entity, attribute);
     }
 
-    private void markAttributeDirty(Object entity, String attribute) {
+    protected void markAttributeDirty(Object entity, String attribute) {
         Set<String> attrs = dirtyAttrs.computeIfAbsent(entity, e -> new HashSet<>());
         boolean wasEmpty = attrs.isEmpty();
         boolean newlyDirtied = attrs.add(attribute);
@@ -184,7 +249,7 @@ public class DataContextChangeTracker {
         }
     }
 
-    private void removeDirty(Object entity, String attribute) {
+    protected void removeDirty(Object entity, String attribute) {
         Map<String, Object> entityBaselines = baselines.get(entity);
         if (entityBaselines != null) {
             entityBaselines.remove(attribute);
@@ -195,7 +260,7 @@ public class DataContextChangeTracker {
         removeDirtyKeepBaseline(entity, attribute);
     }
 
-    private void removeDirtyKeepBaseline(Object entity, String attribute) {
+    protected void removeDirtyKeepBaseline(Object entity, String attribute) {
         Set<String> attrs = dirtyAttrs.get(entity);
         if (attrs == null) {
             return;
@@ -211,13 +276,17 @@ public class DataContextChangeTracker {
     }
 
     @Nullable
-    private static Object refKey(@Nullable Object refOrId) {
+    protected static Object refKey(@Nullable Object refOrId) {
         if (refOrId == null) return null;
         Object id = EntityValues.getId(refOrId);
         return id != null ? id : new IdentityKey(refOrId);
     }
 
-    static Map<Object, Integer> membershipBag(Collection<?> collection) {
+    /**
+     * The membership bag (element key {@code ->} count) of a collection, used as a to-many attribute's
+     * baseline. Each element is keyed by its entity id, or by identity when it has none.
+     */
+    public static Map<Object, Integer> membershipBag(Collection<?> collection) {
         Map<Object, Integer> bag = new HashMap<>();
         for (Object e : collection) {
             bag.merge(refKey(e), 1, Integer::sum);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextChangeTracker.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextChangeTracker.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.model.impl;
+
+import io.jmix.core.entity.EntityValues;
+import org.jspecify.annotations.Nullable;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+/**
+ * Per-attribute dirty state of a {@link DataContextImpl}: which attributes of which managed
+ * instances the user changed, and the baseline value each change is measured against.
+ * Baselines exist only for dirty attributes; an attribute whose current value returns to its
+ * baseline is removed. Entity-level dirty membership is signalled through the two callbacks.
+ */
+class DataContextChangeTracker {
+
+    // entity -> attribute -> baseline (scalar value, reference id, or membership bag for collections)
+    private final Map<Object, Map<String, Object>> baselines = new IdentityHashMap<>();
+
+    // entity -> set of currently-dirty attributes. An attribute may have a baseline stored
+    // (e.g. a collection snapshot taken before mutation) without being dirty yet.
+    private final Map<Object, Set<String>> dirtyAttrs = new IdentityHashMap<>();
+
+    private final Consumer<Object> onEntityDirty;
+    private final Consumer<Object> onEntityClean;
+
+    DataContextChangeTracker(Consumer<Object> onEntityDirty, Consumer<Object> onEntityClean) {
+        this.onEntityDirty = onEntityDirty;
+        this.onEntityClean = onEntityClean;
+    }
+
+    void trackChange(Object entity, String attribute, @Nullable Object prevValue,
+                      @Nullable Object newValue, boolean reference) {
+        Object prev = reference ? refKey(prevValue) : prevValue;
+        Object curr = reference ? refKey(newValue) : newValue;
+        Map<String, Object> entityBaselines = baselines.get(entity);
+        if (entityBaselines != null && entityBaselines.containsKey(attribute)) {
+            if (Objects.equals(entityBaselines.get(attribute), curr)) {
+                removeDirty(entity, attribute);
+            }
+            return;
+        }
+        if (Objects.equals(prev, curr)) {
+            return;
+        }
+        putDirty(entity, attribute, prev);
+    }
+
+    void snapshotCollectionBaseline(Object entity, String attribute, Collection<?> baselineContents) {
+        if (!isAttributeDirty(entity, attribute)) {
+            // A clean attribute's baseline must always track what merge just installed: merge
+            // legitimately replaces a clean collection's contents (e.g. a fresh reload bringing in
+            // DB-side changes), so if the baseline were left stale, later mutations would be
+            // compared against membership that no longer reflects reality (spurious dirty, or a
+            // false clean when a removed-then-re-added item happens to restore the stale bag).
+            // A dirty attribute keeps its existing baseline: mergeFromChild relies on the child's
+            // own baseline surviving the merge (see isOverriding), and putDirty overwrites it
+            // anyway whenever the tracked value actually changes.
+            baselines.computeIfAbsent(entity, e -> new HashMap<>())
+                    .put(attribute, membershipBag(baselineContents));
+        }
+    }
+
+    void trackCollectionChange(Object entity, String attribute, Collection<?> current) {
+        Map<String, Object> entityBaselines = baselines.get(entity);
+        Object baseline = entityBaselines == null ? null : entityBaselines.get(attribute);
+        if (baseline == null) {
+            // no pre-mutation snapshot: cannot reconstruct, treat conservatively as dirty
+            // with the current membership as baseline-of-record minus nothing (coarse dirty)
+            putDirty(entity, attribute, DIRTY_WITHOUT_BASELINE);
+            return;
+        }
+        if (baseline.equals(membershipBag(current))) {
+            if (dirtyAttributes(entity).contains(attribute)) {
+                removeDirtyKeepBaseline(entity, attribute);
+            }
+        } else {
+            markAttributeDirty(entity, attribute);
+        }
+    }
+
+    boolean isAttributeDirty(Object entity, String attribute) {
+        return dirtyAttributes(entity).contains(attribute);
+    }
+
+    Set<String> getModifiedAttributes(Object entity) {
+        Set<String> attrs = dirtyAttrs.get(entity);
+        return attrs == null || attrs.isEmpty() ? Collections.emptySet() : Collections.unmodifiableSet(new LinkedHashSet<>(attrs));
+    }
+
+    void rebaseline(Object entity, String attribute, @Nullable Object incomingValue,
+                     @Nullable Object currentValue, boolean reference) {
+        if (!isAttributeDirty(entity, attribute)) return;
+        Object incoming = reference ? refKey(incomingValue) : incomingValue;
+        Object current = reference ? refKey(currentValue) : currentValue;
+        baselines.get(entity).put(attribute, incoming);
+        if (Objects.equals(incoming, current)) {
+            removeDirty(entity, attribute);
+        } else if (DataContextDiagnostics.log.isDebugEnabled()) {
+            DataContextDiagnostics.log.debug(DataContextDiagnostics.baselineRebased(entity, attribute, incoming));
+        }
+    }
+
+    void rebaselineCollection(Object entity, String attribute, Collection<?> incoming, Collection<?> current) {
+        if (!isAttributeDirty(entity, attribute)) return;
+        Map<Object, Integer> bag = membershipBag(incoming);
+        baselines.get(entity).put(attribute, bag);
+        if (bag.equals(membershipBag(current))) {
+            // keep the new baseline: unlike scalars, a collection mutation callback
+            // cannot reconstruct a lost snapshot from the change event alone
+            removeDirtyKeepBaseline(entity, attribute);
+        } else if (DataContextDiagnostics.log.isDebugEnabled()) {
+            DataContextDiagnostics.log.debug(DataContextDiagnostics.baselineRebased(entity, attribute, bag));
+        }
+    }
+
+    Map<String, Object> dirtyBaselines(Object entity) {
+        Map<String, Object> entityBaselines = baselines.get(entity);
+        Set<String> dirty = dirtyAttrs.get(entity);
+        if (entityBaselines == null || dirty == null || dirty.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (String attribute : dirty) {
+            result.put(attribute, entityBaselines.get(attribute));
+        }
+        return result;
+    }
+
+    void markDirty(Object entity, String attribute, @Nullable Object baseline) {
+        putDirty(entity, attribute, baseline);
+    }
+
+    void drop(Object entity) {
+        baselines.remove(entity);
+        Set<String> dirty = dirtyAttrs.remove(entity);
+        if (dirty != null && !dirty.isEmpty()) {
+            onEntityClean.accept(entity);
+        }
+    }
+
+    void clear() {
+        baselines.clear();
+        dirtyAttrs.clear();
+    }
+
+    private Set<String> dirtyAttributes(Object entity) {
+        Set<String> attrs = dirtyAttrs.get(entity);
+        return attrs == null ? Collections.emptySet() : attrs;
+    }
+
+    private void putDirty(Object entity, String attribute, @Nullable Object baseline) {
+        baselines.computeIfAbsent(entity, e -> new HashMap<>()).put(attribute, baseline);
+        markAttributeDirty(entity, attribute);
+    }
+
+    private void markAttributeDirty(Object entity, String attribute) {
+        Set<String> attrs = dirtyAttrs.computeIfAbsent(entity, e -> new HashSet<>());
+        boolean wasEmpty = attrs.isEmpty();
+        boolean newlyDirtied = attrs.add(attribute);
+        if (newlyDirtied && DataContextDiagnostics.log.isDebugEnabled()) {
+            Map<String, Object> entityBaselines = baselines.get(entity);
+            Object baseline = entityBaselines == null ? null : entityBaselines.get(attribute);
+            if (baseline == DIRTY_WITHOUT_BASELINE) {
+                baseline = "<unknown>";
+            }
+            DataContextDiagnostics.log.debug(DataContextDiagnostics.attributeDirtied(entity, attribute, baseline));
+        }
+        if (wasEmpty) {
+            onEntityDirty.accept(entity);
+        }
+    }
+
+    private void removeDirty(Object entity, String attribute) {
+        Map<String, Object> entityBaselines = baselines.get(entity);
+        if (entityBaselines != null) {
+            entityBaselines.remove(attribute);
+            if (entityBaselines.isEmpty()) {
+                baselines.remove(entity);
+            }
+        }
+        removeDirtyKeepBaseline(entity, attribute);
+    }
+
+    private void removeDirtyKeepBaseline(Object entity, String attribute) {
+        Set<String> attrs = dirtyAttrs.get(entity);
+        if (attrs == null) {
+            return;
+        }
+        boolean wasDirty = attrs.remove(attribute);
+        if (wasDirty && DataContextDiagnostics.log.isDebugEnabled()) {
+            DataContextDiagnostics.log.debug(DataContextDiagnostics.attributeReverted(entity, attribute));
+        }
+        if (attrs.isEmpty()) {
+            dirtyAttrs.remove(entity);
+            onEntityClean.accept(entity);
+        }
+    }
+
+    @Nullable
+    private static Object refKey(@Nullable Object refOrId) {
+        if (refOrId == null) return null;
+        Object id = EntityValues.getId(refOrId);
+        return id != null ? id : new IdentityKey(refOrId);
+    }
+
+    static Map<Object, Integer> membershipBag(Collection<?> collection) {
+        Map<Object, Integer> bag = new HashMap<>();
+        for (Object e : collection) {
+            bag.merge(refKey(e), 1, Integer::sum);
+        }
+        return bag;
+    }
+
+    private record IdentityKey(Object instance) {
+        @Override
+        public boolean equals(Object o) {
+            return o instanceof IdentityKey k && k.instance == instance;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(instance);
+        }
+    }
+
+    private static final Object DIRTY_WITHOUT_BASELINE = new Object();
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextDiagnostics.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextDiagnostics.java
@@ -35,30 +35,51 @@ import java.util.Map;
  */
 public class DataContextDiagnostics {
 
-    static final Logger log = LoggerFactory.getLogger("io.jmix.flowui.datacontext.diagnostics");
+    protected static final Logger log = LoggerFactory.getLogger("io.jmix.flowui.datacontext.diagnostics");
 
-    private DataContextDiagnostics() {
+    /**
+     * Not meant to be instantiated directly; {@code protected} only so the class can be subclassed to add
+     * or reuse message formats.
+     */
+    protected DataContextDiagnostics() {
     }
 
-    static String attributeDirtied(Object entity, String attribute, @Nullable Object baseline) {
+    /**
+     * Message for an attribute that just became dirty, showing the baseline its future changes are
+     * measured against.
+     */
+    public static String attributeDirtied(Object entity, String attribute, @Nullable Object baseline) {
         return "Attribute dirtied: " + formatEntity(entity) + "." + attribute
                 + " (baseline '" + formatEntity(baseline) + "')";
     }
 
-    static String attributeReverted(Object entity, String attribute) {
+    /**
+     * Message for an attribute whose value returned to its baseline and is therefore no longer dirty.
+     */
+    public static String attributeReverted(Object entity, String attribute) {
         return "Attribute reverted to baseline: " + formatEntity(entity) + "." + attribute;
     }
 
-    static String mergeSkippedDirty(Object entity, String attribute) {
+    /**
+     * Message for a non-fresh merge that left a dirty attribute untouched, keeping the user's unsaved value.
+     */
+    public static String mergeSkippedDirty(Object entity, String attribute) {
         return "Merge skipped dirty attribute (kept user value): " + formatEntity(entity) + "." + attribute;
     }
 
-    static String baselineRebased(Object entity, String attribute, @Nullable Object newBaseline) {
+    /**
+     * Message for a dirty attribute whose baseline was moved to an incoming (merged) value by a fresh merge.
+     */
+    public static String baselineRebased(Object entity, String attribute, @Nullable Object newBaseline) {
         return "Baseline rebased for dirty attribute: " + formatEntity(entity) + "." + attribute
                 + " -> '" + formatEntity(newBaseline) + "'";
     }
 
-    static String readOnlyContextMerge() {
+    /**
+     * Message warning that {@code merge()} was called on a read-only {@code NoopDataContext}, so the change
+     * is neither tracked nor saved.
+     */
+    public static String readOnlyContextMerge() {
         return "merge() called on a read-only DataContext (NoopDataContext); changes are not tracked or saved";
     }
 
@@ -67,7 +88,7 @@ public class DataContextDiagnostics {
      * "<collection>"} for a membership bag (used as a collection baseline), {@code "null"} for
      * null, and {@code String.valueOf} otherwise. Never calls {@code toString()} on an entity.
      */
-    static String formatEntity(@Nullable Object value) {
+    public static String formatEntity(@Nullable Object value) {
         if (value == null) {
             return "null";
         }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextDiagnostics.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextDiagnostics.java
@@ -33,21 +33,13 @@ import java.util.Map;
  * instance-name resolution over unfetched attributes); entities are rendered as
  * {@code ClassName-id} via {@link #formatEntity(Object)} instead.
  */
-class DataContextDiagnostics {
+public class DataContextDiagnostics {
 
     static final Logger log = LoggerFactory.getLogger("io.jmix.flowui.datacontext.diagnostics");
 
     private DataContextDiagnostics() {
     }
 
-    static String attributeDirtied(Object entity, String attribute, @Nullable Object baseline, @Nullable Object value) {
-        return "Attribute dirtied: " + formatEntity(entity) + "." + attribute
-                + ": '" + formatEntity(baseline) + "' -> '" + formatEntity(value) + "'";
-    }
-
-    /**
-     * Variant used where the new value is not available at the call site (only the baseline is).
-     */
     static String attributeDirtied(Object entity, String attribute, @Nullable Object baseline) {
         return "Attribute dirtied: " + formatEntity(entity) + "." + attribute
                 + " (baseline '" + formatEntity(baseline) + "')";
@@ -80,6 +72,7 @@ class DataContextDiagnostics {
             return "null";
         }
         if (value instanceof Map) {
+            // a collection baseline is stored as a membership bag (Map, see DataContextChangeTracker.membershipBag)
             return "<collection>";
         }
         if (EntityValues.isEntity(value)) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextDiagnostics.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextDiagnostics.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.model.impl;
+
+import io.jmix.core.entity.EntityValues;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Builds diagnostic log messages for attribute-level dirty tracking and merge decisions in
+ * {@link DataContextImpl} and {@link DataContextChangeTracker}. All output goes through the
+ * {@code io.jmix.flowui.datacontext.diagnostics} logger category at DEBUG level; call sites are
+ * expected to guard with {@code log.isDebugEnabled()} before building a message.
+ * <p>
+ * Messages never call {@code toString()} on an entity (which could trigger lazy loading or
+ * instance-name resolution over unfetched attributes); entities are rendered as
+ * {@code ClassName-id} via {@link #formatEntity(Object)} instead.
+ */
+class DataContextDiagnostics {
+
+    static final Logger log = LoggerFactory.getLogger("io.jmix.flowui.datacontext.diagnostics");
+
+    private DataContextDiagnostics() {
+    }
+
+    static String attributeDirtied(Object entity, String attribute, @Nullable Object baseline, @Nullable Object value) {
+        return "Attribute dirtied: " + formatEntity(entity) + "." + attribute
+                + ": '" + formatEntity(baseline) + "' -> '" + formatEntity(value) + "'";
+    }
+
+    /**
+     * Variant used where the new value is not available at the call site (only the baseline is).
+     */
+    static String attributeDirtied(Object entity, String attribute, @Nullable Object baseline) {
+        return "Attribute dirtied: " + formatEntity(entity) + "." + attribute
+                + " (baseline '" + formatEntity(baseline) + "')";
+    }
+
+    static String attributeReverted(Object entity, String attribute) {
+        return "Attribute reverted to baseline: " + formatEntity(entity) + "." + attribute;
+    }
+
+    static String mergeSkippedDirty(Object entity, String attribute) {
+        return "Merge skipped dirty attribute (kept user value): " + formatEntity(entity) + "." + attribute;
+    }
+
+    static String baselineRebased(Object entity, String attribute, @Nullable Object newBaseline) {
+        return "Baseline rebased for dirty attribute: " + formatEntity(entity) + "." + attribute
+                + " -> '" + formatEntity(newBaseline) + "'";
+    }
+
+    static String readOnlyContextMerge() {
+        return "merge() called on a read-only DataContext (NoopDataContext); changes are not tracked or saved";
+    }
+
+    /**
+     * Renders a value for a diagnostic message: {@code ClassName-id} for entities, {@code
+     * "<collection>"} for a membership bag (used as a collection baseline), {@code "null"} for
+     * null, and {@code String.valueOf} otherwise. Never calls {@code toString()} on an entity.
+     */
+    static String formatEntity(@Nullable Object value) {
+        if (value == null) {
+            return "null";
+        }
+        if (value instanceof Map) {
+            return "<collection>";
+        }
+        if (EntityValues.isEntity(value)) {
+            return value.getClass().getSimpleName() + "-" + EntityValues.getId(value);
+        }
+        return String.valueOf(value);
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -643,13 +643,15 @@ public class DataContextImpl implements DataContextInternal {
     }
 
     /**
-     * Whether this is a root non-fresh merge onto a pre-existing managed instance whose loaded-state
-     * info is the caching kind. Such an instance carries source-relative negatives cached at earlier
-     * merges (its creation merge caches every attribute outside its fetch plan as unloaded), and its
-     * fetch group was just unioned with the source's in {@link #mergeSystemState}.
+     * Whether this is a root non-fresh or a fresh merge onto a pre-existing managed instance whose
+     * loaded-state info is the caching kind. Such an instance carries source-relative negatives cached
+     * at earlier merges, and its fetch group was just unioned with the source's in {@link #mergeSystemState}.
+     * In both cases the loaded-state cache is recomputed from that unioned fetch group (blanked before the
+     * copy loops in {@link #resetLoadedInfoBeforeCopy}) instead of being replaced with the source's, so a
+     * fetched attribute the narrower source omits is not reverted to unloaded by a copied source negative.
      */
     protected boolean isColdResetTarget(Object dstEntity, boolean isRoot, MergeOptions options, boolean dstExisted) {
-        return isRoot && !options.isFresh() && dstExisted
+        return (isRoot || options.isFresh()) && dstExisted
                 && EntitySystemAccess.getEntityEntry(dstEntity).getLoadedPropertiesInfo() instanceof CachingLoadedPropertiesInfo;
     }
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -102,7 +102,18 @@ public class DataContextImpl implements DataContextInternal {
 
     protected PropertyChangeListener propertyChangeListener = new PropertyChangeListener();
 
-    protected boolean disableListeners;
+    // Depth of nested merge() calls. "In a merge" is mergeDepth > 0. A counter (not a boolean)
+    // so a ChangeEvent listener that re-enters merge() cannot corrupt an outer merge's state.
+    protected int mergeDepth;
+
+    // Entities to fire a ChangeEvent for once the outermost merge unwinds. Insertion-ordered,
+    // deduplicated by managed identity (one event per entity per merge).
+    protected Set<Object> deferredChangeEntities = new LinkedHashSet<>();
+
+    // (entity identity -> attribute names) the merge itself wrote during the active merge. A property
+    // or collection change during the merge whose (entity, attribute) is NOT here is a listener-injected
+    // user edit and must be tracked. Cleared when the outermost merge unwinds.
+    protected Map<Object, Set<String>> mergeApplied = new IdentityHashMap<>();
 
     protected DataContextInternal parentContext;
 
@@ -138,6 +149,28 @@ public class DataContextImpl implements DataContextInternal {
         events.publish(ChangeEvent.class, new ChangeEvent(this, entity));
     }
 
+    protected void flushDeferredChangeEvents() {
+        if (deferredChangeEntities.isEmpty()) {
+            return;
+        }
+        List<Object> toFire = new ArrayList<>(deferredChangeEntities);
+        deferredChangeEntities.clear();
+        for (Object entity : toFire) {
+            fireChangeListener(entity);
+        }
+    }
+
+    protected void recordMergeApplied(Object entity, String attribute) {
+        if (mergeDepth > 0) {
+            mergeApplied.computeIfAbsent(entity, e -> new HashSet<>()).add(attribute);
+        }
+    }
+
+    protected boolean isMergeApplied(Object entity, String attribute) {
+        Set<String> attrs = mergeApplied.get(entity);
+        return attrs != null && attrs.contains(attribute);
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     @Nullable
@@ -169,15 +202,19 @@ public class DataContextImpl implements DataContextInternal {
         checkNotNullArgument(entity, "entity is null");
         checkNotNullArgument(entity, "options object is null");
 
-        disableListeners = true;
+        mergeDepth++;
         mergeCollectionInProgress = new IdentityHashMap<>();
         T result;
         try {
             Map<Object, Object> merged = new IdentityHashMap<>();
             result = (T) internalMerge(entity, merged, true, options);
         } finally {
-            disableListeners = false;
             mergeCollectionInProgress = null;
+            mergeDepth--;
+            if (mergeDepth == 0) {
+                mergeApplied.clear();
+                flushDeferredChangeEvents();
+            }
         }
         return result;
     }
@@ -193,7 +230,7 @@ public class DataContextImpl implements DataContextInternal {
         checkNotNullArgument(entities, "options object is null");
 
         List<Object> managedList = new ArrayList<>(entities.size());
-        disableListeners = true;
+        mergeDepth++;
         mergeCollectionInProgress = new IdentityHashMap<>();
         try {
             Map<Object, Object> merged = new IdentityHashMap<>();
@@ -203,8 +240,12 @@ public class DataContextImpl implements DataContextInternal {
                 managedList.add(managed);
             }
         } finally {
-            disableListeners = false;
             mergeCollectionInProgress = null;
+            mergeDepth--;
+            if (mergeDepth == 0) {
+                mergeApplied.clear();
+                flushDeferredChangeEvents();
+            }
         }
         return EntitySet.of(managedList);
     }
@@ -251,7 +292,7 @@ public class DataContextImpl implements DataContextInternal {
 
             if (entityStates.isNew(managed)) {
                 modifiedInstances.add(managed);
-                fireChangeListener(managed);
+                deferredChangeEntities.add(managed);
             }
         } else {
             mergedMap.put(entity, managed);
@@ -598,6 +639,7 @@ public class DataContextImpl implements DataContextInternal {
 
     protected void setPropertyValue(Object entity, MetaProperty property, @Nullable Object value, boolean checkEquals) {
         EntityPreconditions.checkEntityType(entity);
+        recordMergeApplied(entity, property.getName());
         if (!property.isReadOnly()) {
             EntityValues.setValue(entity, property.getName(), value, checkEquals);
         } else {
@@ -709,6 +751,7 @@ public class DataContextImpl implements DataContextInternal {
         if (!beginMergeCollection(managedEntity, propertyName)) {
             return;
         }
+        recordMergeApplied(managedEntity, propertyName);
         try {
             if (replace) {
                 List<Object> managedRefs = new ArrayList<>(list.size());
@@ -759,6 +802,7 @@ public class DataContextImpl implements DataContextInternal {
         if (!beginMergeCollection(managedEntity, propertyName)) {
             return;
         }
+        recordMergeApplied(managedEntity, propertyName);
         try {
             if (replace) {
                 Set<Object> managedRefs = new LinkedHashSet<>(set.size());
@@ -855,7 +899,9 @@ public class DataContextImpl implements DataContextInternal {
     }
 
     protected void collectionChanged(Object entity, @Nullable String property) {
-        if (disableListeners) {
+        if (mergeDepth > 0 && (property == null || isMergeApplied(entity, property))) {
+            // the merge's own collection change: skip the tracker, defer the ChangeEvent
+            deferredChangeEntities.add(entity);
             return;
         }
         // Unconditional mark-and-notify first, matching the scalar PropertyChangeListener's semantics:
@@ -863,7 +909,7 @@ public class DataContextImpl implements DataContextInternal {
         // tracked attribute becomes clean (e.g. a collection mutation reverted to its baseline). Calling
         // the tracker before this unconditional marking would let this marking immediately undo a
         // just-computed clean transition.
-        modified(entity);
+        modifiedInstances.add(entity);
         if (property != null) {
             MetaProperty metaProperty = metadata.getClass(entity).findProperty(property);
             if (metaProperty != null && metaProperty.getRange().isClass()) {
@@ -873,6 +919,11 @@ public class DataContextImpl implements DataContextInternal {
                     changeTracker.trackCollectionChange(entity, property, current);
                 }
             }
+        }
+        if (mergeDepth > 0) {
+            deferredChangeEntities.add(entity);
+        } else {
+            fireChangeListener(entity);
         }
     }
 
@@ -1371,13 +1422,6 @@ public class DataContextImpl implements DataContextInternal {
         return resultList;
     }
 
-    protected void modified(Object entity) {
-        if (!disableListeners) {
-            modifiedInstances.add(entity);
-            fireChangeListener(entity);
-        }
-    }
-
     public String printContent() {
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<Class<?>, Map<Object, Object>> entry : content.entrySet()) {
@@ -1464,27 +1508,35 @@ public class DataContextImpl implements DataContextInternal {
                 }
             }
 
-            if (!disableListeners) {
-                // Unconditional add preserves today's semantics for to-many and unclassifiable properties;
-                // the tracker's transition callback below may remove the entity again once the tracked
-                // attributes are all clean (e.g. a scalar/reference edit reverted to its baseline).
-                modifiedInstances.add(e.getItem());
+            if (mergeDepth > 0 && isMergeApplied(e.getItem(), e.getProperty())) {
+                // the merge's own write: skip the tracker (the merge does its own baseline
+                // bookkeeping) and defer the ChangeEvent to the flush
+                deferredChangeEntities.add(e.getItem());
+                return;
+            }
 
-                MetaProperty changedProperty = metadata.getClass(e.getItem()).findProperty(e.getProperty());
-                if (changedProperty != null && changedProperty.getRange().isClass()
-                        && changedProperty.getRange().getCardinality().isMany()) {
-                    // to-many properties are handled by the observable collection wrappers; skip the tracker here
-                } else if (e.getProperty().equals(primaryKeyPropertyName)) {
-                    // an id change is identity bookkeeping (e.g. setId() in a saveDelegate),
-                    // not a user attribute edit; skip the tracker
-                } else {
-                    boolean reference = changedProperty != null && changedProperty.getRange().isClass()
-                            && !changedProperty.getRange().getCardinality().isMany();
-                    changeTracker.trackChange(e.getItem(), e.getProperty(), e.getPrevValue(), e.getValue(), reference);
-                    // a user set makes the attribute authoritative and present in memory (even a set to null),
-                    // so it is loaded regardless of whether it was fetched
-                    markLoaded(e.getItem(), e.getProperty());
-                }
+            // off-merge edit, OR a listener-injected edit during a merge (#1258): track it as usual
+            modifiedInstances.add(e.getItem());
+
+            MetaProperty changedProperty = metadata.getClass(e.getItem()).findProperty(e.getProperty());
+            if (changedProperty != null && changedProperty.getRange().isClass()
+                    && changedProperty.getRange().getCardinality().isMany()) {
+                // to-many properties are handled by the observable collection wrappers; skip the tracker here
+            } else if (e.getProperty().equals(primaryKeyPropertyName)) {
+                // an id change is identity bookkeeping (e.g. setId() in a saveDelegate),
+                // not a user attribute edit; skip the tracker
+            } else {
+                boolean reference = changedProperty != null && changedProperty.getRange().isClass()
+                        && !changedProperty.getRange().getCardinality().isMany();
+                changeTracker.trackChange(e.getItem(), e.getProperty(), e.getPrevValue(), e.getValue(), reference);
+                // a user set makes the attribute authoritative and present in memory (even a set to null),
+                // so it is loaded regardless of whether it was fetched
+                markLoaded(e.getItem(), e.getProperty());
+            }
+
+            if (mergeDepth > 0) {
+                deferredChangeEntities.add(e.getItem());
+            } else {
                 fireChangeListener(e.getItem());
             }
         }
@@ -1503,17 +1555,25 @@ public class DataContextImpl implements DataContextInternal {
 
         @Override
         public void propertyChanged(EntityPropertyChangeEvent e) {
-            if (!disableListeners) {
-                modifiedInstances.add(entity);
+            if (mergeDepth > 0 && isMergeApplied(e.getItem(), e.getProperty())) {
+                deferredChangeEntities.add(entity);
+                return;
+            }
 
-                MetaProperty changedProperty = metadata.getClass(e.getItem()).findProperty(e.getProperty());
-                if (changedProperty != null && changedProperty.getRange().isClass()
-                        && changedProperty.getRange().getCardinality().isMany()) {
-                    // to-many properties are handled by the observable collection wrappers; skip the tracker here
-                } else {
-                    changeTracker.trackChange(entity, embeddedPropertyName + '.' + e.getProperty(),
-                            e.getPrevValue(), e.getValue(), false);
-                }
+            modifiedInstances.add(entity);
+
+            MetaProperty changedProperty = metadata.getClass(e.getItem()).findProperty(e.getProperty());
+            if (changedProperty != null && changedProperty.getRange().isClass()
+                    && changedProperty.getRange().getCardinality().isMany()) {
+                // to-many properties are handled by the observable collection wrappers; skip the tracker here
+            } else {
+                changeTracker.trackChange(entity, embeddedPropertyName + '.' + e.getProperty(),
+                        e.getPrevValue(), e.getValue(), false);
+            }
+
+            if (mergeDepth > 0) {
+                deferredChangeEntities.add(entity);
+            } else {
                 fireChangeListener(entity);
             }
         }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -146,6 +146,11 @@ public class DataContextImpl implements DataContextInternal {
         events.publish(ChangeEvent.class, new ChangeEvent(this, entity));
     }
 
+    /**
+     * Fires a single {@code ChangeEvent} for each entity queued in {@link #deferredChangeEntities} during a
+     * merge, then clears the queue. Called when the outermost merge unwinds so listeners see one event per
+     * entity, after all of the merge's writes are in place.
+     */
     protected void flushDeferredChangeEvents() {
         if (deferredChangeEntities.isEmpty()) {
             return;
@@ -157,12 +162,21 @@ public class DataContextImpl implements DataContextInternal {
         }
     }
 
+    /**
+     * Records that the merge itself wrote the given (entity, attribute) during the active merge. A change
+     * event for an (entity, attribute) that is <em>not</em> recorded is a listener-injected user edit and
+     * must be tracked; see {@link #isMergeApplied}. No-op outside a merge.
+     */
     protected void recordMergeApplied(Object entity, String attribute) {
         if (mergeDepth > 0) {
             mergeApplied.computeIfAbsent(entity, e -> new HashSet<>()).add(attribute);
         }
     }
 
+    /**
+     * Whether the merge itself wrote the given (entity, attribute) during the active merge (see
+     * {@link #recordMergeApplied}). Used to tell the merge's own writes from listener-injected user edits.
+     */
     protected boolean isMergeApplied(Object entity, String attribute) {
         Set<String> attrs = mergeApplied.get(entity);
         return attrs != null && attrs.contains(attribute);
@@ -341,6 +355,12 @@ public class DataContextImpl implements DataContextInternal {
         mergeLazyLoadingState(srcEntity, dstEntity);
     }
 
+    /**
+     * Copies the loaded datatype and element-collection properties from the source to the destination
+     * instance, honouring the dirty-aware merge rule (a destination attribute with an unsaved user edit is
+     * never overwritten; a fresh merge rebaselines it instead). Element collections are wrapped in an
+     * observable collection so later mutations are tracked.
+     */
     protected void mergeDatatypeProperties(Object srcEntity, Object dstEntity, MetaClass metaClass,
                                            boolean srcNew, boolean dstNew, boolean isRoot, MergeOptions options) {
         for (MetaProperty property : metaClass.getProperties()) {
@@ -390,6 +410,12 @@ public class DataContextImpl implements DataContextInternal {
         }
     }
 
+    /**
+     * Copies the loaded reference and to-many properties from the source to the destination instance,
+     * recursively merging each reached node into the context graph. Delegates the dirty-aware special
+     * cases to {@link #skipOrRebaselineDirtyReference} and {@link #mergeUnloadedOrNullReference}, and
+     * collections to {@code mergeList}/{@code mergeSet}. Embedded references get a change listener installed.
+     */
     protected void mergeReferenceProperties(Object srcEntity, Object dstEntity, MetaClass metaClass,
                                             boolean srcNew, boolean isRoot, MergeOptions options,
                                             Map<Object, Object> mergedMap) {
@@ -445,6 +471,13 @@ public class DataContextImpl implements DataContextInternal {
         }
     }
 
+    /**
+     * Applies the dirty-aware merge rule to a reference or to-many property: when the destination attribute
+     * carries an unsaved user edit (including a dirty dotted path under an embedded reference), the incoming
+     * value is not installed. Returns {@code true} to tell {@link #mergeReferenceProperties} to skip the
+     * property. A fresh merge still rebaselines the edit against the incoming value, and any skipped incoming
+     * node is still merged into the context graph.
+     */
     protected boolean skipOrRebaselineDirtyReference(Object dstEntity, MetaProperty property, @Nullable Object value,
                                                      boolean isRoot, MergeOptions options,
                                                      Map<Object, Object> mergedMap) {
@@ -489,6 +522,13 @@ public class DataContextImpl implements DataContextInternal {
         return false;
     }
 
+    /**
+     * Installs a reference/to-many value when the source side is loaded but the destination side is not yet
+     * loaded (or the incoming value is null). A null value is set directly; otherwise the reached node(s)
+     * are merged so the installed value holds managed instances, a collection is wrapped observable with a
+     * tracker baseline, and the attribute is marked loaded. Embedded properties are handled by the
+     * loaded-destination path, not here.
+     */
     protected void mergeUnloadedOrNullReference(Object dstEntity, MetaProperty property,
                                                 @Nullable Object value, Map<Object, Object> mergedMap,
                                                 MergeOptions options) {
@@ -701,6 +741,11 @@ public class DataContextImpl implements DataContextInternal {
                 && EntitySystemAccess.getEntityEntry(dstEntity).getLoadedPropertiesInfo() instanceof CachingLoadedPropertiesInfo;
     }
 
+    /**
+     * Blanks the destination's caching loaded-state info before the copy loops when {@code coldReset} is
+     * set (see {@link #isColdResetTarget}), so their {@code isLoaded} checks recompute from the fetch group
+     * just unioned in {@link #mergeSystemState} rather than from a stale cached negative. No-op otherwise.
+     */
     protected void resetLoadedInfoBeforeCopy(Object dstEntity, boolean coldReset) {
         if (coldReset) {
             // Reset before the copy loops so their isLoaded(dstEntity, ...) checks recompute from the
@@ -860,6 +905,10 @@ public class DataContextImpl implements DataContextInternal {
         return mergeCollectionInProgress.computeIfAbsent(managedEntity, k -> new HashSet<>()).add(propertyName);
     }
 
+    /**
+     * Clears the in-progress marker set by {@link #beginMergeCollection} for the owner's collection
+     * property, once its merge finishes.
+     */
     protected void endMergeCollection(Object managedEntity, String propertyName) {
         Set<String> props = mergeCollectionInProgress.get(managedEntity);
         if (props != null) {
@@ -870,6 +919,11 @@ public class DataContextImpl implements DataContextInternal {
         }
     }
 
+    /**
+     * Wraps a collection in an observable list/set that notifies {@link #collectionChanged} on mutation and,
+     * when a property is given, snapshots the tracker baseline so a later mutation marks the owner modified.
+     * Returns the collection unchanged if it is neither a list nor a set.
+     */
     protected Collection<Object> wrapLazyValueIntoObservableCollection(Collection<Object> collection, Object notifiedEntity,
                                                                         @Nullable String property) {
         if (collection instanceof List) {
@@ -902,6 +956,11 @@ public class DataContextImpl implements DataContextInternal {
         return new ObservableSet<>(set, (changeType, changes) -> collectionChanged(notifiedEntity, property));
     }
 
+    /**
+     * Mutation callback for the observable collection wrappers. The merge's own collection writes skip the
+     * tracker and defer their {@code ChangeEvent}; any other mutation marks the owner modified, updates the
+     * tracker's to-many dirty state, and fires (or, inside a merge, defers) a {@code ChangeEvent}.
+     */
     protected void collectionChanged(Object entity, @Nullable String property) {
         if (mergeDepth > 0 && (property == null || isMergeApplied(entity, property))) {
             // the merge's own collection change: skip the tracker, defer the ChangeEvent
@@ -1091,10 +1150,18 @@ public class DataContextImpl implements DataContextInternal {
         return changeTracker.getModifiedAttributes(managed);
     }
 
+    /**
+     * Change-tracker callback: an entity gained its first dirty attribute, so it joins
+     * {@link #modifiedInstances}.
+     */
     protected void entityBecameDirty(Object entity) {
         modifiedInstances.add(entity);
     }
 
+    /**
+     * Change-tracker callback: an entity lost its last dirty attribute, so it leaves
+     * {@link #modifiedInstances} unless it was pinned modified via {@link #setModified} ({@code manuallyModified}).
+     */
     protected void entityBecameClean(Object entity) {
         if (!manuallyModified.contains(entity)) {
             modifiedInstances.remove(entity);
@@ -1294,6 +1361,11 @@ public class DataContextImpl implements DataContextInternal {
         return value;
     }
 
+    /**
+     * The first segment of a possibly-dotted attribute path: {@code 'address'} for {@code 'address.city'},
+     * or the whole string when it has no dot. Used to check the loaded state of the top-level property a
+     * dotted (embedded) path belongs to.
+     */
     protected static String rootSegment(String attribute) {
         int dotIndex = attribute.indexOf('.');
         return dotIndex < 0 ? attribute : attribute.substring(0, dotIndex);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -90,6 +90,11 @@ public class DataContextImpl implements DataContextInternal {
     // from within mergeFromChild (a parent's save into a grandparent runs on another instance).
     protected Set<String> overridingAttributes = Set.of();
 
+    // (managedEntity identity -> property names) whose collection is being merged within the active
+    // merge() call. Guards against re-entering mergeList/mergeSet for the same owner collection when
+    // the source graph holds multiple java instances of the same id joined by a bidirectional reference.
+    protected Map<Object, Set<String>> mergeCollectionInProgress;
+
     protected PropertyChangeListener propertyChangeListener = new PropertyChangeListener();
 
     protected boolean disableListeners;
@@ -160,12 +165,14 @@ public class DataContextImpl implements DataContextInternal {
         checkNotNullArgument(entity, "options object is null");
 
         disableListeners = true;
+        mergeCollectionInProgress = new IdentityHashMap<>();
         T result;
         try {
             Map<Object, Object> merged = new IdentityHashMap<>();
             result = (T) internalMerge(entity, merged, true, options);
         } finally {
             disableListeners = false;
+            mergeCollectionInProgress = null;
         }
         return result;
     }
@@ -182,6 +189,7 @@ public class DataContextImpl implements DataContextInternal {
 
         List<Object> managedList = new ArrayList<>(entities.size());
         disableListeners = true;
+        mergeCollectionInProgress = new IdentityHashMap<>();
         try {
             Map<Object, Object> merged = new IdentityHashMap<>();
 
@@ -191,6 +199,7 @@ public class DataContextImpl implements DataContextInternal {
             }
         } finally {
             disableListeners = false;
+            mergeCollectionInProgress = null;
         }
         return EntitySet.of(managedList);
     }
@@ -668,85 +677,119 @@ public class DataContextImpl implements DataContextInternal {
     protected void mergeList(List<Object> list, Object managedEntity, MetaProperty property, boolean replace,
                              MergeOptions options, Map<Object, Object> mergedMap) {
         String propertyName = property.getName();
-        if (replace) {
-            List<Object> managedRefs = new ArrayList<>(list.size());
-            for (Object entity : list) {
-                Object managedRef = internalMerge(entity, mergedMap, false, options);
-                managedRefs.add(managedRef);
-            }
-            changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, managedRefs);
-            List<Object> dstList = createObservableList(managedRefs, managedEntity, propertyName);
-            setPropertyValue(managedEntity, property, dstList);
-
-        } else {
-            Object managedValue = EntityValues.getValue(managedEntity, propertyName);
-
-            List<Object> dstList = null;
-            if (managedValue instanceof List) {
-                dstList = (List<Object>) managedValue;
-            } else if (managedValue != null) {//any proxy Collection can be returned in case of Collection entity attribute (see Haulmont/jmix-ui#243)
-                dstList = new ArrayList<>((Collection<?>) managedValue);
-            }
-
-            if (dstList == null) {
-                dstList = createObservableList(managedEntity, propertyName);
-                setPropertyValue(managedEntity, property, dstList);
-            }
-            if (dstList.size() == 0) {
-                for (Object srcRef : list) {
-                    dstList.add(internalMerge(srcRef, mergedMap, false, options));
+        if (!beginMergeCollection(managedEntity, propertyName)) {
+            return;
+        }
+        try {
+            if (replace) {
+                List<Object> managedRefs = new ArrayList<>(list.size());
+                for (Object entity : list) {
+                    Object managedRef = internalMerge(entity, mergedMap, false, options);
+                    managedRefs.add(managedRef);
                 }
+                changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, managedRefs);
+                List<Object> dstList = createObservableList(managedRefs, managedEntity, propertyName);
+                setPropertyValue(managedEntity, property, dstList);
+
             } else {
-                for (Object srcRef : list) {
-                    Object managedRef = internalMerge(srcRef, mergedMap, false, options);
-                    if (!dstList.contains(managedRef)) {
-                        dstList.add(managedRef);
+                Object managedValue = EntityValues.getValue(managedEntity, propertyName);
+
+                List<Object> dstList = null;
+                if (managedValue instanceof List) {
+                    dstList = (List<Object>) managedValue;
+                } else if (managedValue != null) {//any proxy Collection can be returned in case of Collection entity attribute (see Haulmont/jmix-ui#243)
+                    dstList = new ArrayList<>((Collection<?>) managedValue);
+                }
+
+                if (dstList == null) {
+                    dstList = createObservableList(managedEntity, propertyName);
+                    setPropertyValue(managedEntity, property, dstList);
+                }
+                if (dstList.size() == 0) {
+                    for (Object srcRef : list) {
+                        dstList.add(internalMerge(srcRef, mergedMap, false, options));
+                    }
+                } else {
+                    for (Object srcRef : list) {
+                        Object managedRef = internalMerge(srcRef, mergedMap, false, options);
+                        if (!dstList.contains(managedRef)) {
+                            dstList.add(managedRef);
+                        }
                     }
                 }
+                changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, dstList);
             }
-            changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, dstList);
+        } finally {
+            endMergeCollection(managedEntity, propertyName);
         }
     }
 
     protected void mergeSet(Set<Object> set, Object managedEntity, MetaProperty property, boolean replace,
                             MergeOptions options, Map<Object, Object> mergedMap) {
         String propertyName = property.getName();
-        if (replace) {
-            Set<Object> managedRefs = new LinkedHashSet<>(set.size());
-            for (Object entity : set) {
-                Object managedRef = internalMerge(entity, mergedMap, false, options);
-                managedRefs.add(managedRef);
-            }
-            changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, managedRefs);
-            Set<Object> dstSet = createObservableSet(managedRefs, managedEntity, propertyName);
-            setPropertyValue(managedEntity, property, dstSet);
-
-        } else {
-            Object managedValue = EntityValues.getValue(managedEntity, propertyName);
-
-            Set<Object> dstSet = null;
-            if (managedValue instanceof Set) {
-                dstSet = (Set<Object>) managedValue;
-            } else if (managedValue != null) {//any proxy Collection can be returned in case of Collection entity attribute (see Haulmont/jmix-ui#243)
-                dstSet = new LinkedHashSet<>((Collection<?>) managedValue);
-            }
-
-
-            if (dstSet == null) {
-                dstSet = createObservableSet(managedEntity, propertyName);
+        if (!beginMergeCollection(managedEntity, propertyName)) {
+            return;
+        }
+        try {
+            if (replace) {
+                Set<Object> managedRefs = new LinkedHashSet<>(set.size());
+                for (Object entity : set) {
+                    Object managedRef = internalMerge(entity, mergedMap, false, options);
+                    managedRefs.add(managedRef);
+                }
+                changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, managedRefs);
+                Set<Object> dstSet = createObservableSet(managedRefs, managedEntity, propertyName);
                 setPropertyValue(managedEntity, property, dstSet);
-            }
-            if (dstSet.size() == 0) {
-                for (Object srcRef : set) {
-                    dstSet.add(internalMerge(srcRef, mergedMap, false, options));
-                }
+
             } else {
-                for (Object srcRef : set) {
-                    Object managedRef = internalMerge(srcRef, mergedMap, false, options);
-                    dstSet.add(managedRef);
+                Object managedValue = EntityValues.getValue(managedEntity, propertyName);
+
+                Set<Object> dstSet = null;
+                if (managedValue instanceof Set) {
+                    dstSet = (Set<Object>) managedValue;
+                } else if (managedValue != null) {//any proxy Collection can be returned in case of Collection entity attribute (see Haulmont/jmix-ui#243)
+                    dstSet = new LinkedHashSet<>((Collection<?>) managedValue);
                 }
+
+
+                if (dstSet == null) {
+                    dstSet = createObservableSet(managedEntity, propertyName);
+                    setPropertyValue(managedEntity, property, dstSet);
+                }
+                if (dstSet.size() == 0) {
+                    for (Object srcRef : set) {
+                        dstSet.add(internalMerge(srcRef, mergedMap, false, options));
+                    }
+                } else {
+                    for (Object srcRef : set) {
+                        Object managedRef = internalMerge(srcRef, mergedMap, false, options);
+                        dstSet.add(managedRef);
+                    }
+                }
+                changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, dstSet);
             }
-            changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, dstSet);
+        } finally {
+            endMergeCollection(managedEntity, propertyName);
+        }
+    }
+
+    /**
+     * Marks the given owner entity's collection property as being merged within the active merge() call.
+     * Returns {@code false} if it is already in progress (a re-entry, caused by a source graph holding
+     * multiple java instances of the same id joined by a bidirectional reference), in which case the
+     * caller must return early and let the outer mergeList/mergeSet finish populating the collection.
+     */
+    protected boolean beginMergeCollection(Object managedEntity, String propertyName) {
+        return mergeCollectionInProgress.computeIfAbsent(managedEntity, k -> new HashSet<>()).add(propertyName);
+    }
+
+    protected void endMergeCollection(Object managedEntity, String propertyName) {
+        Set<String> props = mergeCollectionInProgress.get(managedEntity);
+        if (props != null) {
+            props.remove(propertyName);
+            if (props.isEmpty()) {
+                mergeCollectionInProgress.remove(managedEntity);
+            }
         }
     }
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -417,7 +417,7 @@ public class DataContextImpl implements DataContextInternal {
                 }
 
                 if (value == null || !entityStates.isLoaded(dstEntity, propertyName)) {
-                    mergeUnloadedOrNullReference(srcEntity, dstEntity, property, value);
+                    mergeUnloadedOrNullReference(srcEntity, dstEntity, property, value, mergedMap, options);
                     continue;
                 }
 
@@ -497,32 +497,48 @@ public class DataContextImpl implements DataContextInternal {
     }
 
     protected void mergeUnloadedOrNullReference(Object srcEntity, Object dstEntity, MetaProperty property,
-                                                @Nullable Object value) {
-        if (property.getType() != MetaProperty.Type.EMBEDDED) {//dstEntity property value will be lazy loaded and replaced by srcEntity property value
-            String propertyName = property.getName();
-            if (value instanceof Collection) {
-                // a to-many value installed on an unloaded dst property must notify the
-                // context on mutation like every other merge-installed collection
-                boolean[] wrappedLazy = new boolean[1];
-                entitySystemStateSupport.mergeLazyLoadingState((Entity) srcEntity, (Entity) dstEntity, property,
-                        collection -> {
-                            wrappedLazy[0] = true;
-                            return wrapLazyValueIntoObservableCollection(collection, dstEntity, propertyName);
-                        });
-                if (!wrappedLazy[0]) {
-                    Collection<Object> installed = wrapLazyValueIntoObservableCollection(
-                            (Collection<Object>) value, dstEntity, propertyName);
-                    setPropertyValue(dstEntity, property, installed);
-                }
-                // a non-null value is now present in memory; reflect it in the loaded-state info
-                markLoaded(dstEntity, propertyName);
-            } else {
-                setPropertyValue(dstEntity, property, value);
-                if (value != null) {
-                    markLoaded(dstEntity, propertyName);
-                }
-            }
+                                                @Nullable Object value, Map<Object, Object> mergedMap,
+                                                MergeOptions options) {
+        if (property.getType() == MetaProperty.Type.EMBEDDED) {
+            // embedded values are not lazy-loaded and are handled by the loaded-destination path
+            return;
         }
+        String propertyName = property.getName();
+
+        if (value == null) {
+            setPropertyValue(dstEntity, property, null);
+            return;
+        }
+
+        // The source property is loaded (caller guard: srcNew || isLoaded(srcEntity, ...)), so its
+        // value is materialized: merge the reached node(s) into the context so the installed value
+        // holds managed instances (the identity map), exactly as the loaded-destination path
+        // (internalMerge / mergeList) does. The both-sides-unloaded lazy holder is handled elsewhere
+        // (mergeLazyLoadingState) and is out of scope here.
+        Object installed;
+        if (value instanceof Collection<?> srcCollection) {
+            Collection<Object> managedRefs;
+            if (value instanceof List) {
+                managedRefs = new ArrayList<>();
+            } else if (value instanceof Set) {
+                managedRefs = new LinkedHashSet<>();
+            } else {
+                throw new UnsupportedOperationException("Unsupported collection type: " + value.getClass().getName());
+            }
+            for (Object srcRef : srcCollection) {
+                managedRefs.add(internalMerge(srcRef, mergedMap, false, options));
+            }
+            // makes it observable AND snapshots the tracker baseline, so mutating it later marks the
+            // owner modified like every merged collection
+            installed = wrapLazyValueIntoObservableCollection(managedRefs, dstEntity, propertyName);
+        } else {
+            installed = internalMerge(value, mergedMap, false, options);
+        }
+        // checkEquals=false: always install the merged value, matching the loaded-destination
+        // merge-install convention (mergeReferenceProperties) and never skipping the set because a
+        // lazily materialized destination value happens to compare equal
+        setPropertyValue(dstEntity, property, installed, false);
+        markLoaded(dstEntity, propertyName);
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -84,20 +84,17 @@ public class DataContextImpl implements DataContextInternal {
 
     protected Set<Object> manuallyModified = new HashSet<>();
 
-    // Composition owners marked modified only to protect an intermediate editor from a stale reload:
-    // the reopen gate reads isModified, but these owners have no change of their own
-    // and must NOT be persisted, so they are kept out of modifiedInstances and the save set.
+    // Composition owners marked modified only to protect an intermediate editor from a stale reload
+    // (consulted by isModified). They have no change of their own and are kept out of the save set.
     protected Set<Object> compositionModifiedOwners = new HashSet<>();
 
-    // Non-empty only inside mergeFromChild: attributes of the merge root whose incoming (child)
-    // values must overwrite this context's own unsaved edits. Scoped to the single merge call
-    // via try/finally; safe as a plain field because a context never re-enters its own merge
-    // from within mergeFromChild (a parent's save into a grandparent runs on another instance).
+    // Non-empty only inside mergeFromChild: attributes of the merge root whose incoming (child) values
+    // must overwrite this context's own unsaved edits. Scoped to the single merge call via try/finally.
     protected Set<String> overridingAttributes = Set.of();
 
     // (managedEntity identity -> property names) whose collection is being merged within the active
-    // merge() call. Guards against re-entering mergeList/mergeSet for the same owner collection when
-    // the source graph holds multiple java instances of the same id joined by a bidirectional reference.
+    // merge() call. Guards against re-entering mergeList/mergeSet for the same owner collection when the
+    // source graph holds multiple java instances of the same id joined by a bidirectional reference.
     protected Map<Object, Set<String>> mergeCollectionInProgress;
 
     protected PropertyChangeListener propertyChangeListener = new PropertyChangeListener();
@@ -362,13 +359,9 @@ public class DataContextImpl implements DataContextInternal {
 
                 if (changeTracker.isAttributeDirty(dstEntity, propertyName)
                         && !(isRoot && isOverriding(propertyName))) {
-                    // dirty-aware merge rule: the destination attribute carries an unsaved user
-                    // edit and is never overwritten; a fresh merge rebaselines the edit against
-                    // the incoming value instead (un-dirtying it if now equal). Reading the
-                    // current value is safe: a dirty attribute was written by the user through
-                    // the managed instance, so it is loaded on the destination.
-                    // Exception: during mergeFromChild the child's dirty attributes of the merge
-                    // root override this context's own edits (see isOverriding).
+                    // dirty-aware merge rule: a destination attribute with an unsaved user edit is never
+                    // overwritten; a fresh merge rebaselines the edit against the incoming value instead
+                    // (un-dirtying it if now equal). isOverriding is the mergeFromChild exception.
                     if (options.isFresh()) {
                         changeTracker.rebaseline(dstEntity, propertyName, value,
                                 EntityValues.getValue(dstEntity, propertyName), false);
@@ -384,9 +377,9 @@ public class DataContextImpl implements DataContextInternal {
                     // datatype values; do not snapshot a collection baseline for them - their elements
                     // are not entities and cannot be used as a tracker refKey
                     if (value instanceof List) {
-                        value = createObservableList(new ArrayList<>((Collection<Object>) srcCollection), dstEntity, propertyName);
+                        value = createObservableList(new ArrayList<>(srcCollection), dstEntity, propertyName);
                     } else if (value instanceof Set) {
-                        value = createObservableSet(new HashSet<>((Collection<Object>) srcCollection), dstEntity, propertyName);
+                        value = createObservableSet(new HashSet<>(srcCollection), dstEntity, propertyName);
                     } else {
                         throw new UnsupportedOperationException("Unsupported collection type: " + value.getClass().getName());
                     }
@@ -417,7 +410,7 @@ public class DataContextImpl implements DataContextInternal {
                 }
 
                 if (value == null || !entityStates.isLoaded(dstEntity, propertyName)) {
-                    mergeUnloadedOrNullReference(srcEntity, dstEntity, property, value, mergedMap, options);
+                    mergeUnloadedOrNullReference(dstEntity, property, value, mergedMap, options);
                     continue;
                 }
 
@@ -480,7 +473,7 @@ public class DataContextImpl implements DataContextInternal {
                 // destination (references hold a managed instance or null; collections
                 // hold the observable wrapper)
                 if (value instanceof Collection<?> incoming) {
-                    Collection<?> current = (Collection<?>) EntityValues.getValue(dstEntity, propertyName);
+                    Collection<?> current = EntityValues.getValue(dstEntity, propertyName);
                     changeTracker.rebaselineCollection(dstEntity, propertyName, incoming, current);
                 } else if (embedded) {
                     rebaselineEmbedded(dstEntity, propertyName, value, dirtyEmbeddedPaths);
@@ -496,7 +489,7 @@ public class DataContextImpl implements DataContextInternal {
         return false;
     }
 
-    protected void mergeUnloadedOrNullReference(Object srcEntity, Object dstEntity, MetaProperty property,
+    protected void mergeUnloadedOrNullReference(Object dstEntity, MetaProperty property,
                                                 @Nullable Object value, Map<Object, Object> mergedMap,
                                                 MergeOptions options) {
         if (property.getType() == MetaProperty.Type.EMBEDDED) {
@@ -510,11 +503,9 @@ public class DataContextImpl implements DataContextInternal {
             return;
         }
 
-        // The source property is loaded (caller guard: srcNew || isLoaded(srcEntity, ...)), so its
-        // value is materialized: merge the reached node(s) into the context so the installed value
-        // holds managed instances (the identity map), exactly as the loaded-destination path
-        // (internalMerge / mergeList) does. The both-sides-unloaded lazy holder is handled elsewhere
-        // (mergeLazyLoadingState) and is out of scope here.
+        // The source property is loaded (caller guard), so its value is materialized: merge the reached
+        // node(s) so the installed value holds managed instances, like the loaded-destination path does.
+        // The both-sides-unloaded lazy holder is handled elsewhere (mergeLazyLoadingState).
         Object installed;
         if (value instanceof Collection<?> srcCollection) {
             Collection<Object> managedRefs;
@@ -555,14 +546,11 @@ public class DataContextImpl implements DataContextInternal {
     }
 
     /**
-     * Re-asserts the set-loaded markers of an entity into its current {@link LoadedPropertiesInfo}, so a value
-     * that is present in memory because it was set or merge-installed keeps reporting loaded after a fresh merge
-     * replaces the loaded-state cache with a narrower source's (in {@link #mergeLoadedPropertiesInfo}), whose
-     * negative for the attribute would otherwise shadow the fetch-group state. Writes only positive entries for
-     * recorded attributes, so it can never turn a genuinely-unloaded attribute loaded. No-op for entities
-     * without a cache. Runs after every merge, not only fresh ones; on the cold-reset path (which recomputes
-     * loaded-state from the fetch group) it re-affirms the same markers, safe by that positive-only invariant
-     * rather than by being inert.
+     * Re-asserts the set-loaded markers of an entity into its current {@link LoadedPropertiesInfo}, so a
+     * value present in memory because it was set or merge-installed keeps reporting loaded after a fresh
+     * merge replaces the loaded-state cache with a narrower source's (see {@link #mergeLoadedPropertiesInfo}).
+     * Writes only positive entries, so it can never turn a genuinely-unloaded attribute loaded. No-op for
+     * entities without a cache.
      */
     protected void reapplySetLoaded(Object dstEntity) {
         LoadedPropertiesInfo info = EntitySystemAccess.getEntityEntry(dstEntity).getLoadedPropertiesInfo();
@@ -1245,8 +1233,7 @@ public class DataContextImpl implements DataContextInternal {
         Map<String, Object> preMergeValues = new HashMap<>();
         if (managed != null) {
             // the merge below resets this instance's loaded-state cache before its copy loops
-            // (resetLoadedInfoBeforeCopy, same condition as this managed root), so probing isLoaded
-            // here cannot poison the merge's own checks - no disposable-copy guard is needed
+            // (resetLoadedInfoBeforeCopy), so probing isLoaded here cannot poison the merge's own checks
             for (String attribute : childDirtyAttributes) {
                 if (entityStates.isLoaded(managed, rootSegment(attribute))) {
                     preMergeValues.put(attribute, valueForBaseline(managed, attribute));
@@ -1267,10 +1254,8 @@ public class DataContextImpl implements DataContextInternal {
                 continue;
             }
             if (!entityStates.isLoaded(result, rootSegment(attribute))) {
-                // edge guard for the dirty-implies-loaded invariant: after the merge the child's
-                // dirty attributes are normally loaded here (the fetch groups were unioned and the
-                // child's values copied), so this fires only in unusual states; never register
-                // dirt for an unloaded attribute (rebaseline reads would hit unfetched state)
+                // edge guard: never register dirt for an unloaded attribute (later rebaseline reads
+                // would hit unfetched state). After the merge these are normally loaded, so this is rare.
                 log.debug("Skipping dirty union of '{}' from child context: not loaded on the parent instance {}",
                         attribute, result);
                 continue;
@@ -1531,22 +1516,19 @@ public class DataContextImpl implements DataContextInternal {
                 return;
             }
 
-            // off-merge edit, OR a listener-injected edit during a merge (#1258): track it as usual
+            // off-merge edit, or a listener-injected edit during a merge (#1258): track it as usual
             modifiedInstances.add(e.getItem());
 
             MetaProperty changedProperty = metadata.getClass(e.getItem()).findProperty(e.getProperty());
-            if (changedProperty != null && changedProperty.getRange().isClass()
-                    && changedProperty.getRange().getCardinality().isMany()) {
-                // to-many properties are handled by the observable collection wrappers; skip the tracker here
-            } else if (e.getProperty().equals(primaryKeyPropertyName)) {
-                // an id change is identity bookkeeping (e.g. setId() in a saveDelegate),
-                // not a user attribute edit; skip the tracker
-            } else {
-                boolean reference = changedProperty != null && changedProperty.getRange().isClass()
-                        && !changedProperty.getRange().getCardinality().isMany();
+            boolean toMany = changedProperty != null && changedProperty.getRange().isClass()
+                    && changedProperty.getRange().getCardinality().isMany();
+            boolean idChange = e.getProperty().equals(primaryKeyPropertyName);
+            // to-many properties are tracked via the observable collection wrappers; an id change is
+            // identity bookkeeping (e.g. setId() in a saveDelegate), not a user edit - skip both
+            if (!toMany && !idChange) {
+                boolean reference = changedProperty != null && changedProperty.getRange().isClass();
                 changeTracker.trackChange(e.getItem(), e.getProperty(), e.getPrevValue(), e.getValue(), reference);
-                // a user set makes the attribute authoritative and present in memory (even a set to null),
-                // so it is loaded regardless of whether it was fetched
+                // a user set makes the attribute present in memory (even a set to null), so mark it loaded
                 markLoaded(e.getItem(), e.getProperty());
             }
 
@@ -1579,10 +1561,10 @@ public class DataContextImpl implements DataContextInternal {
             modifiedInstances.add(entity);
 
             MetaProperty changedProperty = metadata.getClass(e.getItem()).findProperty(e.getProperty());
-            if (changedProperty != null && changedProperty.getRange().isClass()
-                    && changedProperty.getRange().getCardinality().isMany()) {
-                // to-many properties are handled by the observable collection wrappers; skip the tracker here
-            } else {
+            boolean toMany = changedProperty != null && changedProperty.getRange().isClass()
+                    && changedProperty.getRange().getCardinality().isMany();
+            // to-many properties are tracked via the observable collection wrappers; skip the tracker here
+            if (!toMany) {
                 changeTracker.trackChange(entity, embeddedPropertyName + '.' + e.getProperty(),
                         e.getPrevValue(), e.getValue(), false);
             }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -298,6 +298,8 @@ public class DataContextImpl implements DataContextInternal {
 
         mergeLoadedPropertiesInfo(srcEntity, dstEntity, isRoot, options, coldReset);
 
+        reapplySetLoaded(dstEntity);
+
         mergeLazyLoadingState(srcEntity, dstEntity);
     }
 
@@ -491,6 +493,26 @@ public class DataContextImpl implements DataContextInternal {
         LoadedPropertiesInfo info = EntitySystemAccess.getEntityEntry(entity).getLoadedPropertiesInfo();
         if (info != null) {
             info.registerProperty(propertyName, true);
+            changeTracker.markSetLoaded(entity, propertyName);
+        }
+    }
+
+    /**
+     * Re-asserts the set-loaded markers of an entity into its current {@link LoadedPropertiesInfo}, so a value
+     * that is present in memory because it was set or merge-installed keeps reporting loaded after a fresh merge
+     * replaces the loaded-state cache with a narrower source's (in {@link #mergeLoadedPropertiesInfo}), whose
+     * negative for the attribute would otherwise shadow the fetch-group state. Writes only positive entries for
+     * recorded attributes, so it can never turn a genuinely-unloaded attribute loaded. No-op for entities
+     * without a cache. Runs after every merge, not only fresh ones; on the cold-reset path (which recomputes
+     * loaded-state from the fetch group) it re-affirms the same markers, safe by that positive-only invariant
+     * rather than by being inert.
+     */
+    protected void reapplySetLoaded(Object dstEntity) {
+        LoadedPropertiesInfo info = EntitySystemAccess.getEntityEntry(dstEntity).getLoadedPropertiesInfo();
+        if (info != null) {
+            for (String attribute : changeTracker.setLoadedAttributes(dstEntity)) {
+                info.registerProperty(attribute, true);
+            }
         }
     }
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -84,6 +84,11 @@ public class DataContextImpl implements DataContextInternal {
 
     protected Set<Object> manuallyModified = new HashSet<>();
 
+    // Composition owners marked modified only to protect an intermediate editor from a stale reload:
+    // the reopen gate reads isModified, but these owners have no change of their own
+    // and must NOT be persisted, so they are kept out of modifiedInstances and the save set.
+    protected Set<Object> compositionModifiedOwners = new HashSet<>();
+
     // Non-empty only inside mergeFromChild: attributes of the merge root whose incoming (child)
     // values must overwrite this context's own unsaved edits. Scoped to the single merge call
     // via try/finally; safe as a plain field because a context never re-enters its own merge
@@ -852,6 +857,7 @@ public class DataContextImpl implements DataContextInternal {
         checkNotNullArgument(entity, "entity is null");
 
         modifiedInstances.remove(entity);
+        compositionModifiedOwners.remove(entity);
         if (!entityStates.isNew(entity) || parentContext != null) {
             removedInstances.add(entity);
         }
@@ -911,6 +917,7 @@ public class DataContextImpl implements DataContextInternal {
             }
             modifiedInstances.remove(entity);
             removedInstances.remove(entity);
+            compositionModifiedOwners.remove(entity);
         }
     }
 
@@ -966,11 +973,12 @@ public class DataContextImpl implements DataContextInternal {
         removedInstances.clear();
         changeTracker.clear();
         manuallyModified.clear();
+        compositionModifiedOwners.clear();
     }
 
     @Override
     public boolean isModified(Object entity) {
-        return modifiedInstances.contains(entity);
+        return modifiedInstances.contains(entity) || compositionModifiedOwners.contains(entity);
     }
 
     @Override
@@ -985,6 +993,7 @@ public class DataContextImpl implements DataContextInternal {
         } else {
             manuallyModified.remove(merged);
             modifiedInstances.remove(merged);
+            compositionModifiedOwners.remove(merged);
             changeTracker.drop(merged);
         }
     }
@@ -1057,6 +1066,7 @@ public class DataContextImpl implements DataContextInternal {
         removedInstances.clear();
         changeTracker.clear();
         manuallyModified.clear();
+        compositionModifiedOwners.clear();
 
         return savedAndMerged;
     }
@@ -1176,6 +1186,7 @@ public class DataContextImpl implements DataContextInternal {
             }
             changeTracker.markDirty(result, attribute, preMergeValues.get(attribute));
         }
+        markCompositionOwnersModified(result);
         return result;
     }
 
@@ -1210,6 +1221,77 @@ public class DataContextImpl implements DataContextInternal {
     protected static String rootSegment(String attribute) {
         int dotIndex = attribute.indexOf('.');
         return dotIndex < 0 ? attribute : attribute.substring(0, dotIndex);
+    }
+
+    /**
+     * Marks the composition owner chain of a just-merged composition child for reopen protection in
+     * this (parent) context. A deep-composition edit propagated from a child context dirties only the
+     * edited leaf; the intermediate owners the child never marked would otherwise stay clean, so
+     * reopening an intermediate editor reloads a stale instance and loses the unsaved deeper edit.
+     * Owners go into compositionModifiedOwners (consulted by isModified), NOT into
+     * modifiedInstances, so they are never persisted - saving an aggregate must still persist only
+     * the entities that actually changed.
+     */
+    protected void markCompositionOwnersModified(Object entity) {
+        Set<Object> visited = Collections.newSetFromMap(new IdentityHashMap<>());
+        Object current = entity;
+        while (current != null && visited.add(current)) {
+            Object owner = findCompositionOwner(current);
+            if (owner != null) {
+                compositionModifiedOwners.add(owner);
+            }
+            current = owner;
+        }
+    }
+
+    /**
+     * Resolves the composition owner of a managed instance in this context. Inverse first: a
+     * reference whose inverse is a composition points back to the owner. Scan fallback (when no
+     * loaded inverse owner is found): a managed instance whose composition property references
+     * {@code entity}. Returns the managed owner instance, or {@code null} if none is found.
+     */
+    @Nullable
+    protected Object findCompositionOwner(Object entity) {
+        MetaClass metaClass = getEntityMetaClass(entity);
+        for (MetaProperty property : metaClass.getProperties()) {
+            MetaProperty inverse = property.getInverse();
+            if (property.getRange().isClass()
+                    && inverse != null && inverse.getType() == MetaProperty.Type.COMPOSITION
+                    && entityStates.isLoaded(entity, property.getName())) {
+                Object owner = EntityValues.getValue(entity, property.getName());
+                if (owner != null) {
+                    Object managedOwner = find(owner);
+                    if (managedOwner != null) {
+                        return managedOwner;
+                    }
+                }
+            }
+        }
+        for (Map<Object, Object> entityMap : content.values()) {
+            for (Object candidate : entityMap.values()) {
+                if (candidate == entity) {
+                    continue;
+                }
+                for (MetaProperty property : getEntityMetaClass(candidate).getProperties()) {
+                    if (property.getType() == MetaProperty.Type.COMPOSITION
+                            && entityStates.isLoaded(candidate, property.getName())) {
+                        Object value = EntityValues.getValue(candidate, property.getName());
+                        if (value == null) {
+                            continue;
+                        }
+                        if (property.getRange().getCardinality().isMany()) {
+                            if (value instanceof Collection<?> collection
+                                    && collection.stream().anyMatch(e -> e == entity)) {
+                                return candidate;
+                            }
+                        } else if (value == entity) {
+                            return candidate;
+                        }
+                    }
+                }
+            }
+        }
+        return null;
     }
 
     protected Set<Object> saveToParentContext() {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -79,6 +79,17 @@ public class DataContextImpl implements DataContextInternal {
 
     protected Set<Object> removedInstances = new HashSet<>();
 
+    protected DataContextChangeTracker changeTracker =
+            new DataContextChangeTracker(this::entityBecameDirty, this::entityBecameClean);
+
+    protected Set<Object> manuallyModified = new HashSet<>();
+
+    // Non-empty only inside mergeFromChild: attributes of the merge root whose incoming (child)
+    // values must overwrite this context's own unsaved edits. Scoped to the single merge call
+    // via try/finally; safe as a plain field because a context never re-enters its own merge
+    // from within mergeFromChild (a parent's save into a grandparent runs on another instance).
+    protected Set<String> overridingAttributes = Set.of();
+
     protected PropertyChangeListener propertyChangeListener = new PropertyChangeListener();
 
     protected boolean disableListeners;
@@ -255,11 +266,6 @@ public class DataContextImpl implements DataContextInternal {
     }
 
     protected void mergeState(Object srcEntity, Object dstEntity, Map<Object, Object> mergedMap,
-                              boolean isRoot, MergeOptions options) {
-        mergeState(srcEntity, dstEntity, mergedMap, isRoot, options, false);
-    }
-
-    protected void mergeState(Object srcEntity, Object dstEntity, Map<Object, Object> mergedMap,
                               boolean isRoot, MergeOptions options, boolean dstExisted) {
         boolean srcNew = entityStates.isNew(srcEntity);
         boolean dstNew = entityStates.isNew(dstEntity);
@@ -268,6 +274,17 @@ public class DataContextImpl implements DataContextInternal {
 
         MetaClass metaClass = getEntityMetaClass(srcEntity);
 
+        mergeDatatypeProperties(srcEntity, dstEntity, metaClass, srcNew, dstNew, isRoot, options);
+
+        mergeReferenceProperties(srcEntity, dstEntity, metaClass, srcNew, isRoot, options, mergedMap);
+
+        mergeLoadedPropertiesInfo(srcEntity, dstEntity, isRoot, options, dstExisted);
+
+        mergeLazyLoadingState(srcEntity, dstEntity);
+    }
+
+    protected void mergeDatatypeProperties(Object srcEntity, Object dstEntity, MetaClass metaClass,
+                                           boolean srcNew, boolean dstNew, boolean isRoot, MergeOptions options) {
         for (MetaProperty property : metaClass.getProperties()) {
             String propertyName = property.getName();
             if (!property.getRange().isClass()                                       // datatype or element collection
@@ -282,11 +299,33 @@ public class DataContextImpl implements DataContextInternal {
                     continue;
                 }
 
+                if (changeTracker.isAttributeDirty(dstEntity, propertyName)
+                        && !(isRoot && isOverriding(propertyName))) {
+                    // dirty-aware merge rule: the destination attribute carries an unsaved user
+                    // edit and is never overwritten; a fresh merge rebaselines the edit against
+                    // the incoming value instead (un-dirtying it if now equal). Reading the
+                    // current value is safe: a dirty attribute was written by the user through
+                    // the managed instance, so it is loaded on the destination.
+                    // Exception: during mergeFromChild the child's dirty attributes of the merge
+                    // root override this context's own edits (see isOverriding).
+                    if (options.isFresh()) {
+                        changeTracker.rebaseline(dstEntity, propertyName, value,
+                                EntityValues.getValue(dstEntity, propertyName), false);
+                    } else if (DataContextDiagnostics.log.isDebugEnabled()) {
+                        DataContextDiagnostics.log.debug(DataContextDiagnostics.mergeSkippedDirty(dstEntity, propertyName));
+                    }
+                    continue; // the user's value stays in place in both cases
+                }
+
                 if (value instanceof Collection<?> srcCollection) {
+                    // properties reaching this branch never have a to-many reference range (that is
+                    // handled below via mergeList/mergeSet), so these are always element collections of
+                    // datatype values; do not snapshot a collection baseline for them - their elements
+                    // are not entities and cannot be used as a tracker refKey
                     if (value instanceof List) {
-                        value = createObservableList(new ArrayList<>(srcCollection), dstEntity);
+                        value = createObservableList(new ArrayList<>((Collection<Object>) srcCollection), dstEntity, propertyName);
                     } else if (value instanceof Set) {
-                        value = createObservableSet(new HashSet<>(srcCollection), dstEntity);
+                        value = createObservableSet(new HashSet<>((Collection<Object>) srcCollection), dstEntity, propertyName);
                     } else {
                         throw new UnsupportedOperationException("Unsupported collection type: " + value.getClass().getName());
                     }
@@ -295,7 +334,11 @@ public class DataContextImpl implements DataContextInternal {
                 setPropertyValue(dstEntity, property, value);
             }
         }
+    }
 
+    protected void mergeReferenceProperties(Object srcEntity, Object dstEntity, MetaClass metaClass,
+                                            boolean srcNew, boolean isRoot, MergeOptions options,
+                                            Map<Object, Object> mergedMap) {
         for (MetaProperty property : metaClass.getProperties()) {
             String propertyName = property.getName();
             if (property.getRange().isClass()                                               // refs and collections
@@ -308,10 +351,12 @@ public class DataContextImpl implements DataContextInternal {
                     continue;
                 }
 
+                if (skipOrRebaselineDirtyReference(dstEntity, property, value, isRoot, options, mergedMap)) {
+                    continue;
+                }
+
                 if (value == null || !entityStates.isLoaded(dstEntity, propertyName)) {
-                    if (property.getType() != MetaProperty.Type.EMBEDDED) {//dstEntity property value will be lazy loaded and replaced by srcEntity property value
-                        setPropertyValue(dstEntity, property, value);
-                    }
+                    mergeUnloadedOrNullReference(srcEntity, dstEntity, property, value);
                     continue;
                 }
 
@@ -328,7 +373,7 @@ public class DataContextImpl implements DataContextInternal {
                         Object managedRef = internalMerge(value, mergedMap, false, options);
                         setPropertyValue(dstEntity, property, managedRef, false);
                         if (property.getType() == MetaProperty.Type.EMBEDDED) {
-                            EmbeddedPropertyChangeListener listener = new EmbeddedPropertyChangeListener(dstEntity);
+                            EmbeddedPropertyChangeListener listener = new EmbeddedPropertyChangeListener(dstEntity, propertyName);
                             EntitySystemAccess.addPropertyChangeListener(managedRef, listener);
                             embeddedPropertyListeners.computeIfAbsent(dstEntity, e -> new HashMap<>()).put(propertyName, listener);
                         }
@@ -344,10 +389,150 @@ public class DataContextImpl implements DataContextInternal {
                 }
             }
         }
+    }
 
-        mergeLoadedPropertiesInfo(srcEntity, dstEntity, isRoot, options, dstExisted);
+    protected boolean skipOrRebaselineDirtyReference(Object dstEntity, MetaProperty property, @Nullable Object value,
+                                                     boolean isRoot, MergeOptions options,
+                                                     Map<Object, Object> mergedMap) {
+        String propertyName = property.getName();
 
-        mergeLazyLoadingState(srcEntity, dstEntity);
+        // dirty-aware merge rule: a destination attribute carrying an unsaved user edit
+        // is never overwritten (this must also shield it from the lazy-state transplant
+        // in mergeUnloadedOrNullReference); a fresh merge rebaselines the edit against the
+        // incoming value instead. For an embedded reference the user's edits are recorded
+        // on the owner under dotted paths ('address.city'), so any dirty dotted path
+        // protects the whole embedded value.
+        boolean embedded = property.getType() == MetaProperty.Type.EMBEDDED;
+        Set<String> dirtyEmbeddedPaths = embedded
+                ? getDirtyEmbeddedPaths(dstEntity, propertyName)
+                : Collections.emptySet();
+        if ((changeTracker.isAttributeDirty(dstEntity, propertyName) || !dirtyEmbeddedPaths.isEmpty())
+                && !(isRoot && isOverriding(propertyName))) {
+            if (!embedded && value != null && !(value instanceof Collection) && !mergedMap.containsKey(value)) {
+                // the skipped incoming node must still enter the context graph;
+                // only the reassignment of dst's reference is suppressed
+                internalMerge(value, mergedMap, false, options);
+            }
+            if (options.isFresh()) {
+                // reads of current values below are safe: a dirty attribute was written
+                // by the user through the managed instance, so it is loaded on the
+                // destination (references hold a managed instance or null; collections
+                // hold the observable wrapper)
+                if (value instanceof Collection<?> incoming) {
+                    Collection<?> current = (Collection<?>) EntityValues.getValue(dstEntity, propertyName);
+                    changeTracker.rebaselineCollection(dstEntity, propertyName, incoming, current);
+                } else if (embedded) {
+                    rebaselineEmbedded(dstEntity, propertyName, value, dirtyEmbeddedPaths);
+                } else {
+                    changeTracker.rebaseline(dstEntity, propertyName, value,
+                            EntityValues.getValue(dstEntity, propertyName), true);
+                }
+            } else if (DataContextDiagnostics.log.isDebugEnabled()) {
+                DataContextDiagnostics.log.debug(DataContextDiagnostics.mergeSkippedDirty(dstEntity, propertyName));
+            }
+            return true;
+        }
+        return false;
+    }
+
+    protected void mergeUnloadedOrNullReference(Object srcEntity, Object dstEntity, MetaProperty property,
+                                                @Nullable Object value) {
+        if (property.getType() != MetaProperty.Type.EMBEDDED) {//dstEntity property value will be lazy loaded and replaced by srcEntity property value
+            String propertyName = property.getName();
+            if (value instanceof Collection) {
+                // a to-many value installed on an unloaded dst property must notify the
+                // context on mutation like every other merge-installed collection
+                boolean[] wrappedLazy = new boolean[1];
+                entitySystemStateSupport.mergeLazyLoadingState((Entity) srcEntity, (Entity) dstEntity, property,
+                        collection -> {
+                            wrappedLazy[0] = true;
+                            return wrapLazyValueIntoObservableCollection(collection, dstEntity, propertyName);
+                        });
+                if (!wrappedLazy[0]) {
+                    Collection<Object> installed = wrapLazyValueIntoObservableCollection(
+                            (Collection<Object>) value, dstEntity, propertyName);
+                    setPropertyValue(dstEntity, property, installed);
+                }
+            } else {
+                setPropertyValue(dstEntity, property, value);
+            }
+        }
+    }
+
+    /**
+     * Whether the dirty-protection of the given property of the merge root is suspended by the
+     * current {@link #mergeFromChild(Object, Set)} call. A plain property is overridden when it
+     * is among the child's dirty attributes; an embedded property is also overridden when any
+     * child dirty attribute is a dotted path under it ({@code 'address.city'} overrides the
+     * protection of {@code 'address'}).
+     */
+    protected boolean isOverriding(String propertyName) {
+        if (overridingAttributes.isEmpty()) {
+            return false;
+        }
+        if (overridingAttributes.contains(propertyName)) {
+            return true;
+        }
+        String prefix = propertyName + ".";
+        for (String attribute : overridingAttributes) {
+            if (attribute.startsWith(prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Dotted attribute paths ({@code 'address.city'}) of the given embedded property that are
+     * dirty on the owning managed instance. User edits to embedded sub-attributes are tracked
+     * on the owner under such paths (see {@link EmbeddedPropertyChangeListener}).
+     */
+    protected Set<String> getDirtyEmbeddedPaths(Object dstEntity, String propertyName) {
+        Set<String> modified = changeTracker.getModifiedAttributes(dstEntity);
+        if (modified.isEmpty()) {
+            return Collections.emptySet();
+        }
+        String prefix = propertyName + ".";
+        Set<String> result = null;
+        for (String attribute : modified) {
+            if (attribute.startsWith(prefix)) {
+                if (result == null) {
+                    result = new LinkedHashSet<>();
+                }
+                result.add(attribute);
+            }
+        }
+        return result == null ? Collections.emptySet() : result;
+    }
+
+    /**
+     * Fresh-merge rebaselining for an embedded property whose copy was skipped because the owner
+     * carries dirty state for it: the embedded reference entry itself (if dirty) and each dirty
+     * dotted sub-attribute path, using the sub-attribute values of the incoming (unmanaged)
+     * embedded instance.
+     */
+    protected void rebaselineEmbedded(Object dstEntity, String propertyName, @Nullable Object incomingEmbedded,
+                                      Set<String> dirtyEmbeddedPaths) {
+        if (changeTracker.isAttributeDirty(dstEntity, propertyName)) {
+            changeTracker.rebaseline(dstEntity, propertyName, incomingEmbedded,
+                    EntityValues.getValue(dstEntity, propertyName), true);
+        }
+        if (incomingEmbedded == null) {
+            // no incoming sub-values to rebaseline against; the user's edits stay dirty
+            return;
+        }
+        Object currentEmbedded = EntityValues.getValue(dstEntity, propertyName);
+        for (String path : dirtyEmbeddedPaths) {
+            String subAttribute = path.substring(propertyName.length() + 1);
+            if (!entityStates.isLoaded(incomingEmbedded, subAttribute)) {
+                // cannot compare: keep the existing baseline and dirty state
+                continue;
+            }
+            Object incomingValue = EntityValues.getValue(incomingEmbedded, subAttribute);
+            Object currentValue = currentEmbedded == null ? null
+                    : EntityValues.getValue(currentEmbedded, subAttribute);
+            changeTracker.rebaseline(dstEntity, path, incomingValue, currentValue, false);
+        }
     }
 
     protected void setPropertyValue(Object entity, MetaProperty property, @Nullable Object value) {
@@ -400,10 +585,6 @@ public class DataContextImpl implements DataContextInternal {
         }
     }
 
-    protected void mergeLoadedPropertiesInfo(Object srcEntity, Object dstEntity, boolean isRoot, MergeOptions options) {
-        mergeLoadedPropertiesInfo(srcEntity, dstEntity, isRoot, options, false);
-    }
-
     protected void mergeLoadedPropertiesInfo(Object srcEntity, Object dstEntity, boolean isRoot, MergeOptions options,
                                              boolean dstExisted) {
         if (isRoot || options.isFresh()) {
@@ -437,7 +618,7 @@ public class DataContextImpl implements DataContextInternal {
                     && !srcNew && !entityStates.isLoaded(srcEntity, propertyName)
                     && !entityStates.isLoaded(dstEntity, propertyName)) {
                 entitySystemStateSupport.mergeLazyLoadingState((Entity) srcEntity, (Entity) dstEntity, property,
-                        collection -> wrapLazyValueIntoObservableCollection(collection, dstEntity));
+                        collection -> wrapLazyValueIntoObservableCollection(collection, dstEntity, propertyName));
             }
         }
 
@@ -445,17 +626,19 @@ public class DataContextImpl implements DataContextInternal {
 
     protected void mergeList(List<Object> list, Object managedEntity, MetaProperty property, boolean replace,
                              MergeOptions options, Map<Object, Object> mergedMap) {
+        String propertyName = property.getName();
         if (replace) {
             List<Object> managedRefs = new ArrayList<>(list.size());
             for (Object entity : list) {
                 Object managedRef = internalMerge(entity, mergedMap, false, options);
                 managedRefs.add(managedRef);
             }
-            List<Object> dstList = createObservableList(managedRefs, managedEntity);
+            changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, managedRefs);
+            List<Object> dstList = createObservableList(managedRefs, managedEntity, propertyName);
             setPropertyValue(managedEntity, property, dstList);
 
         } else {
-            Object managedValue = EntityValues.getValue(managedEntity, property.getName());
+            Object managedValue = EntityValues.getValue(managedEntity, propertyName);
 
             List<Object> dstList = null;
             if (managedValue instanceof List) {
@@ -465,7 +648,7 @@ public class DataContextImpl implements DataContextInternal {
             }
 
             if (dstList == null) {
-                dstList = createObservableList(managedEntity);
+                dstList = createObservableList(managedEntity, propertyName);
                 setPropertyValue(managedEntity, property, dstList);
             }
             if (dstList.size() == 0) {
@@ -480,22 +663,25 @@ public class DataContextImpl implements DataContextInternal {
                     }
                 }
             }
+            changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, dstList);
         }
     }
 
     protected void mergeSet(Set<Object> set, Object managedEntity, MetaProperty property, boolean replace,
                             MergeOptions options, Map<Object, Object> mergedMap) {
+        String propertyName = property.getName();
         if (replace) {
             Set<Object> managedRefs = new LinkedHashSet<>(set.size());
             for (Object entity : set) {
                 Object managedRef = internalMerge(entity, mergedMap, false, options);
                 managedRefs.add(managedRef);
             }
-            Set<Object> dstSet = createObservableSet(managedRefs, managedEntity);
+            changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, managedRefs);
+            Set<Object> dstSet = createObservableSet(managedRefs, managedEntity, propertyName);
             setPropertyValue(managedEntity, property, dstSet);
 
         } else {
-            Object managedValue = EntityValues.getValue(managedEntity, property.getName());
+            Object managedValue = EntityValues.getValue(managedEntity, propertyName);
 
             Set<Object> dstSet = null;
             if (managedValue instanceof Set) {
@@ -506,7 +692,7 @@ public class DataContextImpl implements DataContextInternal {
 
 
             if (dstSet == null) {
-                dstSet = createObservableSet(managedEntity);
+                dstSet = createObservableSet(managedEntity, propertyName);
                 setPropertyValue(managedEntity, property, dstSet);
             }
             if (dstSet.size() == 0) {
@@ -519,32 +705,62 @@ public class DataContextImpl implements DataContextInternal {
                     dstSet.add(managedRef);
                 }
             }
+            changeTracker.snapshotCollectionBaseline(managedEntity, propertyName, dstSet);
         }
     }
 
-    protected Collection<Object> wrapLazyValueIntoObservableCollection(Collection<Object> collection, Object notifiedEntity) {
+    protected Collection<Object> wrapLazyValueIntoObservableCollection(Collection<Object> collection, Object notifiedEntity,
+                                                                        @Nullable String property) {
         if (collection instanceof List) {
-            return createObservableList((List<Object>) collection, notifiedEntity);
+            if (property != null) {
+                changeTracker.snapshotCollectionBaseline(notifiedEntity, property, collection);
+            }
+            return createObservableList((List<Object>) collection, notifiedEntity, property);
         } else if (collection instanceof Set) {
-            return createObservableSet((Set<Object>) collection, notifiedEntity);
+            if (property != null) {
+                changeTracker.snapshotCollectionBaseline(notifiedEntity, property, collection);
+            }
+            return createObservableSet((Set<Object>) collection, notifiedEntity, property);
         }
         return collection;
     }
 
-    protected List<Object> createObservableList(Object notifiedEntity) {
-        return createObservableList(new ArrayList<>(), notifiedEntity);
+    protected List<Object> createObservableList(Object notifiedEntity, @Nullable String property) {
+        return createObservableList(new ArrayList<>(), notifiedEntity, property);
     }
 
-    protected List<Object> createObservableList(List<Object> list, Object notifiedEntity) {
-        return new ObservableList<>(list, (changeType, changes) -> modified(notifiedEntity));
+    protected List<Object> createObservableList(List<Object> list, Object notifiedEntity, @Nullable String property) {
+        return new ObservableList<>(list, (changeType, changes) -> collectionChanged(notifiedEntity, property));
     }
 
-    protected Set<Object> createObservableSet(Object notifiedEntity) {
-        return createObservableSet(new LinkedHashSet<>(), notifiedEntity);
+    protected Set<Object> createObservableSet(Object notifiedEntity, @Nullable String property) {
+        return createObservableSet(new LinkedHashSet<>(), notifiedEntity, property);
     }
 
-    protected ObservableSet<Object> createObservableSet(Set<Object> set, Object notifiedEntity) {
-        return new ObservableSet<>(set, (changeType, changes) -> modified(notifiedEntity));
+    protected ObservableSet<Object> createObservableSet(Set<Object> set, Object notifiedEntity, @Nullable String property) {
+        return new ObservableSet<>(set, (changeType, changes) -> collectionChanged(notifiedEntity, property));
+    }
+
+    protected void collectionChanged(Object entity, @Nullable String property) {
+        if (disableListeners) {
+            return;
+        }
+        // Unconditional mark-and-notify first, matching the scalar PropertyChangeListener's semantics:
+        // the tracker's transition below may remove the entity from modifiedInstances again once the
+        // tracked attribute becomes clean (e.g. a collection mutation reverted to its baseline). Calling
+        // the tracker before this unconditional marking would let this marking immediately undo a
+        // just-computed clean transition.
+        modified(entity);
+        if (property != null) {
+            MetaProperty metaProperty = metadata.getClass(entity).findProperty(property);
+            if (metaProperty != null && metaProperty.getRange().isClass()) {
+                Collection<?> current = entityStates.isLoaded(entity, property)
+                        ? (Collection<?>) EntityValues.getValue(entity, property) : null;
+                if (current != null) {
+                    changeTracker.trackCollectionChange(entity, property, current);
+                }
+            }
+        }
     }
 
     @Override
@@ -564,6 +780,8 @@ public class DataContextImpl implements DataContextInternal {
             if (mergedEntity != null) {
                 entityMap.remove(makeKey(entity));
                 removeFromCollections(mergedEntity);
+                changeTracker.drop(mergedEntity);
+                manuallyModified.remove(entity);
             }
         }
 
@@ -604,6 +822,8 @@ public class DataContextImpl implements DataContextInternal {
             if (mergedEntity != null) {
                 entityMap.remove(makeKey(entity));
                 removeListeners(entity);
+                changeTracker.drop(mergedEntity);
+                manuallyModified.remove(entity);
             }
             modifiedInstances.remove(entity);
             removedInstances.remove(entity);
@@ -660,6 +880,8 @@ public class DataContextImpl implements DataContextInternal {
     public void clearChanges() {
         modifiedInstances.clear();
         removedInstances.clear();
+        changeTracker.clear();
+        manuallyModified.clear();
     }
 
     @Override
@@ -674,15 +896,37 @@ public class DataContextImpl implements DataContextInternal {
             return;
         }
         if (modified) {
+            manuallyModified.add(merged);
             modifiedInstances.add(merged);
         } else {
+            manuallyModified.remove(merged);
             modifiedInstances.remove(merged);
+            changeTracker.drop(merged);
         }
     }
 
     @Override
     public Set<Object> getModified() {
         return Collections.unmodifiableSet(modifiedInstances);
+    }
+
+    @Override
+    public Set<String> getModifiedAttributes(Object entity) {
+        Object managed = find(entity);
+        if (managed == null) {
+            return Collections.emptySet();
+        }
+        return changeTracker.getModifiedAttributes(managed);
+    }
+
+    protected void entityBecameDirty(Object entity) {
+        modifiedInstances.add(entity);
+    }
+
+    protected void entityBecameClean(Object entity) {
+        if (!manuallyModified.contains(entity)) {
+            modifiedInstances.remove(entity);
+        }
     }
 
     @Override
@@ -710,6 +954,10 @@ public class DataContextImpl implements DataContextInternal {
         EntitySet savedAndMerged;
         try {
             Set<Object> saved = performSave(reloadSaved);
+            // the user's edits have been consumed by the save; drop attribute-level dirty state
+            // now so the merge-back of saved results below is not mistaken for a conflicting
+            // overwrite of unsaved edits and skipped by the dirty-aware merge rule
+            changeTracker.clear();
             if (reloadSaved) {
                 savedAndMerged = mergeSaved(saved);
             } else {
@@ -723,6 +971,8 @@ public class DataContextImpl implements DataContextInternal {
 
         modifiedInstances.clear();
         removedInstances.clear();
+        changeTracker.clear();
+        manuallyModified.clear();
 
         return savedAndMerged;
     }
@@ -799,10 +1049,103 @@ public class DataContextImpl implements DataContextInternal {
         return isolatedEntities;
     }
 
+    @Override
+    public Object mergeFromChild(Object entity, Set<String> childDirtyAttributes) {
+        if (childDirtyAttributes.isEmpty()) {
+            return merge(entity);
+        }
+        // capture this context's pre-overwrite values: they become the baselines of the
+        // attributes the child's merge is about to overwrite (when not already dirty here)
+        Object managed = find(entity);
+        Map<String, Object> preMergeValues = new HashMap<>();
+        if (managed != null) {
+            // probe against a disposable copy of the loaded-properties info: isLoaded caches its
+            // answers in the instance's CachingLoadedPropertiesInfo, and a 'false' cached here
+            // (pre fetch-group union) would poison the merge's own isLoaded checks, suppressing
+            // the copy of child values unloaded on this instance
+            EntityEntry entry = EntitySystemAccess.getEntityEntry(managed);
+            LoadedPropertiesInfo original = entry.getLoadedPropertiesInfo();
+            entry.setLoadedPropertiesInfo(original == null ? null : original.copy());
+            try {
+                for (String attribute : childDirtyAttributes) {
+                    if (entityStates.isLoaded(managed, rootSegment(attribute))) {
+                        preMergeValues.put(attribute, valueForBaseline(managed, attribute));
+                    }
+                }
+            } finally {
+                // the instance may also carry stale 'false' answers cached by earlier merges
+                // (its creation merge caches every attribute outside its fetch plan as unloaded);
+                // install a fresh cache so the merge below recomputes loaded state after the
+                // fetch-group union - mergeLoadedPropertiesInfo resets it again at merge end
+                entry.setLoadedPropertiesInfo(original instanceof CachingLoadedPropertiesInfo
+                        ? new CachingLoadedPropertiesInfo()
+                        : original);
+            }
+        }
+        overridingAttributes = childDirtyAttributes; // consulted by the merge-rule checks
+        Object result;
+        try {
+            result = merge(entity);
+        } finally {
+            overridingAttributes = Set.of();
+        }
+        for (String attribute : childDirtyAttributes) {
+            if (changeTracker.isAttributeDirty(result, attribute)) {
+                // already dirty here: keep the existing baseline, the child's value replaced
+                // the current value only
+                continue;
+            }
+            if (!entityStates.isLoaded(result, rootSegment(attribute))) {
+                // edge guard for the dirty-implies-loaded invariant: after the merge the child's
+                // dirty attributes are normally loaded here (the fetch groups were unioned and the
+                // child's values copied), so this fires only in unusual states; never register
+                // dirt for an unloaded attribute (rebaseline reads would hit unfetched state)
+                log.debug("Skipping dirty union of '{}' from child context: not loaded on the parent instance {}",
+                        attribute, result);
+                continue;
+            }
+            changeTracker.markDirty(result, attribute, preMergeValues.get(attribute));
+        }
+        return result;
+    }
+
+    /**
+     * Baseline-shaped current value of the given attribute of a managed instance, in the form
+     * {@link DataContextChangeTracker} compares against: a scalar value as is, a reference as
+     * its id, a to-many attribute as the membership bag of its current contents, a dotted path
+     * via {@link EntityValues#getValueEx(Object, String)}. The root segment of the attribute
+     * must be loaded on the instance.
+     */
+    @Nullable
+    protected Object valueForBaseline(Object entity, String attribute) {
+        if (attribute.indexOf('.') >= 0) {
+            // dotted (embedded) paths are tracked with raw sub-attribute values
+            return EntityValues.getValueEx(entity, attribute);
+        }
+        Object value = EntityValues.getValue(entity, attribute);
+        if (value == null) {
+            return null;
+        }
+        MetaProperty property = getEntityMetaClass(entity).findProperty(attribute);
+        if (property != null && property.getRange().isClass()) {
+            if (property.getRange().getCardinality().isMany()) {
+                return DataContextChangeTracker.membershipBag((Collection<?>) value);
+            }
+            Object id = EntityValues.getId(value);
+            return id != null ? id : value;
+        }
+        return value;
+    }
+
+    protected static String rootSegment(String attribute) {
+        int dotIndex = attribute.indexOf('.');
+        return dotIndex < 0 ? attribute : attribute.substring(0, dotIndex);
+    }
+
     protected Set<Object> saveToParentContext() {
         Set<Object> savedEntities = new HashSet<>();
         for (Object entity : modifiedInstances) {
-            Object merged = parentContext.merge(entity);
+            Object merged = parentContext.mergeFromChild(entity, changeTracker.getModifiedAttributes(entity));
             parentContext.getModifiedInstances().add(merged);
             savedEntities.add(merged);
         }
@@ -931,8 +1274,9 @@ public class DataContextImpl implements DataContextInternal {
     protected class PropertyChangeListener implements EntityPropertyChangeListener {
         @Override
         public void propertyChanged(EntityPropertyChangeEvent e) {
+            String primaryKeyPropertyName = getPrimaryKeyPropertyName(e.getItem());
             // if id has been changed, put the entity to the content with the new id
-            if (e.getProperty().equals(getPrimaryKeyPropertyName(e.getItem()))) {
+            if (e.getProperty().equals(primaryKeyPropertyName)) {
                 Map<Object, Object> entityMap = content.get(e.getItem().getClass());
                 if (entityMap != null) {
                     if (e.getPrevValue() == null) {
@@ -945,7 +1289,23 @@ public class DataContextImpl implements DataContextInternal {
             }
 
             if (!disableListeners) {
+                // Unconditional add preserves today's semantics for to-many and unclassifiable properties;
+                // the tracker's transition callback below may remove the entity again once the tracked
+                // attributes are all clean (e.g. a scalar/reference edit reverted to its baseline).
                 modifiedInstances.add(e.getItem());
+
+                MetaProperty changedProperty = metadata.getClass(e.getItem()).findProperty(e.getProperty());
+                if (changedProperty != null && changedProperty.getRange().isClass()
+                        && changedProperty.getRange().getCardinality().isMany()) {
+                    // to-many properties are handled by the observable collection wrappers; skip the tracker here
+                } else if (e.getProperty().equals(primaryKeyPropertyName)) {
+                    // an id change is identity bookkeeping (e.g. setId() in a saveDelegate),
+                    // not a user attribute edit; skip the tracker
+                } else {
+                    boolean reference = changedProperty != null && changedProperty.getRange().isClass()
+                            && !changedProperty.getRange().getCardinality().isMany();
+                    changeTracker.trackChange(e.getItem(), e.getProperty(), e.getPrevValue(), e.getValue(), reference);
+                }
                 fireChangeListener(e.getItem());
             }
         }
@@ -955,14 +1315,26 @@ public class DataContextImpl implements DataContextInternal {
 
         private final Object entity;
 
-        public EmbeddedPropertyChangeListener(Object entity) {
+        private final String embeddedPropertyName;
+
+        public EmbeddedPropertyChangeListener(Object entity, String embeddedPropertyName) {
             this.entity = entity;
+            this.embeddedPropertyName = embeddedPropertyName;
         }
 
         @Override
         public void propertyChanged(EntityPropertyChangeEvent e) {
             if (!disableListeners) {
                 modifiedInstances.add(entity);
+
+                MetaProperty changedProperty = metadata.getClass(e.getItem()).findProperty(e.getProperty());
+                if (changedProperty != null && changedProperty.getRange().isClass()
+                        && changedProperty.getRange().getCardinality().isMany()) {
+                    // to-many properties are handled by the observable collection wrappers; skip the tracker here
+                } else {
+                    changeTracker.trackChange(entity, embeddedPropertyName + '.' + e.getProperty(),
+                            e.getPrevValue(), e.getValue(), false);
+                }
                 fireChangeListener(entity);
             }
         }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -272,13 +272,17 @@ public class DataContextImpl implements DataContextInternal {
 
         mergeSystemState(srcEntity, dstEntity, isRoot, options);
 
+        boolean coldReset = isColdResetTarget(dstEntity, isRoot, options, dstExisted);
+
+        resetLoadedInfoBeforeCopy(dstEntity, coldReset);
+
         MetaClass metaClass = getEntityMetaClass(srcEntity);
 
         mergeDatatypeProperties(srcEntity, dstEntity, metaClass, srcNew, dstNew, isRoot, options);
 
         mergeReferenceProperties(srcEntity, dstEntity, metaClass, srcNew, isRoot, options, mergedMap);
 
-        mergeLoadedPropertiesInfo(srcEntity, dstEntity, isRoot, options, dstExisted);
+        mergeLoadedPropertiesInfo(srcEntity, dstEntity, isRoot, options, coldReset);
 
         mergeLazyLoadingState(srcEntity, dstEntity);
     }
@@ -585,19 +589,39 @@ public class DataContextImpl implements DataContextInternal {
         }
     }
 
+    /**
+     * Whether this is a root non-fresh merge onto a pre-existing managed instance whose loaded-state
+     * info is the caching kind. Such an instance carries source-relative negatives cached at earlier
+     * merges (its creation merge caches every attribute outside its fetch plan as unloaded), and its
+     * fetch group was just unioned with the source's in {@link #mergeSystemState}.
+     */
+    protected boolean isColdResetTarget(Object dstEntity, boolean isRoot, MergeOptions options, boolean dstExisted) {
+        return isRoot && !options.isFresh() && dstExisted
+                && EntitySystemAccess.getEntityEntry(dstEntity).getLoadedPropertiesInfo() instanceof CachingLoadedPropertiesInfo;
+    }
+
+    protected void resetLoadedInfoBeforeCopy(Object dstEntity, boolean coldReset) {
+        if (coldReset) {
+            // Reset before the copy loops so their isLoaded(dstEntity, ...) checks recompute from the
+            // fetch group just unioned in mergeSystemState. Otherwise a stale cached negative suppresses
+            // the copy of a newly available value, and the end-of-merge reset then makes that attribute
+            // report loaded while holding a default - a later save writes null over real data.
+            // (see specs/limitations.md cluster 2)
+            EntitySystemAccess.getEntityEntry(dstEntity).setLoadedPropertiesInfo(new CachingLoadedPropertiesInfo());
+        }
+    }
+
     protected void mergeLoadedPropertiesInfo(Object srcEntity, Object dstEntity, boolean isRoot, MergeOptions options,
-                                             boolean dstExisted) {
+                                             boolean coldReset) {
         if (isRoot || options.isFresh()) {
+            if (coldReset) {
+                // already reset before the copy loops (resetLoadedInfoBeforeCopy); the loops repopulated
+                // correct answers into the fresh cache from the unioned fetch group, so leave it as is
+                return;
+            }
             EntityEntry srcEntityEntry = EntitySystemAccess.getEntityEntry(srcEntity);
             EntityEntry dstEntityEntry = EntitySystemAccess.getEntityEntry(dstEntity);
-            if (dstExisted && !options.isFresh()
-                    && dstEntityEntry.getLoadedPropertiesInfo() instanceof CachingLoadedPropertiesInfo) {
-                // The source's cached answers are relative to the source instance and may be wrong for a managed
-                // instance that already carries more loaded state (its fetch group was unioned with the source's
-                // in mergeSystemState). Reset to an empty cache so the loaded state is recomputed from the managed
-                // instance's own fetch group and value holders, which reflect its real state at this point.
-                dstEntityEntry.setLoadedPropertiesInfo(new CachingLoadedPropertiesInfo());
-            } else if (srcEntityEntry.getLoadedPropertiesInfo() == null) {
+            if (srcEntityEntry.getLoadedPropertiesInfo() == null) {
                 dstEntityEntry.setLoadedPropertiesInfo(null);
             } else {
                 dstEntityEntry.setLoadedPropertiesInfo(srcEntityEntry.getLoadedPropertiesInfo().copy());
@@ -1059,27 +1083,13 @@ public class DataContextImpl implements DataContextInternal {
         Object managed = find(entity);
         Map<String, Object> preMergeValues = new HashMap<>();
         if (managed != null) {
-            // probe against a disposable copy of the loaded-properties info: isLoaded caches its
-            // answers in the instance's CachingLoadedPropertiesInfo, and a 'false' cached here
-            // (pre fetch-group union) would poison the merge's own isLoaded checks, suppressing
-            // the copy of child values unloaded on this instance
-            EntityEntry entry = EntitySystemAccess.getEntityEntry(managed);
-            LoadedPropertiesInfo original = entry.getLoadedPropertiesInfo();
-            entry.setLoadedPropertiesInfo(original == null ? null : original.copy());
-            try {
-                for (String attribute : childDirtyAttributes) {
-                    if (entityStates.isLoaded(managed, rootSegment(attribute))) {
-                        preMergeValues.put(attribute, valueForBaseline(managed, attribute));
-                    }
+            // the merge below resets this instance's loaded-state cache before its copy loops
+            // (resetLoadedInfoBeforeCopy, same condition as this managed root), so probing isLoaded
+            // here cannot poison the merge's own checks - no disposable-copy guard is needed
+            for (String attribute : childDirtyAttributes) {
+                if (entityStates.isLoaded(managed, rootSegment(attribute))) {
+                    preMergeValues.put(attribute, valueForBaseline(managed, attribute));
                 }
-            } finally {
-                // the instance may also carry stale 'false' answers cached by earlier merges
-                // (its creation merge caches every attribute outside its fetch plan as unloaded);
-                // install a fresh cache so the merge below recomputes loaded state after the
-                // fetch-group union - mergeLoadedPropertiesInfo resets it again at merge end
-                entry.setLoadedPropertiesInfo(original instanceof CachingLoadedPropertiesInfo
-                        ? new CachingLoadedPropertiesInfo()
-                        : original);
             }
         }
         overridingAttributes = childDirtyAttributes; // consulted by the merge-rule checks

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextImpl.java
@@ -457,9 +457,26 @@ public class DataContextImpl implements DataContextInternal {
                             (Collection<Object>) value, dstEntity, propertyName);
                     setPropertyValue(dstEntity, property, installed);
                 }
+                // a non-null value is now present in memory; reflect it in the loaded-state info
+                markLoaded(dstEntity, propertyName);
             } else {
                 setPropertyValue(dstEntity, property, value);
+                if (value != null) {
+                    markLoaded(dstEntity, propertyName);
+                }
             }
+        }
+    }
+
+    /**
+     * Marks an attribute as loaded on the entity's loaded-state info, so {@code isLoaded} reflects a value
+     * that is present in memory because it was set (a user edit) or installed by a merge, rather than lazily
+     * materialized. No-op for entities without a {@link LoadedPropertiesInfo} (e.g. DTOs).
+     */
+    protected void markLoaded(Object entity, String propertyName) {
+        LoadedPropertiesInfo info = EntitySystemAccess.getEntityEntry(entity).getLoadedPropertiesInfo();
+        if (info != null) {
+            info.registerProperty(propertyName, true);
         }
     }
 
@@ -1315,6 +1332,9 @@ public class DataContextImpl implements DataContextInternal {
                     boolean reference = changedProperty != null && changedProperty.getRange().isClass()
                             && !changedProperty.getRange().getCardinality().isMany();
                     changeTracker.trackChange(e.getItem(), e.getProperty(), e.getPrevValue(), e.getValue(), reference);
+                    // a user set makes the attribute authoritative and present in memory (even a set to null),
+                    // so it is loaded regardless of whether it was fetched
+                    markLoaded(e.getItem(), e.getProperty());
                 }
                 fireChangeListener(e.getItem());
             }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextInternal.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/DataContextInternal.java
@@ -20,10 +20,27 @@ import io.jmix.flowui.model.DataContext;
 import io.jmix.flowui.model.DataContextChanges;
 import org.jspecify.annotations.NullMarked;
 
+import java.util.Set;
+
 /**
  * Marker interface of {@link DataContext} implementations that can form hierarchies
  * using {@link DataContext#setParent(DataContext)}.
  */
 @NullMarked
 public interface DataContextInternal extends DataContext, DataContextChanges {
+
+    /**
+     * Merges an entity saved by a child context into this (parent) context.
+     * <p>
+     * Unlike a plain {@link #merge(Object)}, the child's dirty attributes override this
+     * context's own unsaved edits of the same attributes (the child's later intent wins),
+     * and are then registered as dirty here so the parent's eventual save carries them.
+     *
+     * @param entity               the entity instance saved by the child context
+     * @param childDirtyAttributes attributes the child tracked as changed for this entity
+     * @return the managed instance of this context
+     */
+    default Object mergeFromChild(Object entity, Set<String> childDirtyAttributes) {
+        return merge(entity);
+    }
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/NoopDataContext.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/model/impl/NoopDataContext.java
@@ -43,8 +43,19 @@ public class NoopDataContext implements DataContext {
 
     protected ApplicationContext applicationContext;
 
+    private boolean mergeReported;
+
     public NoopDataContext(ApplicationContext applicationContext) {
         this.applicationContext = applicationContext;
+    }
+
+    private void reportMergeOnce() {
+        // the flag is set only when the notice actually reaches the log, so enabling the
+        // diagnostics category after the first merge still gets the notice on the next one
+        if (!mergeReported && DataContextDiagnostics.log.isDebugEnabled()) {
+            mergeReported = true;
+            DataContextDiagnostics.log.debug(DataContextDiagnostics.readOnlyContextMerge());
+        }
     }
 
     @Nullable
@@ -65,21 +76,25 @@ public class NoopDataContext implements DataContext {
 
     @Override
     public <T> T merge(T entity, MergeOptions options) {
+        reportMergeOnce();
         return entity;
     }
 
     @Override
     public <T> T merge(T entity) {
+        reportMergeOnce();
         return entity;
     }
 
     @Override
     public EntitySet merge(Collection entities, MergeOptions options) {
+        reportMergeOnce();
         return EntitySet.of(entities);
     }
 
     @Override
     public EntitySet merge(Collection entities) {
+        reportMergeOnce();
         return EntitySet.of(entities);
     }
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
@@ -517,7 +517,15 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
 
         // if only new entities are registered as modified in DataContext,
         // check whether they were modified after opening the view
-        return isModifiedAfterOpen();
+        if (!isModifiedAfterOpen()) {
+            return false;
+        }
+        // modifiedAfterOpen latches true on any ChangeEvent and is never lowered on revert, so it
+        // cannot be trusted alone. Attribute-level tracking removes an entity from the modified set
+        // when its edits are reverted to their baseline, so an empty modified set here means every
+        // edit made after opening was reverted and there is nothing to save. A non-empty set
+        // still means a pending change (including a new entity that save() would persist).
+        return !dataContext.getModified().isEmpty();
     }
 
     @Override

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
@@ -520,11 +520,9 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
         if (!isModifiedAfterOpen()) {
             return false;
         }
-        // modifiedAfterOpen latches true on any ChangeEvent and is never lowered on revert, so it
-        // cannot be trusted alone. Attribute-level tracking removes an entity from the modified set
-        // when its edits are reverted to their baseline, so an empty modified set here means every
-        // edit made after opening was reverted and there is nothing to save. A non-empty set
-        // still means a pending change (including a new entity that save() would persist).
+        // modifiedAfterOpen latches true on any ChangeEvent and is never lowered on revert, so it cannot
+        // be trusted alone. Attribute-level tracking drops an entity from the modified set once its edits
+        // are reverted to baseline, so an empty modified set here means everything was reverted.
         return !dataContext.getModified().isEmpty();
     }
 

--- a/jmix-flowui/flowui/src/test/groovy/component/standarddetailview/StandardDetailViewTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standarddetailview/StandardDetailViewTest.groovy
@@ -25,6 +25,7 @@ import io.jmix.core.DataManager
 import io.jmix.core.Metadata
 import io.jmix.flowui.DialogWindows
 import io.jmix.flowui.ViewNavigators
+import io.jmix.flowui.testassist.UiTestUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import test_support.entity.TestCopyingSystemStateEntity
@@ -118,5 +119,99 @@ class StandardDetailViewTest extends FlowuiTestSpecification {
               """
 
         noExceptionThrown()
+    }
+
+    def "existing entity: editing then reverting a scalar clears the unsaved-changes prompt (#1409)"() {
+        given: "an Order detail view opened on an existing entity"
+        def origin = navigateToView(BlankTestView)
+        navigators.detailView(origin, Order)
+                .editEntity(orderToEdit)
+                .withViewClass(OrderDetailTestView)
+                .withBackwardNavigation(false)
+                .navigate()
+        OrderDetailTestView view = UiTestUtils.getCurrentView()
+        Order edited = view.getEditedEntity()
+        def original = edited.number
+
+        when: "a scalar is edited and then set back to its original value"
+        edited.number = 'temp-changed'
+        edited.number = original
+
+        then: "the edit reverted, so the view reports no unsaved changes"
+        !view.hasUnsavedChanges()
+    }
+
+    def "existing entity: an outstanding scalar edit still reports unsaved changes"() {
+        given: "an Order detail view opened on an existing entity"
+        def origin = navigateToView(BlankTestView)
+        navigators.detailView(origin, Order)
+                .editEntity(orderToEdit)
+                .withViewClass(OrderDetailTestView)
+                .withBackwardNavigation(false)
+                .navigate()
+        OrderDetailTestView view = UiTestUtils.getCurrentView()
+        Order edited = view.getEditedEntity()
+
+        when: "a scalar is edited and left changed"
+        edited.number = 'temp-changed'
+
+        then: "the outstanding edit still reports unsaved changes"
+        view.hasUnsavedChanges()
+    }
+
+    def "create view: an untouched new entity reports no unsaved changes"() {
+        given: "an Order detail view opened to create a new entity"
+        def origin = navigateToView(BlankTestView)
+        navigators.detailView(origin, Order)
+                .newEntity()
+                .withViewClass(OrderDetailTestView)
+                .withBackwardNavigation(false)
+                .navigate()
+        OrderDetailTestView view = UiTestUtils.getCurrentView()
+
+        expect: "nothing was edited after opening, so there are no unsaved changes"
+        !view.hasUnsavedChanges()
+    }
+
+    def "create view: editing the new entity reports unsaved changes"() {
+        given: "an Order detail view opened to create a new entity"
+        def origin = navigateToView(BlankTestView)
+        navigators.detailView(origin, Order)
+                .newEntity()
+                .withViewClass(OrderDetailTestView)
+                .withBackwardNavigation(false)
+                .navigate()
+        OrderDetailTestView view = UiTestUtils.getCurrentView()
+        Order edited = view.getEditedEntity()
+
+        when: "a scalar of the new entity is edited"
+        edited.number = 'n1'
+
+        then: "the view reports unsaved changes"
+        view.hasUnsavedChanges()
+    }
+
+    def "create view: a new entity kept in the modified set with no attribute edits still reports unsaved changes"() {
+        given: "an Order detail view opened to create a new entity"
+        def origin = navigateToView(BlankTestView)
+        navigators.detailView(origin, Order)
+                .newEntity()
+                .withViewClass(OrderDetailTestView)
+                .withBackwardNavigation(false)
+                .navigate()
+        OrderDetailTestView view = UiTestUtils.getCurrentView()
+        Order edited = view.getEditedEntity()
+        io.jmix.flowui.model.DataContext dataContext = view.getViewData().getDataContext()
+
+        when: "an edit sets the modifiedAfterOpen latch and is then reverted (which un-tracks the attribute), but the new entity is explicitly kept modified with no tracked attributes"
+        def original = edited.number
+        edited.number = 'temp-changed'
+        edited.number = original
+        dataContext.setModified(edited, true)
+
+        then: "the new entity is in the modified set with no modified attributes, and the view still reports unsaved changes (save() would persist it)"
+        dataContext.getModifiedAttributes(edited).isEmpty()
+        !dataContext.getModified().isEmpty()
+        view.hasUnsavedChanges()
     }
 }

--- a/jmix-flowui/flowui/src/test/groovy/component/standarddetailview/StandardDetailViewTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standarddetailview/StandardDetailViewTest.groovy
@@ -25,6 +25,7 @@ import io.jmix.core.DataManager
 import io.jmix.core.Metadata
 import io.jmix.flowui.DialogWindows
 import io.jmix.flowui.ViewNavigators
+import io.jmix.flowui.model.DataContext
 import io.jmix.flowui.testassist.UiTestUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -38,7 +39,7 @@ class StandardDetailViewTest extends FlowuiTestSpecification {
     @Autowired
     protected ViewNavigators navigators
     @Autowired
-    protected DialogWindows dialogWindows;
+    protected DialogWindows dialogWindows
 
     @Autowired
     protected Metadata metadata
@@ -201,7 +202,7 @@ class StandardDetailViewTest extends FlowuiTestSpecification {
                 .navigate()
         OrderDetailTestView view = UiTestUtils.getCurrentView()
         Order edited = view.getEditedEntity()
-        io.jmix.flowui.model.DataContext dataContext = view.getViewData().getDataContext()
+        DataContext dataContext = view.getViewData().getDataContext()
 
         when: "an edit sets the modifiedAfterOpen latch and is then reverted (which un-tracks the attribute), but the new entity is explicitly kept modified with no tracked attributes"
         def original = edited.number

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextChangeTrackerTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextChangeTrackerTest.groovy
@@ -1,12 +1,17 @@
 package data_components
 
+import io.jmix.core.DataManager
+import io.jmix.core.Id
+import io.jmix.core.Metadata
+import io.jmix.flowui.model.DataComponents
 import io.jmix.flowui.model.impl.DataContextChangeTracker
+import org.springframework.beans.factory.annotation.Autowired
+import test_support.entity.TestNullableIdEntity
+import test_support.entity.sales.Address
 import test_support.entity.sales.Customer
 import test_support.entity.sales.Order
+import test_support.entity.sales.OrderLine
 import test_support.spec.DataContextSpec
-import org.springframework.beans.factory.annotation.Autowired
-import io.jmix.core.DataManager
-import io.jmix.core.Metadata
 
 class DataContextChangeTrackerTest extends DataContextSpec {
 
@@ -17,7 +22,7 @@ class DataContextChangeTrackerTest extends DataContextSpec {
     DataManager dataManager
 
     @Autowired
-    io.jmix.flowui.model.DataComponents factory
+    DataComponents factory
 
     def dirty = [], clean = []
     def tracker = new DataContextChangeTracker({ e -> dirty << e }, { e -> clean << e })
@@ -73,8 +78,8 @@ class DataContextChangeTrackerTest extends DataContextSpec {
     def "collection dirty follows membership, not order or instance"() {
         given:
         Order order = metadata.create(Order)
-        def l1 = metadata.create(test_support.entity.sales.OrderLine)
-        def l2 = metadata.create(test_support.entity.sales.OrderLine)
+        def l1 = metadata.create(OrderLine)
+        def l2 = metadata.create(OrderLine)
         tracker.snapshotCollectionBaseline(order, 'orderLines', [l1, l2])
 
         when: "same membership in different order is clean"
@@ -99,8 +104,8 @@ class DataContextChangeTrackerTest extends DataContextSpec {
     def "collection rebaseline keeps the new baseline usable after un-dirtying"() {
         given:
         Order order = metadata.create(Order)
-        def l1 = metadata.create(test_support.entity.sales.OrderLine)
-        def l2 = metadata.create(test_support.entity.sales.OrderLine)
+        def l1 = metadata.create(OrderLine)
+        def l2 = metadata.create(OrderLine)
         tracker.snapshotCollectionBaseline(order, 'orderLines', [l1])
 
         when: "adding an element dirties"
@@ -195,7 +200,7 @@ class DataContextChangeTrackerTest extends DataContextSpec {
     def "getModifiedAttributes reflects user edits through the context"() {
         given:
         def context = factory.createDataContext()
-        Customer customer = dataManager.save(new Customer(name: 'c1', address: new test_support.entity.sales.Address()))
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
         Customer managed = context.merge(customer)
 
         expect:
@@ -222,7 +227,7 @@ class DataContextChangeTrackerTest extends DataContextSpec {
     def "setModified manual flag survives tracker transitions"() {
         given:
         def context = factory.createDataContext()
-        Customer customer = dataManager.save(new Customer(name: 'c1', address: new test_support.entity.sales.Address()))
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
         Customer managed = context.merge(customer)
         context.setModified(managed, true)
 
@@ -248,9 +253,9 @@ class DataContextChangeTrackerTest extends DataContextSpec {
         given:
         def context = factory.createDataContext()
         Customer customer = dataManager.save(new Customer(name: 'c1',
-                address: new test_support.entity.sales.Address(city: 'Rome')))
+                address: new Address(city: 'Rome')))
         Customer managed = context.merge(
-                dataManager.load(io.jmix.core.Id.of(customer)).fetchPlan { it.addAll('name', 'address') }.one())
+                dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'address') }.one())
 
         when:
         managed.address.city = 'Pisa'
@@ -271,7 +276,7 @@ class DataContextChangeTrackerTest extends DataContextSpec {
     def "lifecycle drops tracker state"() {
         given:
         def context = factory.createDataContext()
-        Customer customer = dataManager.save(new Customer(name: 'c1', address: new test_support.entity.sales.Address()))
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
         Customer managed = context.merge(customer)
         managed.name = 'x'
 
@@ -295,7 +300,7 @@ class DataContextChangeTrackerTest extends DataContextSpec {
     def "primary key changes are not tracked as attribute modifications"() {
         given:
         def context = factory.createDataContext()
-        def entity = context.merge(metadata.create(test_support.entity.TestNullableIdEntity))
+        def entity = context.merge(metadata.create(TestNullableIdEntity))
 
         when: "id is assigned like the saveDelegate DTO pattern does"
         entity.id = 10L
@@ -313,7 +318,7 @@ class DataContextChangeTrackerTest extends DataContextSpec {
     def "successful save clears attribute state"() {
         given:
         def context = factory.createDataContext()
-        Customer customer = dataManager.save(new Customer(name: 'c1', address: new test_support.entity.sales.Address()))
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
         Customer managed = context.merge(customer)
         managed.name = 'c2'
 
@@ -331,11 +336,11 @@ class DataContextChangeTrackerTest extends DataContextSpec {
     def "collection mutation dirties the attribute and revert un-dirties it"() {
         given:
         def context = factory.createDataContext()
-        Customer customer = dataManager.save(new Customer(name: 'c1', address: new test_support.entity.sales.Address()))
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
         Order order = dataManager.save(new Order(number: 'o1', customer: customer))
-        def line = dataManager.save(new test_support.entity.sales.OrderLine(quantity: 1, order: order))
+        def line = dataManager.save(new OrderLine(quantity: 1, order: order))
 
-        Order managed = context.merge(dataManager.load(io.jmix.core.Id.of(order))
+        Order managed = context.merge(dataManager.load(Id.of(order))
                 .fetchPlan { it.addAll('number', 'orderLines.quantity') }.one())
         def managedLine = managed.orderLines[0]
 

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextChangeTrackerTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextChangeTrackerTest.groovy
@@ -1,0 +1,359 @@
+package data_components
+
+import io.jmix.flowui.model.impl.DataContextChangeTracker
+import test_support.entity.sales.Customer
+import test_support.entity.sales.Order
+import test_support.spec.DataContextSpec
+import org.springframework.beans.factory.annotation.Autowired
+import io.jmix.core.DataManager
+import io.jmix.core.Metadata
+
+class DataContextChangeTrackerTest extends DataContextSpec {
+
+    @Autowired
+    Metadata metadata
+
+    @Autowired
+    DataManager dataManager
+
+    @Autowired
+    io.jmix.flowui.model.DataComponents factory
+
+    def dirty = [], clean = []
+    def tracker = new DataContextChangeTracker({ e -> dirty << e }, { e -> clean << e })
+
+    def "first change creates baseline and dirties the entity"() {
+        given:
+        Order order = metadata.create(Order)
+
+        when:
+        tracker.trackChange(order, 'number', 'o1', 'x1', false)
+
+        then:
+        tracker.isAttributeDirty(order, 'number')
+        tracker.getModifiedAttributes(order) == ['number'] as Set
+        dirty == [order]
+
+        when: "changing again does not move the baseline"
+        tracker.trackChange(order, 'number', 'x1', 'x2', false)
+
+        then:
+        tracker.isAttributeDirty(order, 'number')
+        dirty == [order]
+    }
+
+    def "reverting to the baseline un-dirties attribute and entity"() {
+        given:
+        Order order = metadata.create(Order)
+        tracker.trackChange(order, 'number', 'o1', 'x1', false)
+
+        when:
+        tracker.trackChange(order, 'number', 'x1', 'o1', false)
+
+        then:
+        !tracker.isAttributeDirty(order, 'number')
+        tracker.getModifiedAttributes(order).empty
+        clean == [order]
+    }
+
+    def "references are compared by id"() {
+        given:
+        Order order = metadata.create(Order)
+        Customer c1 = metadata.create(Customer)
+        Customer c1copy = metadata.create(Customer)
+        c1copy.id = c1.id
+
+        when: "assigning a different instance with the same id counts as revert"
+        tracker.trackChange(order, 'customer', c1, c1copy, true)
+
+        then:
+        !tracker.isAttributeDirty(order, 'customer')
+    }
+
+    def "collection dirty follows membership, not order or instance"() {
+        given:
+        Order order = metadata.create(Order)
+        def l1 = metadata.create(test_support.entity.sales.OrderLine)
+        def l2 = metadata.create(test_support.entity.sales.OrderLine)
+        tracker.snapshotCollectionBaseline(order, 'orderLines', [l1, l2])
+
+        when: "same membership in different order is clean"
+        tracker.trackCollectionChange(order, 'orderLines', [l2, l1])
+
+        then:
+        !tracker.isAttributeDirty(order, 'orderLines')
+
+        when: "removing an element dirties"
+        tracker.trackCollectionChange(order, 'orderLines', [l2])
+
+        then:
+        tracker.isAttributeDirty(order, 'orderLines')
+
+        when: "re-adding it un-dirties"
+        tracker.trackCollectionChange(order, 'orderLines', [l1, l2])
+
+        then:
+        !tracker.isAttributeDirty(order, 'orderLines')
+    }
+
+    def "collection rebaseline keeps the new baseline usable after un-dirtying"() {
+        given:
+        Order order = metadata.create(Order)
+        def l1 = metadata.create(test_support.entity.sales.OrderLine)
+        def l2 = metadata.create(test_support.entity.sales.OrderLine)
+        tracker.snapshotCollectionBaseline(order, 'orderLines', [l1])
+
+        when: "adding an element dirties"
+        tracker.trackCollectionChange(order, 'orderLines', [l1, l2])
+
+        then:
+        tracker.isAttributeDirty(order, 'orderLines')
+
+        when: "rebaseline with incoming equal to current un-dirties"
+        tracker.rebaselineCollection(order, 'orderLines', [l1, l2], [l1, l2])
+
+        then:
+        !tracker.isAttributeDirty(order, 'orderLines')
+
+        when: "mutating again dirties against the new baseline"
+        tracker.trackCollectionChange(order, 'orderLines', [l1])
+
+        then:
+        tracker.isAttributeDirty(order, 'orderLines')
+
+        when: "reverting to the new baseline un-dirties, no coarse-dirty fallback"
+        tracker.trackCollectionChange(order, 'orderLines', [l1, l2])
+
+        then:
+        !tracker.isAttributeDirty(order, 'orderLines')
+    }
+
+    def "fresh rebaseline keeps dirty when values differ and un-dirties when equal"() {
+        given:
+        Order order = metadata.create(Order)
+        tracker.trackChange(order, 'number', 'o1', 'edited', false)
+
+        when: "fresh value differs from the user's value"
+        tracker.rebaseline(order, 'number', 'db-new', 'edited', false)
+
+        then:
+        tracker.isAttributeDirty(order, 'number')
+
+        when: "fresh value equals the user's value"
+        tracker.rebaseline(order, 'number', 'edited', 'edited', false)
+
+        then:
+        !tracker.isAttributeDirty(order, 'number')
+    }
+
+    def "drop and clear remove state"() {
+        given:
+        Order order = metadata.create(Order)
+        tracker.trackChange(order, 'number', 'a', 'b', false)
+
+        when:
+        tracker.drop(order)
+
+        then:
+        tracker.getModifiedAttributes(order).empty
+        clean == [order]
+
+        when: "clear() wipes all tracked state without firing the clean callback"
+        tracker.trackChange(order, 'number', 'a', 'b', false)
+
+        and:
+        tracker.clear()
+
+        then:
+        tracker.getModifiedAttributes(order).empty
+        clean == [order]
+    }
+
+    def "baseline does not move while the attribute stays dirty"() {
+        given:
+        Order order = metadata.create(Order)
+
+        when: "first change establishes the baseline"
+        tracker.trackChange(order, 'number', 'o1', 'x1', false)
+
+        and: "a further change moves the current value but not the baseline"
+        tracker.trackChange(order, 'number', 'x1', 'x2', false)
+
+        and: "moving back to the first edited value is still not the original baseline"
+        tracker.trackChange(order, 'number', 'x2', 'x1', false)
+
+        then:
+        tracker.isAttributeDirty(order, 'number')
+
+        when: "only returning to the original baseline un-dirties"
+        tracker.trackChange(order, 'number', 'x1', 'o1', false)
+
+        then:
+        !tracker.isAttributeDirty(order, 'number')
+    }
+
+    def "getModifiedAttributes reflects user edits through the context"() {
+        given:
+        def context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new test_support.entity.sales.Address()))
+        Customer managed = context.merge(customer)
+
+        expect:
+        context.getModifiedAttributes(managed).empty
+
+        when:
+        managed.name = 'c2'
+
+        then:
+        context.getModifiedAttributes(managed) == ['name'] as Set
+        context.isModified(managed)
+
+        when: "reverting un-dirties entity-level state too"
+        managed.name = 'c1'
+
+        then:
+        context.getModifiedAttributes(managed).empty
+        !context.isModified(managed)
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "setModified manual flag survives tracker transitions"() {
+        given:
+        def context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new test_support.entity.sales.Address()))
+        Customer managed = context.merge(customer)
+        context.setModified(managed, true)
+
+        when: "an edit-and-revert cycle happens"
+        managed.name = 'x'
+        managed.name = 'c1'
+
+        then: "the manual flag keeps the entity modified"
+        context.isModified(managed)
+        context.getModifiedAttributes(managed).empty
+
+        when:
+        context.setModified(managed, false)
+
+        then:
+        !context.isModified(managed)
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "embedded sub-attribute changes are tracked under dotted paths"() {
+        given:
+        def context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1',
+                address: new test_support.entity.sales.Address(city: 'Rome')))
+        Customer managed = context.merge(
+                dataManager.load(io.jmix.core.Id.of(customer)).fetchPlan { it.addAll('name', 'address') }.one())
+
+        when:
+        managed.address.city = 'Pisa'
+
+        then:
+        context.getModifiedAttributes(managed) == ['address.city'] as Set
+
+        when:
+        managed.address.city = 'Rome'
+
+        then:
+        context.getModifiedAttributes(managed).empty
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "lifecycle drops tracker state"() {
+        given:
+        def context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new test_support.entity.sales.Address()))
+        Customer managed = context.merge(customer)
+        managed.name = 'x'
+
+        when:
+        context.evict(managed)
+
+        then:
+        context.getModifiedAttributes(managed).empty
+
+        when: "re-merged instance starts clean"
+        Customer again = context.merge(customer)
+
+        then:
+        context.getModifiedAttributes(again).empty
+        !context.isModified(again)
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "primary key changes are not tracked as attribute modifications"() {
+        given:
+        def context = factory.createDataContext()
+        def entity = context.merge(metadata.create(test_support.entity.TestNullableIdEntity))
+
+        when: "id is assigned like the saveDelegate DTO pattern does"
+        entity.id = 10L
+
+        then:
+        !context.getModifiedAttributes(entity).contains('id')
+
+        when: "a normal attribute edit still tracks"
+        entity.name = 'n1'
+
+        then:
+        context.getModifiedAttributes(entity) == ['name'] as Set
+    }
+
+    def "successful save clears attribute state"() {
+        given:
+        def context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new test_support.entity.sales.Address()))
+        Customer managed = context.merge(customer)
+        managed.name = 'c2'
+
+        when:
+        context.save()
+
+        then:
+        context.getModifiedAttributes(managed).empty
+        !context.hasChanges()
+
+        cleanup:
+        deleteRecord(managed)
+    }
+
+    def "collection mutation dirties the attribute and revert un-dirties it"() {
+        given:
+        def context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new test_support.entity.sales.Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: customer))
+        def line = dataManager.save(new test_support.entity.sales.OrderLine(quantity: 1, order: order))
+
+        Order managed = context.merge(dataManager.load(io.jmix.core.Id.of(order))
+                .fetchPlan { it.addAll('number', 'orderLines.quantity') }.one())
+        def managedLine = managed.orderLines[0]
+
+        when:
+        managed.orderLines.remove(managedLine)
+
+        then:
+        context.getModifiedAttributes(managed) == ['orderLines'] as Set
+        context.isModified(managed)
+
+        when: "re-adding the same element restores the baseline membership"
+        managed.orderLines.add(managedLine)
+
+        then:
+        context.getModifiedAttributes(managed).empty
+        !context.isModified(managed)
+
+        cleanup:
+        dataManager.remove(line, order, customer)
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextDiagnosticsTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextDiagnosticsTest.groovy
@@ -32,9 +32,9 @@ class DataContextDiagnosticsTest extends DataContextSpec {
         Customer customer = metadata.create(Customer)
 
         expect:
-        DataContextDiagnostics.attributeDirtied(customer, 'name', 'a', 'b')
+        DataContextDiagnostics.attributeDirtied(customer, 'name', 'a')
                 .contains("Customer-${customer.id}")
-        DataContextDiagnostics.attributeDirtied(customer, 'name', 'a', 'b').contains("'a' -> 'b'")
+        DataContextDiagnostics.attributeDirtied(customer, 'name', 'a').contains("baseline 'a'")
         DataContextDiagnostics.attributeReverted(customer, 'name').contains('reverted')
         DataContextDiagnostics.mergeSkippedDirty(customer, 'name').contains('kept user value')
         DataContextDiagnostics.formatEntity(null) == 'null'

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextDiagnosticsTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextDiagnosticsTest.groovy
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data_components
+
+import io.jmix.core.Metadata
+import io.jmix.flowui.model.impl.DataContextDiagnostics
+import org.springframework.beans.factory.annotation.Autowired
+import test_support.entity.sales.Customer
+import test_support.spec.DataContextSpec
+
+class DataContextDiagnosticsTest extends DataContextSpec {
+
+    @Autowired
+    Metadata metadata
+
+    def "messages carry entity, attribute, values"() {
+        given:
+        Customer customer = metadata.create(Customer)
+
+        expect:
+        DataContextDiagnostics.attributeDirtied(customer, 'name', 'a', 'b')
+                .contains("Customer-${customer.id}")
+        DataContextDiagnostics.attributeDirtied(customer, 'name', 'a', 'b').contains("'a' -> 'b'")
+        DataContextDiagnostics.attributeReverted(customer, 'name').contains('reverted')
+        DataContextDiagnostics.mergeSkippedDirty(customer, 'name').contains('kept user value')
+        DataContextDiagnostics.formatEntity(null) == 'null'
+        DataContextDiagnostics.formatEntity('x') == 'x'
+        DataContextDiagnostics.formatEntity(customer) == "Customer-${customer.id}"
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextInvariantFuzzTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextInvariantFuzzTest.groovy
@@ -1,0 +1,428 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package data_components
+
+import io.jmix.core.DataManager
+import io.jmix.core.EntityStates
+import io.jmix.core.Id
+import io.jmix.core.entity.EntityValues
+import io.jmix.flowui.model.DataComponents
+import io.jmix.flowui.model.DataContext
+import io.jmix.flowui.model.MergeOptions
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.IgnoreIf
+import test_support.entity.sales.Address
+import test_support.entity.sales.Customer
+import test_support.entity.sales.Order
+import test_support.entity.sales.OrderLine
+import test_support.spec.DataContextSpec
+
+/**
+ * Measurement harness, not a regression suite: generates random scenarios of
+ * loads-with-random-fetch-plans, merges (fresh and stale) and user edits against a DataContext,
+ * and counts violations of proposed merge invariants instead of failing on the first one.
+ *
+ * Invariants checked after every operation:
+ *  I1  edits-preserved      — a user edit on a managed instance (attribute or reference) survives
+ *                             subsequent merges (violations split by the op that clobbered it)
+ *  I2  loaded-not-regressed — an attribute loaded on a managed instance never becomes unloaded
+ *  I3  no-collection-dups   — to-many collections contain no duplicates (by id or instance)
+ *  I4  identity-map         — every reachable reference is THE managed instance of its id
+ *  I5  dirty-not-missed     — a user-edited entity is present in getModified()
+ *  I6  dirty-not-phantom    — a never-edited entity is not in getModified()
+ *  I7  membership-preserved — a line added to an order's collection is still there
+ *  EX  exception            — an operation threw
+ *
+ * The run always passes; it prints a violation report. Reproduce a scenario by its printed seed.
+ * <p>
+ * Slow test: excluded from the regular suite, run with {@code -PincludeSlowTests=true}.
+ */
+@IgnoreIf({ env["slowTests"] != 'true' })
+@IgnoreIf({ Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING")) })
+class DataContextInvariantFuzzTest extends DataContextSpec {
+
+    @Autowired
+    DataComponents factory
+    @Autowired
+    EntityStates entityStates
+    @Autowired
+    DataManager dataManager
+
+    static final int SCENARIOS = Integer.getInteger('fuzz.scenarios', 200)
+    static final int OPS_PER_SCENARIO = 10
+    static final long BASE_SEED = Long.getLong('fuzz.baseSeed', 20260710L)
+    static final boolean TRACE = Boolean.getBoolean('fuzz.trace')
+
+    static final List<List<String>> ORDER_PLANS = [
+            ['number'],
+            ['number', 'description'],
+            ['number', 'customer.name'],
+            ['number', 'orderLines.quantity'],
+            ['number', 'description', 'customer.name', 'orderLines.quantity', 'orderLines.description'],
+    ]
+    static final List<List<String>> LINE_PLANS = [
+            ['quantity'],
+            ['quantity', 'description'],
+            ['quantity', 'order.number'],
+            ['quantity', 'description', 'order.number', 'order.customer.name'],
+    ]
+
+    // ---- violation bookkeeping ----------------------------------------------------------------
+
+    Map<String, Integer> violationCounts = [:].withDefault { 0 }
+    Map<String, Set<Long>> violationSeeds = [:].withDefault { new LinkedHashSet<Long>() }
+    List<String> samples = []
+
+    void violation(String invariant, String opType, long seed, int opIndex, String detail) {
+        String key = "$invariant|$opType"
+        violationCounts[key] = violationCounts[key] + 1
+        violationSeeds[invariant] << seed
+        if (samples.size() < 40) {
+            samples << String.format('%-24s op=%-22s seed=%d opIndex=%d  %s', invariant, opType, seed, opIndex, detail)
+        }
+    }
+
+    // ---- oracle state per scenario ------------------------------------------------------------
+
+    static class Oracle {
+        // key -> attr -> expected value (ids for references)
+        Map<String, Map<String, Object>> userEdits = [:].withDefault { [:] }
+        // orderKey -> set of line ids expected in orderLines
+        Map<String, Set<Object>> membership = [:].withDefault { new HashSet<>() }
+        // keys of entities the user edited (must be dirty)
+        Set<String> editedKeys = new HashSet<>()
+        // phantom-dirty entities already reported (count once)
+        Set<String> phantomSeen = new HashSet<>()
+        // dedup for I2/I4: same broken fact reported once per scenario
+        Set<String> reportedFacts = new HashSet<>()
+    }
+
+    static String key(Object entity) {
+        entity.getClass().simpleName + '-' + EntityValues.getId(entity)
+    }
+
+    // ---- scenario ------------------------------------------------------------------------------
+
+    def "merge invariant fuzz"() {
+        given:
+        int scenariosRun = 0
+
+        when:
+        for (int s = 0; s < SCENARIOS; s++) {
+            long seed = BASE_SEED + s
+            try {
+                runScenario(seed)
+            } catch (Throwable t) {
+                violation('EX-scenario-abort', 'setup', seed, -1, t.class.simpleName + ': ' + String.valueOf(t.message).take(500))
+            }
+            scenariosRun++
+        }
+        printReport(scenariosRun)
+
+        then:
+        scenariosRun == SCENARIOS
+    }
+
+    void runScenario(long seed) {
+        Random rnd = new Random(seed)
+
+        // persisted baseline: 2 customers, 2 orders, 3 lines
+        Customer c1 = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Customer c2 = dataManager.save(new Customer(name: 'c2', address: new Address()))
+        Order o1 = dataManager.save(new Order(number: 'o1', description: 'd1', customer: c1))
+        Order o2 = dataManager.save(new Order(number: 'o2', description: 'd2', customer: c2))
+        List<OrderLine> lines = []
+        3.times { i ->
+            lines << dataManager.save(new OrderLine(quantity: i + 1, description: "l$i",
+                    order: (i < 2 ? o1 : o2)))
+        }
+        List<Order> orders = [o1, o2]
+        List<Customer> customers = [c1, c2]
+        // scenario-creation order of ids, used as a JVM-run-stable sort key for pickManaged
+        List<Object> creationOrder = ([c1, c2, o1, o2] + lines).collect { EntityValues.getId(it) }
+
+        DataContext context = factory.createDataContext()
+        Oracle oracle = new Oracle()
+
+        for (int op = 0; op < OPS_PER_SCENARIO; op++) {
+            String opType = 'none'
+            Map<String, Set<String>> loadedBefore = snapshotLoaded(context)
+            try {
+                switch (rnd.nextInt(6)) {
+                    case 0:
+                        opType = 'load-order-fresh'
+                        def order = orders[rnd.nextInt(orders.size())]
+                        def plan = ORDER_PLANS[rnd.nextInt(ORDER_PLANS.size())]
+                        def loaded = dataManager.load(Id.of(order)).fetchPlan { it.addAll(plan as String[]) }.one()
+                        def managed = context.merge(loaded, new MergeOptions().setFresh(true))
+                        // by current design a fresh merge resets incoming loaded attrs to DB state:
+                        // drop oracle expectations for attrs the plan covered, so I1 counts only
+                        // non-fresh clobbering (the bug class) — fresh clobbering is design-intended
+                        forgetEditsCoveredByPlan(oracle, managed, plan)
+                        break
+                    case 1:
+                        opType = 'merge-stale-order'
+                        def order = orders[rnd.nextInt(orders.size())]
+                        def plan = ORDER_PLANS[rnd.nextInt(ORDER_PLANS.size())]
+                        def loaded = dataManager.load(Id.of(order)).fetchPlan { it.addAll(plan as String[]) }.one()
+                        context.merge(loaded)
+                        break
+                    case 2:
+                        opType = 'merge-stale-line'
+                        def line = lines[rnd.nextInt(lines.size())]
+                        def plan = LINE_PLANS[rnd.nextInt(LINE_PLANS.size())]
+                        def loaded = dataManager.load(Id.of(line)).fetchPlan { it.addAll(plan as String[]) }.one()
+                        context.merge(loaded)
+                        break
+                    case 3:
+                        opType = 'edit-local'
+                        def managed = pickManaged(context, rnd, creationOrder)
+                        if (managed == null) continue
+                        def attrs = localAttrs(managed).findAll { entityStates.isLoaded(managed, it) }
+                        if (attrs.empty) continue
+                        String attr = attrs[rnd.nextInt(attrs.size())]
+                        def value = (attr == 'quantity') ? rnd.nextInt(1000) : ('v' + rnd.nextInt(1000))
+                        if (EntityValues.getValue(managed, attr) != value) {
+                            EntityValues.setValue(managed, attr, value)
+                            oracle.userEdits[key(managed)][attr] = value
+                            oracle.editedKeys << key(managed)
+                        }
+                        break
+                    case 4:
+                        opType = 'set-order-customer'
+                        Order managedOrder = context.find(Order, orders[rnd.nextInt(orders.size())].id)
+                        if (managedOrder == null || !entityStates.isLoaded(managedOrder, 'customer')) continue
+                        def customer = customers[rnd.nextInt(customers.size())]
+                        def managedCustomer = context.merge(
+                                dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name') }.one())
+                        if (!managedCustomer.is(managedOrder.customer)) {
+                            managedOrder.customer = managedCustomer
+                            oracle.userEdits[key(managedOrder)]['customer'] = EntityValues.getId(managedCustomer)
+                            oracle.editedKeys << key(managedOrder)
+                        }
+                        break
+                    case 5:
+                        opType = 'add-line-to-order'
+                        // the AddAction flow: merge a slim copy of the line, set the back reference,
+                        // add to the order's collection if loaded
+                        Order managedOrder = context.find(Order, orders[rnd.nextInt(orders.size())].id)
+                        if (managedOrder == null) continue
+                        def line = lines[rnd.nextInt(lines.size())]
+                        def loaded = dataManager.load(Id.of(line)).fetchPlan { it.addAll('quantity') }.one()
+                        OrderLine managedLine = context.merge(loaded)
+                        boolean refChanged = !entityStates.isLoaded(managedLine, 'order') ||
+                                !managedOrder.is(managedLine.order)
+                        managedLine.order = managedOrder
+                        if (refChanged) {
+                            oracle.userEdits[key(managedLine)]['order'] = EntityValues.getId(managedOrder)
+                            oracle.editedKeys << key(managedLine)
+                        }
+                        if (entityStates.isLoaded(managedOrder, 'orderLines') && managedOrder.orderLines != null) {
+                            if (!managedOrder.orderLines.contains(managedLine)) {
+                                managedOrder.orderLines.add(managedLine)
+                                oracle.editedKeys << key(managedOrder)
+                            }
+                            oracle.membership[key(managedOrder)] << EntityValues.getId(managedLine)
+                        }
+                        break
+                }
+            } catch (Throwable t) {
+                violation('EX-op-threw', opType, seed, op, t.class.simpleName + ': ' + String.valueOf(t.message).take(120))
+            }
+            if (TRACE) {
+                def impl = (io.jmix.flowui.model.impl.DataContextImpl) context
+                println "TRACE seed=$seed op=$op $opType"
+                println "  edited=${oracle.editedKeys}"
+                println "  modified=${impl.modifiedInstances.collect { key(it) }}"
+            }
+            checkInvariants(context, oracle, loadedBefore, seed, op, opType)
+        }
+    }
+
+    // ---- ops helpers ---------------------------------------------------------------------------
+
+    Object pickManaged(DataContext context, Random rnd, List<Object> creationOrder) {
+        // sorted by scenario-creation index so op targets are deterministic per seed across
+        // JVM runs (sorting by key(it) is stable within a run but keyed to per-run random
+        // UUIDs, which reshuffles which entity a given rnd index picks between runs)
+        def all = ((io.jmix.flowui.model.impl.DataContextImpl) context).all.toList().sort {
+            creationOrder.indexOf(EntityValues.getId(it))
+        }
+        all.empty ? null : all[rnd.nextInt(all.size())]
+    }
+
+    static List<String> localAttrs(Object entity) {
+        switch (entity.getClass()) {
+            // Order.description is excluded: its setter is fluent (returns Order), and
+            // SettersEnhancingStep only enhances void setters (MetaModelUtil.isSetterMethod),
+            // so no property-change event fires and DataContext cannot see the edit —
+            // the I5 oracle cannot apply to it (framework enhancer limitation, not a merge bug)
+            case Order: return ['number']
+            case OrderLine: return ['quantity', 'description']
+            case Customer: return ['name', 'email']
+            default: return []
+        }
+    }
+
+    void forgetEditsCoveredByPlan(Oracle oracle, Object managed, List<String> plan) {
+        def rootAttrs = plan.collect { it.split('\\.')[0] }.toSet()
+        oracle.userEdits[key(managed)]?.keySet()?.removeAll(rootAttrs)
+        if (rootAttrs.contains('orderLines')) {
+            oracle.membership.remove(key(managed))
+        }
+    }
+
+    // ---- invariants ----------------------------------------------------------------------------
+
+    Map<String, Set<String>> snapshotLoaded(DataContext context) {
+        Map<String, Set<String>> result = [:]
+        for (Object entity : ((io.jmix.flowui.model.impl.DataContextImpl) context).all) {
+            def loaded = (localAttrs(entity) + refAttrs(entity)).findAll {
+                entityStates.isLoaded(entity, it)
+            } as Set
+            result[key(entity)] = loaded
+        }
+        result
+    }
+
+    static List<String> refAttrs(Object entity) {
+        switch (entity.getClass()) {
+            case Order: return ['customer', 'orderLines']
+            case OrderLine: return ['order']
+            default: return []
+        }
+    }
+
+    void checkInvariants(DataContext context, Oracle oracle, Map<String, Set<String>> loadedBefore,
+                         long seed, int op, String opType) {
+        def impl = (io.jmix.flowui.model.impl.DataContextImpl) context
+        def all = impl.all.toList()
+        def byKey = all.collectEntries { [(key(it)): it] }
+
+        // I1 edits-preserved (references compared by id)
+        oracle.userEdits.each { entityKey, edits ->
+            def managed = byKey[entityKey]
+            if (managed == null) return
+            def clobbered = []
+            edits.each { attr, expected ->
+                if (!entityStates.isLoaded(managed, attr)) {
+                    clobbered << "$attr expected=$expected actual=<unloaded>"
+                    return
+                }
+                def actual = EntityValues.getValue(managed, attr)
+                if (attr in ['customer', 'order']) {
+                    actual = actual == null ? null : EntityValues.getId(actual)
+                }
+                if (actual != expected) {
+                    clobbered << "$attr expected=$expected actual=$actual"
+                }
+            }
+            clobbered.each { detail ->
+                violation('I1-edit-clobbered', opType, seed, op, "$entityKey $detail")
+            }
+            // count each loss once: re-baseline to current state
+            clobbered.each { String d -> edits.remove((d as String).split(' ')[0]) }
+        }
+
+        // I2 loaded-not-regressed
+        loadedBefore.each { entityKey, attrs ->
+            def managed = byKey[entityKey]
+            if (managed == null) return
+            def regressed = attrs.findAll { !entityStates.isLoaded(managed, it) }
+                    .findAll { oracle.reportedFacts.add("I2|$entityKey|$it" as String) }
+            if (regressed) {
+                violation('I2-loaded-regressed', opType, seed, op, "$entityKey attrs=$regressed")
+            }
+        }
+
+        // I3 no duplicates + I4 identity map + reachability
+        all.each { entity ->
+            refAttrs(entity).findAll { entityStates.isLoaded(entity, it) }.each { attr ->
+                def value = EntityValues.getValue(entity, attr)
+                if (value == null) return
+                def targets = (value instanceof Collection) ? value : [value]
+                if (value instanceof Collection) {
+                    def ids = targets.collect { EntityValues.getId(it) }
+                    if (ids.size() != ids.toSet().size() || targets.size() != targets.collect { System.identityHashCode(it) }.toSet().size()) {
+                        violation('I3-collection-dups', opType, seed, op, "${key(entity)}.$attr ids=$ids")
+                    }
+                }
+                targets.each { target ->
+                    def managedTarget = context.find(target.getClass(), EntityValues.getId(target))
+                    String fact = "I4|${key(entity)}|$attr|${EntityValues.getId(target)}"
+                    if (managedTarget == null) {
+                        if (oracle.reportedFacts.add(fact)) {
+                            violation('I4-ref-not-in-context', opType, seed, op, "${key(entity)}.$attr -> ${key(target)}")
+                        }
+                    } else if (!managedTarget.is(target)) {
+                        if (oracle.reportedFacts.add(fact)) {
+                            violation('I4-ref-not-identical', opType, seed, op, "${key(entity)}.$attr -> ${key(target)}")
+                        }
+                    }
+                }
+            }
+        }
+
+        // I7 membership preserved
+        oracle.membership.each { orderKey, lineIds ->
+            Order managedOrder = byKey[orderKey] as Order
+            if (managedOrder == null || !entityStates.isLoaded(managedOrder, 'orderLines') || managedOrder.orderLines == null) return
+            def actualIds = managedOrder.orderLines.collect { EntityValues.getId(it) }.toSet()
+            def missing = lineIds.findAll { !(it in actualIds) }
+            if (missing) {
+                violation('I7-membership-lost', opType, seed, op, "$orderKey missing=$missing")
+                lineIds.removeAll(missing) // count once
+            }
+        }
+
+        // I5 dirty-not-missed / I6 dirty-not-phantom
+        def modifiedKeys = impl.modifiedInstances.collect { key(it) }.toSet()
+        def missed = oracle.editedKeys.findAll { byKey[it] != null && !(it in modifiedKeys) }
+        missed.each { violation('I5-dirty-missed', opType, seed, op, it as String) }
+        oracle.editedKeys.removeAll(missed) // count once
+        modifiedKeys.each { entityKey ->
+            if (!(entityKey in oracle.editedKeys) && !(entityKey in oracle.phantomSeen)
+                    && byKey[entityKey] != null && !entityStates.isNew(byKey[entityKey])) {
+                violation('I6-dirty-phantom', opType, seed, op, entityKey as String)
+                oracle.phantomSeen << entityKey // count once
+            }
+        }
+    }
+
+    // ---- report --------------------------------------------------------------------------------
+
+    void printReport(int scenariosRun) {
+        println '\n================ DataContext invariant fuzz report ================'
+        println "scenarios=${scenariosRun}, ops/scenario=${OPS_PER_SCENARIO}, baseSeed=${BASE_SEED}"
+        if (violationCounts.isEmpty()) {
+            println 'No invariant violations.'
+        } else {
+            println String.format('%-26s %-22s %8s', 'invariant', 'op', 'count')
+            violationCounts.sort { -it.value }.each { k, v ->
+                def (inv, opType) = k.split('\\|')
+                println String.format('%-26s %-22s %8d', inv, opType, v)
+            }
+            println '\naffected scenarios per invariant:'
+            violationSeeds.each { inv, seeds ->
+                println String.format('%-26s %5d scenarios, sample seeds: %s', inv, seeds.size(), seeds.take(8).toList())
+            }
+            println '\nsample violations:'
+            samples.each { println '  ' + it }
+        }
+        println '===================================================================\n'
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextInvariantFuzzTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextInvariantFuzzTest.groovy
@@ -50,6 +50,10 @@ import test_support.spec.DataContextSpec
  * The run always passes; it prints a violation report. Reproduce a scenario by its printed seed.
  * <p>
  * Slow test: excluded from the regular suite, run with {@code -PincludeSlowTests=true}.
+ * <p>
+ * Oracle mirrors the 3.1 attribute-level tracking merge semantics as of increment 02: non-fresh
+ * merges never overwrite a dirty attribute, and fresh merges keep the user's value but rebaseline
+ * it (the attribute un-dirties only if the incoming value equals the user's value).
  */
 @IgnoreIf({ env["slowTests"] != 'true' })
 @IgnoreIf({ Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING")) })
@@ -105,6 +109,10 @@ class DataContextInvariantFuzzTest extends DataContextSpec {
         Map<String, Set<Object>> membership = [:].withDefault { new HashSet<>() }
         // keys of entities the user edited (must be dirty)
         Set<String> editedKeys = new HashSet<>()
+        // subset of editedKeys whose dirt comes (at least partly) from a collection-membership
+        // change rather than a scalar/reference attribute edit; a fresh merge's per-attribute
+        // rebaseline must not evict these from editedKeys just because userEdits emptied out
+        Set<String> collectionEditedKeys = new HashSet<>()
         // phantom-dirty entities already reported (count once)
         Set<String> phantomSeen = new HashSet<>()
         // dedup for I2/I4: same broken fact reported once per scenario
@@ -169,10 +177,11 @@ class DataContextInvariantFuzzTest extends DataContextSpec {
                         def plan = ORDER_PLANS[rnd.nextInt(ORDER_PLANS.size())]
                         def loaded = dataManager.load(Id.of(order)).fetchPlan { it.addAll(plan as String[]) }.one()
                         def managed = context.merge(loaded, new MergeOptions().setFresh(true))
-                        // by current design a fresh merge resets incoming loaded attrs to DB state:
-                        // drop oracle expectations for attrs the plan covered, so I1 counts only
-                        // non-fresh clobbering (the bug class) — fresh clobbering is design-intended
-                        forgetEditsCoveredByPlan(oracle, managed, plan)
+                        // 3.1 semantics: a fresh merge keeps the user's value but rebases the
+                        // baseline to the incoming (DB) value — the attribute un-dirties only if
+                        // that incoming value equals what the user already had. Edits the fresh
+                        // value doesn't match keep being expected (I1 checks unchanged).
+                        rebaselineOnFreshMerge(oracle, managed, loaded, plan)
                         break
                     case 1:
                         opType = 'merge-stale-order'
@@ -235,6 +244,7 @@ class DataContextInvariantFuzzTest extends DataContextSpec {
                             if (!managedOrder.orderLines.contains(managedLine)) {
                                 managedOrder.orderLines.add(managedLine)
                                 oracle.editedKeys << key(managedOrder)
+                                oracle.collectionEditedKeys << key(managedOrder)
                             }
                             oracle.membership[key(managedOrder)] << EntityValues.getId(managedLine)
                         }
@@ -278,11 +288,31 @@ class DataContextInvariantFuzzTest extends DataContextSpec {
         }
     }
 
-    void forgetEditsCoveredByPlan(Oracle oracle, Object managed, List<String> plan) {
+    // Fresh-merge rebaseline (3.1 semantics): for each recorded scalar/reference edit whose
+    // attribute the fetch plan covered, compare against the freshly loaded (DB) value. Equal ->
+    // the edit legitimately un-dirtied (drop the expectation; drop the entity from editedKeys too,
+    // but only if nothing else — e.g. a collection-membership change — still keeps it dirty).
+    // Not equal -> keep expecting the user's value; I1 still checks it on every subsequent op.
+    // Collection membership (orderLines) is untouched here: the merge rule keeps the user's
+    // collection contents on a fresh merge too, so oracle.membership expectations stand.
+    void rebaselineOnFreshMerge(Oracle oracle, Object managed, Object loaded, List<String> plan) {
+        String entityKey = key(managed)
+        def edits = oracle.userEdits[entityKey]
+        if (edits.isEmpty()) return
         def rootAttrs = plan.collect { it.split('\\.')[0] }.toSet()
-        oracle.userEdits[key(managed)]?.keySet()?.removeAll(rootAttrs)
-        if (rootAttrs.contains('orderLines')) {
-            oracle.membership.remove(key(managed))
+        rootAttrs.each { attr ->
+            if (!edits.containsKey(attr)) return
+            if (!entityStates.isLoaded(loaded, attr)) return
+            def dbValue = EntityValues.getValue(loaded, attr)
+            if (attr in ['customer', 'order']) {
+                dbValue = dbValue == null ? null : EntityValues.getId(dbValue)
+            }
+            if (dbValue == edits[attr]) {
+                edits.remove(attr)
+            }
+        }
+        if (edits.isEmpty() && !(entityKey in oracle.collectionEditedKeys)) {
+            oracle.editedKeys.remove(entityKey)
         }
     }
 

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextInvariantFuzzTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextInvariantFuzzTest.groovy
@@ -23,6 +23,7 @@ import io.jmix.core.entity.EntityValues
 import io.jmix.flowui.model.DataComponents
 import io.jmix.flowui.model.DataContext
 import io.jmix.flowui.model.MergeOptions
+import io.jmix.flowui.model.impl.DataContextImpl
 import org.springframework.beans.factory.annotation.Autowired
 import spock.lang.IgnoreIf
 import test_support.entity.sales.Address
@@ -329,7 +330,7 @@ class DataContextInvariantFuzzTest extends DataContextSpec {
                 violation('EX-op-threw', opType, seed, op, t.class.simpleName + ': ' + String.valueOf(t.message).take(120))
             }
             if (TRACE) {
-                def impl = (io.jmix.flowui.model.impl.DataContextImpl) context
+                def impl = (DataContextImpl) context
                 println "TRACE seed=$seed op=$op $opType"
                 println "  edited=${oracle.editedKeys}"
                 println "  modified=${impl.modifiedInstances.collect { key(it) }}"
@@ -344,7 +345,7 @@ class DataContextInvariantFuzzTest extends DataContextSpec {
         // sorted by scenario-creation index so op targets are deterministic per seed across
         // JVM runs (sorting by key(it) is stable within a run but keyed to per-run random
         // UUIDs, which reshuffles which entity a given rnd index picks between runs)
-        def all = ((io.jmix.flowui.model.impl.DataContextImpl) context).all.toList().sort {
+        def all = ((DataContextImpl) context).all.toList().sort {
             creationOrder.indexOf(EntityValues.getId(it))
         }
         all.empty ? null : all[rnd.nextInt(all.size())]
@@ -395,7 +396,7 @@ class DataContextInvariantFuzzTest extends DataContextSpec {
 
     Map<String, Set<String>> snapshotLoaded(DataContext context) {
         Map<String, Set<String>> result = [:]
-        for (Object entity : ((io.jmix.flowui.model.impl.DataContextImpl) context).all) {
+        for (Object entity : ((DataContextImpl) context).all) {
             def loaded = (localAttrs(entity) + refAttrs(entity)).findAll {
                 entityStates.isLoaded(entity, it)
             } as Set
@@ -414,7 +415,7 @@ class DataContextInvariantFuzzTest extends DataContextSpec {
 
     void checkInvariants(DataContext context, Oracle oracle, Map<String, Set<String>> loadedBefore,
                          long seed, int op, String opType) {
-        def impl = (io.jmix.flowui.model.impl.DataContextImpl) context
+        def impl = (DataContextImpl) context
         def all = impl.all.toList()
         def byKey = all.collectEntries { [(key(it)): it] }
 

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextInvariantFuzzTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextInvariantFuzzTest.groovy
@@ -32,7 +32,7 @@ import test_support.entity.sales.OrderLine
 import test_support.spec.DataContextSpec
 
 /**
- * Measurement harness, not a regression suite: generates random scenarios of
+ * Measurement harness and regression gate: generates random scenarios of
  * loads-with-random-fetch-plans, merges (fresh and stale) and user edits against a DataContext,
  * and counts violations of proposed merge invariants instead of failing on the first one.
  *
@@ -47,7 +47,12 @@ import test_support.spec.DataContextSpec
  *  I7  membership-preserved — a line added to an order's collection is still there
  *  EX  exception            — an operation threw
  *
- * The run always passes; it prints a violation report. Reproduce a scenario by its printed seed.
+ * It prints a violation report and then applies a tiered regression gate (see {@code then:}):
+ * the closed invariants (I1, I2, I3, I6, I7, exceptions) must stay at zero at any scenario count,
+ * and the known residuals (I4-ref-not-in-context, I4-ref-not-identical, I5) must stay at or below
+ * their calibrated upper bounds when run at the canonical config (200 scenarios, default seed).
+ * Improvements below a bound keep the gate green and are only logged. Reproduce a scenario by its
+ * printed seed; the baseline lives in {@code docs/features/data-context/tests/coverage.md}.
  * <p>
  * Slow test: excluded from the regular suite, run with {@code -PincludeSlowTests=true}.
  * <p>
@@ -141,8 +146,78 @@ class DataContextInvariantFuzzTest extends DataContextSpec {
         }
         printReport(scenariosRun)
 
-        then:
+        then: 'tiered regression gate — see docs/features/data-context/tests/coverage.md'
         scenariosRun == SCENARIOS
+
+        and:
+        Map<String, Integer> totals = totalsByInvariant()
+        List<String> breaches = []
+
+        // closed invariants: must stay at zero at any scenario count
+        CLOSED_INVARIANTS.each { String inv ->
+            int actual = totals[inv] ?: 0
+            if (actual != 0) {
+                breaches << "$inv = $actual, expected 0".toString()
+            }
+        }
+        int exceptions = (totals['EX-scenario-abort'] ?: 0) + (totals['EX-op-threw'] ?: 0)
+        if (exceptions != 0) {
+            breaches << "exceptions = $exceptions, expected 0".toString()
+        }
+
+        // known residuals: upper bounds, enforced only at the config they were calibrated for
+        boolean canonical = SCENARIOS == 200 && BASE_SEED == 20260710L
+        if (canonical) {
+            RESIDUAL_BOUNDS.each { String inv, int bound ->
+                int actual = totals[inv] ?: 0
+                if (actual > bound) {
+                    breaches << "$inv = $actual, exceeds bound $bound".toString()
+                } else if (actual < bound) {
+                    println "NOTE: $inv = $actual < bound $bound — residual improved; the baseline in coverage.md can be tightened"
+                }
+            }
+        } else {
+            println "NOTE: non-canonical config (scenarios=$SCENARIOS, baseSeed=$BASE_SEED); " +
+                    "residual upper bounds not enforced, only the zero-invariants are checked"
+        }
+
+        assert breaches.isEmpty(), gateFailureMessage(breaches)
+    }
+
+    // ---- regression gate -----------------------------------------------------------------------
+
+    // Closed invariants: fully fixed, must stay at zero at any scenario count.
+    static final List<String> CLOSED_INVARIANTS = [
+            'I1-edit-clobbered', 'I2-loaded-regressed', 'I3-collection-dups',
+            'I6-dirty-phantom', 'I7-membership-lost',
+    ]
+
+    // Known residuals: upper bounds calibrated to the canonical config (200 scenarios, default
+    // seed). I4 is the deferred both-sides-unloaded lazy-holder defect (limitations cluster 7);
+    // I5 = 9 are fuzz-oracle false positives. See tests/coverage.md for the full baseline note.
+    static final Map<String, Integer> RESIDUAL_BOUNDS = [
+            'I4-ref-not-in-context': 90,
+            'I4-ref-not-identical' : 64,
+            'I5-dirty-missed'      : 9,
+    ]
+
+    // Sum the per-op violation counts (keyed "invariant|opType") into per-invariant totals that
+    // match the granularity of the tests/coverage.md baseline table.
+    Map<String, Integer> totalsByInvariant() {
+        Map<String, Integer> totals = [:].withDefault { 0 }
+        violationCounts.each { String k, int v ->
+            String inv = k.split('\\|')[0]
+            totals[inv] = totals[inv] + v
+        }
+        totals
+    }
+
+    static String gateFailureMessage(List<String> breaches) {
+        'DataContext fuzz regression gate failed:\n  ' + breaches.join('\n  ') +
+                '\n\nThe full violation report is printed above. A rise may be a real regression ' +
+                'OR fuzz-config drift\n(a change to the sales test entities or the op mix ' +
+                're-shuffles the counts). Reproduce any\nlisted scenario by its printed seed. ' +
+                'Baseline table: docs/features/data-context/tests/coverage.md.'
     }
 
     void runScenario(long seed) {

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
@@ -7,6 +7,7 @@ import io.jmix.core.FetchPlans
 import io.jmix.core.entity.EntityPropertyChangeEvent
 import io.jmix.core.entity.EntityPropertyChangeListener
 import io.jmix.core.entity.EntitySystemAccess
+import io.jmix.core.entity.EntityValues
 import test_support.entity.sales.OrderLineParam
 import io.jmix.flowui.model.DataComponents
 import io.jmix.flowui.model.DataContext
@@ -938,5 +939,61 @@ class DataContextMergePolicyTest extends DataContextSpec {
 
         cleanup:
         dataManager.remove(customer)
+    }
+
+    @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
+    def "root merge of a wider copy merges a transplanted to-one reference into the context (#418)"() {
+        DataContext context = factory.createDataContext()
+
+        given: "an order merged with customer unloaded, then a wider copy carrying customer"
+        Customer customer1 = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order1 = dataManager.save(new Order(number: '1', customer: customer1))
+
+        Order managed = context.merge(
+                dataManager.load(Id.of(order1)).fetchPlan { it.add('number') }.one())
+
+        expect:
+        !entityStates.isLoaded(managed, 'customer')
+
+        when:
+        context.merge(dataManager.load(Id.of(order1))
+                .fetchPlan { it.addAll('number', 'customer.name') }.one())
+
+        then: "the reached customer is THE managed instance of its id, not a transplanted copy"
+        entityStates.isLoaded(managed, 'customer')
+        managed.customer != null
+        context.find(Customer, customer1.id).is(managed.customer)
+
+        cleanup:
+        dataManager.remove(order1, customer1)
+    }
+
+    @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
+    def "non-root graph merge merges transplanted collection elements into the context"() {
+        DataContext context = factory.createDataContext()
+
+        given: "an order managed with orderLines unloaded"
+        Customer customer1 = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order1 = dataManager.save(new Order(number: '1', customer: customer1))
+        OrderLine line1 = dataManager.save(new OrderLine(quantity: 1, order: order1))
+
+        Order managed = context.merge(
+                dataManager.load(Id.of(order1)).fetchPlan { it.add('number') }.one())
+
+        expect:
+        !entityStates.isLoaded(managed, 'orderLines')
+
+        when: "a line carrying order.orderLines is merged — order is reached non-root"
+        def loadedLine = dataManager.load(Id.of(line1))
+                .fetchPlan { it.addAll('quantity', 'order.number', 'order.orderLines.quantity') }.one()
+        context.merge(loadedLine)
+
+        then: "each element of the transplanted collection is THE managed instance of its id"
+        entityStates.isLoaded(managed, 'orderLines')
+        managed.orderLines.size() == 1
+        managed.orderLines.every { context.find(OrderLine, EntityValues.getId(it)).is(it) }
+
+        cleanup:
+        dataManager.remove(line1, order1, customer1)
     }
 }

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
@@ -742,4 +742,62 @@ class DataContextMergePolicyTest extends DataContextSpec {
         cleanup:
         dataManager.remove(line, order1, order2, customer)
     }
+
+    @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
+    def "a fetched reference stays loaded after a fresh merge of a narrower copy"() {
+        given: "an order merged with 'customer' fetched wide"
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order1 = dataManager.save(new Order(number: 'o1', customer: customer))
+
+        Order managedWide = context.merge(
+                dataManager.load(Id.of(order1)).fetchPlan { it.addAll('number', 'customer.name') }.one())
+
+        expect: "'customer' is loaded and present"
+        entityStates.isLoaded(managedWide, 'customer')
+        managedWide.customer != null
+
+        when: "a FRESH merge brings a narrower copy of the same order (no 'customer' in its fetch plan)"
+        // fresh + pre-existing managed instance: mergeLoadedPropertiesInfo copies the narrow source's loaded-info
+        // wholesale onto the managed order, and its source-relative negative for 'customer' shadows the unioned
+        // fetch group, reverting the flag - unless the cold-reset recompute is generalized to the fresh path
+        context.merge(dataManager.load(Id.of(order1)).fetchPlan { it.add('number') }.one(),
+                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+
+        then: "'customer' stays loaded and keeps its value"
+        entityStates.isLoaded(managedWide, 'customer')
+        managedWide.customer != null
+        managedWide.customer.name == 'c1'
+
+        cleanup:
+        dataManager.remove(order1, customer)
+    }
+
+    @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
+    def "a fresh narrower merge then save does not null out a fetched reference"() {
+        given: "an order merged with 'customer' fetched wide"
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order1 = dataManager.save(new Order(number: 'o1', customer: customer))
+
+        Order managed = context.merge(
+                dataManager.load(Id.of(order1)).fetchPlan { it.addAll('number', 'customer.name') }.one())
+
+        when: "a FRESH narrower merge (no 'customer'), then a datatype edit and a save"
+        context.merge(dataManager.load(Id.of(order1)).fetchPlan { it.add('number') }.one(),
+                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+        managed.number = 'o1-edited'
+        context.save()
+
+        then: "the DB round-trip proves the customer FK survived (not nulled by the save)"
+        def reloaded = dataManager.load(Id.of(order1)).fetchPlan { it.addAll('number', 'customer.name') }.one()
+        reloaded.number == 'o1-edited'
+        reloaded.customer != null
+        reloaded.customer.name == 'c1'
+
+        cleanup:
+        // remove the post-save reference: context.save() bumped order1's DB version, so the pre-save
+        // 'order1' object is stale and would fail the optimistic-lock check on delete
+        dataManager.remove(reloaded, customer)
+    }
 }

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
@@ -45,7 +45,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
 
         Order managed = context.merge(dataManager.load(Id.of(order)).fetchPlan { it.add('number') }.one())
         context.merge(dataManager.load(Id.of(order)).fetchPlan { it.addAll('number', 'orderLines.quantity') }.one(),
-                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+                new MergeOptions().setFresh(true))
         context.setModified(managed, false) // start clean
 
         when: "the user mutates the (transplanted) collection"
@@ -91,7 +91,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
         Customer freshCopy = dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one()
         freshCopy.name = 'db-new'
         makeDetached(freshCopy, ['name'])
-        context.merge(freshCopy, new io.jmix.flowui.model.MergeOptions().setFresh(true))
+        context.merge(freshCopy, new MergeOptions().setFresh(true))
 
         then: "user's value survives, still dirty (against the new baseline)"
         managed.name == 'edited'
@@ -101,7 +101,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
         Customer equalCopy = dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one()
         equalCopy.name = 'edited'
         makeDetached(equalCopy, ['name'])
-        context.merge(equalCopy, new io.jmix.flowui.model.MergeOptions().setFresh(true))
+        context.merge(equalCopy, new MergeOptions().setFresh(true))
 
         then:
         managed.name == 'edited'
@@ -362,7 +362,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
 
         when: "the database has moved on (still c1) and a fresh copy arrives"
         Order freshCopy = dataManager.load(Id.of(order)).fetchPlan { it.addAll('number', 'customer.name') }.one()
-        context.merge(freshCopy, new io.jmix.flowui.model.MergeOptions().setFresh(true))
+        context.merge(freshCopy, new MergeOptions().setFresh(true))
 
         then: "user's reference survives, still dirty (against the new baseline, still c1)"
         managed.customer.is(managedC2)
@@ -373,7 +373,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
         dbOrder.customer = c2
         dbOrder = dataManager.save(dbOrder)
         Order equalCopy = dataManager.load(Id.of(order)).fetchPlan { it.addAll('number', 'customer.name') }.one()
-        context.merge(equalCopy, new io.jmix.flowui.model.MergeOptions().setFresh(true))
+        context.merge(equalCopy, new MergeOptions().setFresh(true))
 
         then: "the reference un-dirties (ids equal)"
         managed.customer.is(managedC2)
@@ -401,7 +401,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
         when: "the database has moved on (still [l1, l2]) and a fresh copy arrives"
         context.merge(dataManager.load(Id.of(order))
                 .fetchPlan { it.addAll('number', 'orderLines.quantity') }.one(),
-                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+                new MergeOptions().setFresh(true))
 
         then: "user's emptied-of-l2 contents survive, still dirty (membership differs from the new baseline)"
         managed.orderLines*.id == [l1.id]
@@ -427,7 +427,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
 
         when: "the database has moved on (still 'Rome') and a fresh copy arrives"
         context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'address') }.one(),
-                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+                new MergeOptions().setFresh(true))
 
         then: "user's value survives, still dirty (against the new baseline, still 'Rome')"
         managed.address.city == 'Pisa'
@@ -437,7 +437,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
         Customer equalCopy = dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'address') }.one()
         equalCopy.address.city = 'Pisa'
         makeDetached(equalCopy, ['name', 'address'])
-        context.merge(equalCopy, new io.jmix.flowui.model.MergeOptions().setFresh(true))
+        context.merge(equalCopy, new MergeOptions().setFresh(true))
 
         then: "the path un-dirties"
         managed.address.city == 'Pisa'
@@ -466,7 +466,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
         dataManager.remove(l2)
         context.merge(dataManager.load(Id.of(order))
                 .fetchPlan { it.addAll('number', 'orderLines.quantity') }.one(),
-                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+                new MergeOptions().setFresh(true))
 
         then: "the managed collection reflects the DB and stays clean -- merge legitimately changed a clean collection"
         managed.orderLines*.id == [l1.id]
@@ -739,7 +739,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
         // fresh + root -> mergeLoadedPropertiesInfo copies the narrow source's loaded-info wholesale onto the
         // managed line, reverting the set-loaded flag unless it is re-applied from the marker registry
         context.merge(dataManager.load(Id.of(line)).fetchPlan { it.add('quantity') }.one(),
-                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+                new MergeOptions().setFresh(true))
 
         then: "'order' stays loaded and keeps the user's value"
         entityStates.isLoaded(managedLine, 'order')
@@ -768,7 +768,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
         // wholesale onto the managed order, and its source-relative negative for 'customer' shadows the unioned
         // fetch group, reverting the flag - unless the cold-reset recompute is generalized to the fresh path
         context.merge(dataManager.load(Id.of(order1)).fetchPlan { it.add('number') }.one(),
-                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+                new MergeOptions().setFresh(true))
 
         then: "'customer' stays loaded and keeps its value"
         entityStates.isLoaded(managedWide, 'customer')
@@ -791,7 +791,7 @@ class DataContextMergePolicyTest extends DataContextSpec {
 
         when: "a FRESH narrower merge (no 'customer'), then a datatype edit and a save"
         context.merge(dataManager.load(Id.of(order1)).fetchPlan { it.add('number') }.one(),
-                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+                new MergeOptions().setFresh(true))
         managed.number = 'o1-edited'
         context.save()
 

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
@@ -710,4 +710,36 @@ class DataContextMergePolicyTest extends DataContextSpec {
         mergedUser.userRoles.size() == 2
         mergedUser.userRoles.unique().size() == 2
     }
+
+    @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
+    def "a set reference stays loaded after a fresh merge of a narrower copy"() {
+        given: "a managed order line whose 'order' reference was not fetched, then set by the user"
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order1 = dataManager.save(new Order(number: 'o1', customer: customer))
+        Order order2 = dataManager.save(new Order(number: 'o2', customer: customer))
+        OrderLine line = dataManager.save(new OrderLine(quantity: 1, order: order1))
+
+        Order managedOrder2 = context.merge(dataManager.load(Id.of(order2)).fetchPlan { it.add('number') }.one())
+        OrderLine managedLine = context.merge(dataManager.load(Id.of(line)).fetchPlan { it.add('quantity') }.one())
+        // set 'order' to a DIFFERENT managed order so the change fires and marks 'order' loaded (increment 04);
+        // a same-id set would be a no-op change and would neither track dirty nor mark loaded
+        managedLine.order = managedOrder2
+
+        expect: "the set makes 'order' loaded"
+        entityStates.isLoaded(managedLine, 'order')
+
+        when: "a FRESH merge brings a narrower copy of the same line (no 'order' in its fetch plan)"
+        // fresh + root -> mergeLoadedPropertiesInfo copies the narrow source's loaded-info wholesale onto the
+        // managed line, reverting the set-loaded flag unless it is re-applied from the marker registry
+        context.merge(dataManager.load(Id.of(line)).fetchPlan { it.add('quantity') }.one(),
+                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+
+        then: "'order' stays loaded and keeps the user's value"
+        entityStates.isLoaded(managedLine, 'order')
+        managedLine.order == managedOrder2
+
+        cleanup:
+        dataManager.remove(line, order1, order2, customer)
+    }
 }

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
@@ -9,7 +9,6 @@ import io.jmix.flowui.model.DataComponents
 import io.jmix.flowui.model.DataContext
 import org.springframework.beans.factory.annotation.Autowired
 import spock.lang.IgnoreIf
-import spock.lang.PendingFeature
 import test_support.entity.sales.Address
 import test_support.entity.sales.Customer
 import test_support.entity.sales.Order
@@ -619,11 +618,33 @@ class DataContextMergePolicyTest extends DataContextSpec {
         dataManager.remove(param, line, order, customer)
     }
 
-    @PendingFeature(reason = """
-                        #5331 is not fixed on this branch: re-entrant mergeList duplicates the owner collection (4 elements instead of 2). 
-                        The fix lives on a separate branch (commit ff17359559), not merged here. 
-                        Remove this annotation when #5331 is fixed. See docs/features/data-context/issues.md.
-                        """)
+    def "merge bidirectional graph with two java instances of same id does not duplicate collection (#5331)"() {
+        given: "two java instances of the same user id, joined by a bidirectional user <-> userRoles graph"
+        DataContext context = factory.createDataContext()
+        User user1 = new User(login: 'u1', name: 'User 1')
+        User user1Dup = new User(id: user1.id, login: 'u1', name: 'User 1')
+
+        Role role1 = new Role(name: 'Role 1')
+        Role role2 = new Role(name: 'Role 2')
+
+        UserRole ur1 = new UserRole(user: user1Dup, role: role1)
+        UserRole ur2 = new UserRole(user: user1Dup, role: role2)
+
+        user1.userRoles = [ur1, ur2]
+        user1Dup.userRoles = [ur1, ur2]
+
+        when: "a root UserRole pulls user1 in as a NON-ROOT reference, so the owner collection merges with replace=false"
+        Role rootRole = new Role(name: 'Root Role')
+        UserRole rootUr = new UserRole(user: user1, role: rootRole)
+
+        UserRole mergedRoot = context.merge(rootUr)
+        User mergedUser = mergedRoot.user
+
+        then: "the re-entrant merge does not duplicate the owner collection"
+        mergedUser.userRoles.size() == 2
+        mergedUser.userRoles.unique().size() == 2
+    }
+
     def "merge of a bidirectional graph with two java instances of the same id does not duplicate the owner collection"() {
         given: "two java instances of the same user id, with a bidirectional user <-> userRoles graph (#5331)"
         DataContext context = factory.createDataContext()

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
@@ -7,10 +7,14 @@ import io.jmix.flowui.model.DataComponents
 import io.jmix.flowui.model.DataContext
 import org.springframework.beans.factory.annotation.Autowired
 import spock.lang.IgnoreIf
+import spock.lang.PendingFeature
 import test_support.entity.sales.Address
 import test_support.entity.sales.Customer
 import test_support.entity.sales.Order
 import test_support.entity.sales.OrderLine
+import test_support.entity.sec.Role
+import test_support.entity.sec.User
+import test_support.entity.sec.UserRole
 import test_support.spec.DataContextSpec
 
 class DataContextMergePolicyTest extends DataContextSpec {
@@ -479,5 +483,37 @@ class DataContextMergePolicyTest extends DataContextSpec {
 
         cleanup:
         dataManager.remove(order, customer)
+    }
+
+    @PendingFeature(reason = """
+                        #5331 is not fixed on this branch: re-entrant mergeList duplicates the owner collection (4 elements instead of 2). 
+                        The fix lives on a separate branch (commit ff17359559), not merged here. 
+                        Remove this annotation when #5331 is fixed. See docs/features/data-context/issues.md.
+                        """)
+    def "merge of a bidirectional graph with two java instances of the same id does not duplicate the owner collection"() {
+        given: "two java instances of the same user id, with a bidirectional user <-> userRoles graph (#5331)"
+        DataContext context = factory.createDataContext()
+        User user1 = new User(login: 'u1', name: 'User 1')
+        User user1Dup = new User(id: user1.id, login: 'u1', name: 'User 1')
+
+        Role role1 = new Role(name: 'Role 1')
+        Role role2 = new Role(name: 'Role 2')
+
+        UserRole ur1 = new UserRole(user: user1Dup, role: role1)
+        UserRole ur2 = new UserRole(user: user1Dup, role: role2)
+
+        user1.userRoles = [ur1, ur2]
+        user1Dup.userRoles = [ur1, ur2]
+
+        when: "a root UserRole pulls user1 in as a non-root reference, so the owner collection merges with replace=false into an empty list"
+        Role rootRole = new Role(name: 'Root Role')
+        UserRole rootUr = new UserRole(user: user1, role: rootRole)
+
+        UserRole mergedRoot = context.merge(rootUr)
+        User mergedUser = mergedRoot.user
+
+        then: "the re-entrant merge does not duplicate the owner collection"
+        mergedUser.userRoles.size() == 2
+        mergedUser.userRoles.unique().size() == 2
     }
 }

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
@@ -4,15 +4,20 @@ import io.jmix.core.DataManager
 import io.jmix.core.EntityStates
 import io.jmix.core.Id
 import io.jmix.core.FetchPlans
+import io.jmix.core.entity.EntityPropertyChangeEvent
+import io.jmix.core.entity.EntityPropertyChangeListener
+import io.jmix.core.entity.EntitySystemAccess
 import test_support.entity.sales.OrderLineParam
 import io.jmix.flowui.model.DataComponents
 import io.jmix.flowui.model.DataContext
+import io.jmix.flowui.model.MergeOptions
 import org.springframework.beans.factory.annotation.Autowired
 import spock.lang.IgnoreIf
 import test_support.entity.sales.Address
 import test_support.entity.sales.Customer
 import test_support.entity.sales.Order
 import test_support.entity.sales.OrderLine
+import test_support.entity.sales.Status
 import test_support.entity.sec.Role
 import test_support.entity.sec.User
 import test_support.entity.sec.UserRole
@@ -799,5 +804,139 @@ class DataContextMergePolicyTest extends DataContextSpec {
         // remove the post-save reference: context.save() bumped order1's DB version, so the pre-save
         // 'order1' object is stale and would fail the optimistic-lock check on delete
         dataManager.remove(reloaded, customer)
+    }
+
+    def "a merge that changes a managed instance scalar fires a ChangeEvent (#4071)"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Customer managed = context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one())
+
+        and: "a change listener recording the entities it is notified about"
+        def events = []
+        context.addChangeListener { events << it.entity }
+
+        when: "a fresh merge brings a changed value for the same managed instance"
+        def reloaded = dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one()
+        reloaded.name = 'changed'
+        context.merge(reloaded, new MergeOptions().setFresh(true))
+
+        then: "exactly one ChangeEvent fires, for the managed instance"
+        managed.name == 'changed'
+        events == [managed]
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "a plain merge of unchanged data fires no ChangeEvent; a new instance fires once after the merge"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one())
+
+        def events = []
+        context.addChangeListener { events << it.entity }
+
+        when: "the same unchanged data is merged again"
+        context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one())
+
+        then: "nothing fires (no value actually changed)"
+        events.isEmpty()
+
+        when: "a brand-new instance is merged"
+        def created = context.merge(new Customer(name: 'c2', address: new Address()))
+
+        then: "exactly one ChangeEvent fires, for the new instance"
+        events == [created]
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "an edit made by a listener during a merge is tracked without setModified (#1258)"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', status: Status.OK, address: new Address()))
+        // 'status' is fetched here so the managed instance can be read/set directly (detached entities
+        // cannot lazily fetch a plain scalar); the fresh merge below deliberately omits it from ITS fetch
+        // plan, which is what keeps the merge from ever writing it (see the 'when' block).
+        Customer managed = context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'status') }.one())
+
+        and: "a listener on the managed instance that, when name changes, also edits status"
+        EntitySystemAccess.addPropertyChangeListener(managed, new EntityPropertyChangeListener() {
+            @Override
+            void propertyChanged(EntityPropertyChangeEvent e) {
+                if (e.property == 'name') {
+                    managed.status = Status.NOT_OK
+                }
+            }
+        })
+
+        when: "a fresh merge changes name, firing the listener mid-merge"
+        def reloaded = dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one()
+        reloaded.name = 'changed'
+        context.merge(reloaded, new MergeOptions().setFresh(true))
+
+        then: "the listener's status edit is tracked as a modification, with no manual setModified"
+        managed.status == Status.NOT_OK
+        context.isModified(managed)
+        'status' in context.getModifiedAttributes(managed)
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "a listener-injected edit is tracked even after an earlier merge's flush listener threw"() {
+        given: "a managed instance with name and email loaded"
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', email: 'e1@x.com', address: new Address()))
+        Customer managed = context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'email') }.one())
+
+        and: "a change listener that throws on its first invocation only, then goes inert"
+        boolean thrown = false
+        context.addChangeListener {
+            if (!thrown) {
+                thrown = true
+                throw new RuntimeException('boom')
+            }
+        }
+
+        when: "a fresh merge changes name; its post-merge flush fires the throwing listener"
+        def reloaded1 = dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'email') }.one()
+        reloaded1.name = 'changed1'
+        try {
+            context.merge(reloaded1, new MergeOptions().setFresh(true))
+        } catch (RuntimeException ignored) {
+            // expected: the flush listener throws; this must not stop mergeApplied.clear() from
+            // having already run for this merge (see the fix ordering in DataContextImpl)
+        }
+
+        then: "the merge itself did apply, regardless of the listener exception"
+        managed.name == 'changed1'
+
+        and: "a listener on the managed instance that, when email changes, also edits name (listener-injected edit)"
+        EntitySystemAccess.addPropertyChangeListener(managed, new EntityPropertyChangeListener() {
+            @Override
+            void propertyChanged(EntityPropertyChangeEvent e) {
+                if (e.property == 'email') {
+                    managed.name = 'injected'
+                }
+            }
+        })
+
+        when: "a second fresh merge changes email only; name is NOT in this merge's fetch plan, so the merge itself never writes it"
+        def reloaded2 = dataManager.load(Id.of(customer)).fetchPlan { it.add('email') }.one()
+        reloaded2.email = 'changed2@x.com'
+        context.merge(reloaded2, new MergeOptions().setFresh(true))
+
+        then: "the injected name edit is tracked as a modification - proof that mergeApplied from the" +
+                " earlier (throwing) merge was cleared and did not leak into this merge"
+        managed.name == 'injected'
+        context.isModified(managed)
+        'name' in context.getModifiedAttributes(managed)
+
+        cleanup:
+        dataManager.remove(customer)
     }
 }

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
@@ -3,6 +3,8 @@ package data_components
 import io.jmix.core.DataManager
 import io.jmix.core.EntityStates
 import io.jmix.core.Id
+import io.jmix.core.FetchPlans
+import test_support.entity.sales.OrderLineParam
 import io.jmix.flowui.model.DataComponents
 import io.jmix.flowui.model.DataContext
 import org.springframework.beans.factory.annotation.Autowired
@@ -25,6 +27,8 @@ class DataContextMergePolicyTest extends DataContextSpec {
     EntityStates entityStates
     @Autowired
     DataManager dataManager
+    @Autowired
+    FetchPlans fetchPlans
 
     @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
     def "mutating a transplanted collection marks the owner modified"() {
@@ -483,6 +487,136 @@ class DataContextMergePolicyTest extends DataContextSpec {
 
         cleanup:
         dataManager.remove(order, customer)
+    }
+
+    @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
+    def "setting a value on an unfetched reference marks it loaded"() {
+        given: "a managed order line whose 'order' reference was not fetched"
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order1 = dataManager.save(new Order(number: 'o1', customer: customer))
+        Order order2 = dataManager.save(new Order(number: 'o2', customer: customer))
+        OrderLine line = dataManager.save(new OrderLine(quantity: 1, order: order1))
+
+        Order managedOrder2 = context.merge(dataManager.load(Id.of(order2)).fetchPlan { it.add('number') }.one())
+        OrderLine managedLine = context.merge(dataManager.load(Id.of(line)).fetchPlan { it.add('quantity') }.one())
+
+        expect: "'order' is not loaded on the managed line"
+        !entityStates.isLoaded(managedLine, 'order')
+
+        when: "the user sets the reference to a DIFFERENT order through the managed instance"
+        // set to order2 (not the line's existing order1): the enhanced setter reads the old value to build
+        // the change event, which lazily materializes order1; a same-id set would not be a change, so the
+        // new value must differ for the edit to be both loaded and dirty
+        managedLine.order = managedOrder2
+
+        then: "the attribute is now reported loaded and tracked dirty"
+        entityStates.isLoaded(managedLine, 'order')
+        'order' in context.getModifiedAttributes(managedLine)
+
+        cleanup:
+        dataManager.remove(line, order1, order2, customer)
+    }
+
+    @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
+    def "child save reaching a line non-root marks its deeper collection loaded on the parent"() {
+        given: "a parent holding an order whose lines are loaded WITHOUT their 'params' collection (#4906)"
+        DataContext parent = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: customer))
+        OrderLine line = dataManager.save(new OrderLine(quantity: 1, order: order))
+        OrderLineParam param = dataManager.save(new OrderLineParam(name: 'p1', value: 'v1', orderLine: line))
+
+        def shallowPlan = fetchPlans.builder(Order)
+                .addFetchPlan('_local')
+                .add('customer', '_local')
+                .add('orderLines', '_local')
+                .build()
+        Order parentOrder = parent.merge(dataManager.load(Id.of(order)).fetchPlan(shallowPlan).one())
+        OrderLine parentLine = parentOrder.orderLines[0]
+
+        def lineEditorPlan = fetchPlans.builder(OrderLine)
+                .addFetchPlan('_local')
+                .add('params', '_local')
+                .build()
+
+        expect: "the line editor's fetch plan is not satisfied on the parent line - 'params' is unloaded"
+        !entityStates.isLoaded(parentLine, 'params')
+        !entityStates.isLoadedWithFetchPlan(parentLine, lineEditorPlan)
+
+        when: "a child loads the order with a fuller nested plan (lines WITH params), edits the order, and saves back"
+        // editing the order (not the line) makes the ORDER the merge root, so each line is reached NON-ROOT
+        // on the child->parent merge - that is the path (mergeUnloadedOrNullReference) where the fix must mark
+        // the installed collection loaded. Editing the line itself would merge the line as root, where the
+        // root mergeLoadedPropertiesInfo copy (from the #5445 fix) already carries loaded-state and hides the gap.
+        def fullerPlan = fetchPlans.builder(Order)
+                .addFetchPlan('_local')
+                .add('customer', '_local')
+                .add('orderLines', { builder -> builder.addFetchPlan('_local').add('params', '_local') })
+                .build()
+        DataContext child = factory.createDataContext()
+        child.setParent(parent)
+        Order childOrder = child.merge(dataManager.load(Id.of(order)).fetchPlan(fullerPlan).one())
+        childOrder.number = 'o2'
+        child.save()
+
+        then: "the deeper 'params' attribute is now loaded on the (non-root) parent line, so the reopen gate passes"
+        entityStates.isLoaded(parentLine, 'params')
+        entityStates.isLoadedWithFetchPlan(parentLine, lineEditorPlan)
+
+        cleanup:
+        dataManager.remove(param, line, order, customer)
+    }
+
+    @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
+    def "reopening a line editor after a deep nested save keeps the edit instead of losing it to a stale reload (#4907)"() {
+        given: "a parent holding an order whose lines are loaded WITHOUT their 'params' collection"
+        DataContext parent = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: customer))
+        OrderLine line = dataManager.save(new OrderLine(quantity: 1, order: order))
+        OrderLineParam param = dataManager.save(new OrderLineParam(name: 'p1', value: 'v1', orderLine: line))
+
+        def shallowPlan = fetchPlans.builder(Order)
+                .addFetchPlan('_local')
+                .add('customer', '_local')
+                .add('orderLines', '_local')
+                .build()
+        Order parentOrder = parent.merge(dataManager.load(Id.of(order)).fetchPlan(shallowPlan).one())
+        OrderLine parentLine = parentOrder.orderLines[0]
+
+        def lineEditorPlan = fetchPlans.builder(OrderLine)
+                .addFetchPlan('_local')
+                .add('params', '_local')
+                .build()
+
+        when: "a child (the line editor) loads the deeper 3-level graph, edits both the order and the nested param, and saves back"
+        def deepPlan = fetchPlans.builder(Order)
+                .addFetchPlan('_local')
+                .add('customer', '_local')
+                .add('orderLines', { b -> b.addFetchPlan('_local').add('params', '_local') })
+                .build()
+        DataContext child = factory.createDataContext()
+        child.setParent(parent)
+        Order childOrder = child.merge(dataManager.load(Id.of(order)).fetchPlan(deepPlan).one())
+        childOrder.number = 'o2'
+        childOrder.orderLines[0].params[0].value = 'v2'
+        child.save()
+
+        then: "the reopen gate is now satisfied on the parent's line"
+        entityStates.isLoadedWithFetchPlan(parentLine, lineEditorPlan)
+
+        when: "a second child 'reopens' the line editor - since the gate passed, it merges the parent's in-memory " +
+                "line directly instead of reloading a stale copy from the database"
+        DataContext reopenedChild = factory.createDataContext()
+        reopenedChild.setParent(parent)
+        OrderLine reopenedLine = reopenedChild.merge(parentLine)
+
+        then: "the nested edit survives the reopen"
+        reopenedLine.params[0].value == 'v2'
+
+        cleanup:
+        dataManager.remove(param, line, order, customer)
     }
 
     @PendingFeature(reason = """

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
@@ -1,0 +1,483 @@
+package data_components
+
+import io.jmix.core.DataManager
+import io.jmix.core.EntityStates
+import io.jmix.core.Id
+import io.jmix.flowui.model.DataComponents
+import io.jmix.flowui.model.DataContext
+import org.springframework.beans.factory.annotation.Autowired
+import spock.lang.IgnoreIf
+import test_support.entity.sales.Address
+import test_support.entity.sales.Customer
+import test_support.entity.sales.Order
+import test_support.entity.sales.OrderLine
+import test_support.spec.DataContextSpec
+
+class DataContextMergePolicyTest extends DataContextSpec {
+
+    @Autowired
+    DataComponents factory
+    @Autowired
+    EntityStates entityStates
+    @Autowired
+    DataManager dataManager
+
+    @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
+    def "mutating a transplanted collection marks the owner modified"() {
+        given: "managed order without orderLines; a copy carrying them is merged over it"
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: customer))
+        OrderLine line = dataManager.save(new OrderLine(quantity: 1, order: order))
+
+        Order managed = context.merge(dataManager.load(Id.of(order)).fetchPlan { it.add('number') }.one())
+        context.merge(dataManager.load(Id.of(order)).fetchPlan { it.addAll('number', 'orderLines.quantity') }.one(),
+                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+        context.setModified(managed, false) // start clean
+
+        when: "the user mutates the (transplanted) collection"
+        def newLine = context.create(OrderLine)
+        newLine.quantity = 2
+        newLine.order = managed
+        managed.orderLines.add(newLine)
+
+        then:
+        context.isModified(managed)
+        'orderLines' in context.getModifiedAttributes(managed)
+
+        cleanup:
+        dataManager.remove(line, order, customer)
+    }
+
+    def "non-fresh merge does not overwrite a dirty scalar"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Customer managed = context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one())
+        managed.name = 'edited'
+
+        when:
+        context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one())
+
+        then:
+        managed.name == 'edited'
+        context.getModifiedAttributes(managed) == ['name'] as Set
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "fresh merge keeps a dirty scalar but rebaselines it"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Customer managed = context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one())
+        managed.name = 'edited'
+
+        when: "the database has moved on and a fresh copy arrives"
+        Customer freshCopy = dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one()
+        freshCopy.name = 'db-new'
+        makeDetached(freshCopy, ['name'])
+        context.merge(freshCopy, new io.jmix.flowui.model.MergeOptions().setFresh(true))
+
+        then: "user's value survives, still dirty (against the new baseline)"
+        managed.name == 'edited'
+        context.getModifiedAttributes(managed) == ['name'] as Set
+
+        when: "a fresh copy equal to the user's value un-dirties"
+        Customer equalCopy = dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one()
+        equalCopy.name = 'edited'
+        makeDetached(equalCopy, ['name'])
+        context.merge(equalCopy, new io.jmix.flowui.model.MergeOptions().setFresh(true))
+
+        then:
+        managed.name == 'edited'
+        context.getModifiedAttributes(managed).empty
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "non-fresh merge does not overwrite a dirty reference"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer c1 = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Customer c2 = dataManager.save(new Customer(name: 'c2', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: c1))
+        Order managed = context.merge(dataManager.load(Id.of(order)).fetchPlan { it.addAll('number', 'customer.name') }.one())
+        Customer managedC2 = context.merge(c2)
+        managed.customer = managedC2
+
+        when:
+        context.merge(dataManager.load(Id.of(order)).fetchPlan { it.addAll('number', 'customer.name') }.one())
+
+        then:
+        managed.customer.is(managedC2)
+        'customer' in context.getModifiedAttributes(managed)
+
+        cleanup:
+        dataManager.remove(order, c1, c2)
+    }
+
+    def "non-fresh merge does not replace a dirty collection"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: customer))
+        OrderLine line = dataManager.save(new OrderLine(quantity: 1, order: order))
+        Order managed = context.merge(dataManager.load(Id.of(order))
+                .fetchPlan { it.addAll('number', 'orderLines.quantity') }.one())
+        managed.orderLines.remove(0)
+
+        expect:
+        'orderLines' in context.getModifiedAttributes(managed)
+
+        when:
+        context.merge(dataManager.load(Id.of(order))
+                .fetchPlan { it.addAll('number', 'orderLines.quantity') }.one())
+
+        then: "the user's emptied collection is preserved"
+        managed.orderLines.empty
+        'orderLines' in context.getModifiedAttributes(managed)
+
+        cleanup:
+        dataManager.remove(line, order, customer)
+    }
+
+    def "incoming graph nodes still enter the context when a dirty reference copy is skipped"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer c1 = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Customer c2 = dataManager.save(new Customer(name: 'c2', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: c1))
+        Order managed = context.merge(dataManager.load(Id.of(order)).fetchPlan { it.addAll('number', 'customer.name') }.one())
+        managed.customer = context.merge(c2)
+
+        when: "a copy referencing c1 is merged; the reference copy is skipped but c1 must be tracked"
+        context.merge(dataManager.load(Id.of(order)).fetchPlan { it.addAll('number', 'customer.name') }.one())
+
+        then:
+        context.find(Customer, c1.id) != null
+
+        cleanup:
+        dataManager.remove(order, c1, c2)
+    }
+
+    def "child save unions dirty attributes into the parent and child edits win"() {
+        given:
+        DataContext parent = factory.createDataContext()
+        DataContext child = factory.createDataContext()
+        child.setParent(parent)
+        Customer customer = dataManager.save(new Customer(name: 'c1', email: 'e1', address: new Address()))
+        Customer parentManaged = parent.merge(dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'email') }.one())
+        parentManaged.email = 'parent-edit'
+        Customer childManaged = child.merge(parentManaged)
+
+        when: "child edits name (and the parent had independently edited email)"
+        childManaged.name = 'child-edit'
+        child.save()
+
+        then: "child's edit landed, parent's own edit survived, both attrs dirty in parent"
+        parentManaged.name == 'child-edit'
+        parentManaged.email == 'parent-edit'
+        parent.getModifiedAttributes(parentManaged) == ['name', 'email'] as Set
+        parent.isModified(parentManaged)
+
+        when: "conflicting edit: child also edited email"
+        Customer childManaged2 = child.merge(parentManaged)
+        childManaged2.email = 'child-email'
+        child.save()
+
+        then: "the child's later intent wins"
+        parentManaged.email == 'child-email'
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "child save of an attribute unloaded on the parent lands the value and marks it dirty"() {
+        given:
+        DataContext parent = factory.createDataContext()
+        DataContext child = factory.createDataContext()
+        child.setParent(parent)
+        Customer customer = dataManager.save(new Customer(name: 'c1', email: 'e1', address: new Address()))
+        Customer parentManaged = parent.merge(dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one())
+
+        when: "child works with a fuller state and edits an attribute the parent never loaded"
+        Customer childManaged = child.merge(dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'email') }.one())
+        childManaged.email = 'child-email'
+        child.save()
+
+        then: "the child's value (not null) landed in the parent and the attribute is dirty there"
+        parentManaged.email == 'child-email'
+        'email' in parent.getModifiedAttributes(parentManaged)
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "child save lands edits of several entities in the parent with per-entity dirty attributes"() {
+        given:
+        DataContext parent = factory.createDataContext()
+        DataContext child = factory.createDataContext()
+        child.setParent(parent)
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: customer))
+        OrderLine line = dataManager.save(new OrderLine(quantity: 1, order: order))
+        Order parentOrder = parent.merge(dataManager.load(Id.of(order))
+                .fetchPlan { it.addAll('number', 'orderLines.quantity') }.one())
+        OrderLine parentLine = parentOrder.orderLines[0]
+
+        when: "child edits an Order attribute and a nested OrderLine attribute"
+        Order childOrder = child.merge(parentOrder)
+        childOrder.number = 'o1-child'
+        childOrder.orderLines[0].quantity = 42
+        child.save()
+
+        then: "both edits landed and both entities are dirty in the parent on the right attributes"
+        parentOrder.number == 'o1-child'
+        parentLine.quantity == 42
+        'number' in parent.getModifiedAttributes(parentOrder)
+        'quantity' in parent.getModifiedAttributes(parentLine)
+
+        cleanup:
+        dataManager.remove(line, order, customer)
+    }
+
+    def "child edit of an embedded sub-attribute overrides the parent's own conflicting edit"() {
+        given:
+        DataContext parent = factory.createDataContext()
+        DataContext child = factory.createDataContext()
+        child.setParent(parent)
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address(city: 'Rome')))
+        Customer parentManaged = parent.merge(dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'address') }.one())
+        parentManaged.address.city = 'parent-city'
+
+        when: "child (branched from the parent's state) edits the same embedded sub-attribute"
+        Customer childManaged = child.merge(parentManaged)
+        childManaged.address.city = 'child-city'
+        child.save()
+
+        then: "the child's later intent wins and the path stays dirty in the parent"
+        parentManaged.address.city == 'child-city'
+        'address.city' in parent.getModifiedAttributes(parentManaged)
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "child reassignment of a reference and mutation of a collection union into the parent"() {
+        given:
+        DataContext parent = factory.createDataContext()
+        DataContext child = factory.createDataContext()
+        child.setParent(parent)
+        Customer c1 = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Customer c2 = dataManager.save(new Customer(name: 'c2', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: c1))
+        OrderLine line = dataManager.save(new OrderLine(quantity: 1, order: order))
+        Order parentOrder = parent.merge(dataManager.load(Id.of(order))
+                .fetchPlan { it.addAll('number', 'customer.name', 'orderLines.quantity') }.one())
+
+        when: "child reassigns the reference and mutates the collection"
+        Order childOrder = child.merge(parentOrder)
+        childOrder.customer = child.merge(dataManager.load(Id.of(c2)).one())
+        childOrder.orderLines.remove(0)
+        child.save()
+
+        then: "both landed in the parent and both attributes are dirty there"
+        parentOrder.customer.name == 'c2'
+        parentOrder.orderLines.empty
+        'customer' in parent.getModifiedAttributes(parentOrder)
+        'orderLines' in parent.getModifiedAttributes(parentOrder)
+
+        cleanup:
+        dataManager.remove(line, order, c1, c2)
+    }
+
+    def "child edit propagates through two levels of parent contexts"() {
+        given:
+        DataContext grand = factory.createDataContext()
+        DataContext mid = factory.createDataContext()
+        DataContext child = factory.createDataContext()
+        mid.setParent(grand)
+        child.setParent(mid)
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Customer grandManaged = grand.merge(dataManager.load(Id.of(customer)).fetchPlan { it.add('name') }.one())
+        Customer midManaged = mid.merge(grandManaged)
+        Customer childManaged = child.merge(midManaged)
+
+        when:
+        childManaged.name = 'deep-edit'
+        child.save()
+        mid.save()
+
+        then:
+        grandManaged.name == 'deep-edit'
+        'name' in grand.getModifiedAttributes(grandManaged)
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "non-fresh merge does not overwrite a dirty embedded sub-attribute"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address(city: 'Rome')))
+        Customer managed = context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'address') }.one())
+        managed.address.city = 'Pisa'
+
+        when:
+        context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'address') }.one())
+
+        then:
+        managed.address.city == 'Pisa'
+        context.getModifiedAttributes(managed) == ['address.city'] as Set
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "fresh merge keeps a dirty reference but rebaselines it"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer c1 = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Customer c2 = dataManager.save(new Customer(name: 'c2', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: c1))
+        Order managed = context.merge(dataManager.load(Id.of(order)).fetchPlan { it.addAll('number', 'customer.name') }.one())
+        Customer managedC2 = context.merge(c2)
+        managed.customer = managedC2
+
+        when: "the database has moved on (still c1) and a fresh copy arrives"
+        Order freshCopy = dataManager.load(Id.of(order)).fetchPlan { it.addAll('number', 'customer.name') }.one()
+        context.merge(freshCopy, new io.jmix.flowui.model.MergeOptions().setFresh(true))
+
+        then: "user's reference survives, still dirty (against the new baseline, still c1)"
+        managed.customer.is(managedC2)
+        'customer' in context.getModifiedAttributes(managed)
+
+        when: "the database itself moves to the user's chosen customer and a fresh copy arrives"
+        Order dbOrder = dataManager.load(Id.of(order)).one()
+        dbOrder.customer = c2
+        dbOrder = dataManager.save(dbOrder)
+        Order equalCopy = dataManager.load(Id.of(order)).fetchPlan { it.addAll('number', 'customer.name') }.one()
+        context.merge(equalCopy, new io.jmix.flowui.model.MergeOptions().setFresh(true))
+
+        then: "the reference un-dirties (ids equal)"
+        managed.customer.is(managedC2)
+        context.getModifiedAttributes(managed).empty
+
+        cleanup:
+        dataManager.remove(dbOrder, c1, c2)
+    }
+
+    def "fresh merge keeps a dirty collection's contents but rebaselines its membership"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: customer))
+        OrderLine l1 = dataManager.save(new OrderLine(quantity: 1, order: order))
+        OrderLine l2 = dataManager.save(new OrderLine(quantity: 2, order: order))
+        Order managed = context.merge(dataManager.load(Id.of(order))
+                .fetchPlan { it.addAll('number', 'orderLines.quantity') }.one())
+        def managedL2 = managed.orderLines.find { it.id == l2.id }
+        managed.orderLines.remove(managedL2)
+
+        expect:
+        'orderLines' in context.getModifiedAttributes(managed)
+
+        when: "the database has moved on (still [l1, l2]) and a fresh copy arrives"
+        context.merge(dataManager.load(Id.of(order))
+                .fetchPlan { it.addAll('number', 'orderLines.quantity') }.one(),
+                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+
+        then: "user's emptied-of-l2 contents survive, still dirty (membership differs from the new baseline)"
+        managed.orderLines*.id == [l1.id]
+        'orderLines' in context.getModifiedAttributes(managed)
+
+        when: "the user brings the contents back to match the (rebaselined) incoming membership"
+        managed.orderLines.add(managedL2)
+
+        then: "the collection un-dirties"
+        managed.orderLines*.id.toSet() == [l1.id, l2.id].toSet()
+        context.getModifiedAttributes(managed).empty
+
+        cleanup:
+        dataManager.remove(l1, l2, order, customer)
+    }
+
+    def "fresh merge keeps a dirty embedded sub-attribute but rebaselines it"() {
+        given:
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address(city: 'Rome')))
+        Customer managed = context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'address') }.one())
+        managed.address.city = 'Pisa'
+
+        when: "the database has moved on (still 'Rome') and a fresh copy arrives"
+        context.merge(dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'address') }.one(),
+                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+
+        then: "user's value survives, still dirty (against the new baseline, still 'Rome')"
+        managed.address.city == 'Pisa'
+        'address.city' in context.getModifiedAttributes(managed)
+
+        when: "a fresh copy equal to the user's value arrives"
+        Customer equalCopy = dataManager.load(Id.of(customer)).fetchPlan { it.addAll('name', 'address') }.one()
+        equalCopy.address.city = 'Pisa'
+        makeDetached(equalCopy, ['name', 'address'])
+        context.merge(equalCopy, new io.jmix.flowui.model.MergeOptions().setFresh(true))
+
+        then: "the path un-dirties"
+        managed.address.city == 'Pisa'
+        context.getModifiedAttributes(managed).empty
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "fresh merge of a clean collection rebaselines it to the newly installed membership"() {
+        given: "managed order with two clean lines"
+        DataContext context = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: customer))
+        OrderLine l1 = dataManager.save(new OrderLine(quantity: 1, order: order))
+        OrderLine l2 = dataManager.save(new OrderLine(quantity: 2, order: order))
+        Order managed = context.merge(dataManager.load(Id.of(order))
+                .fetchPlan { it.addAll('number', 'orderLines.quantity') }.one())
+        def managedL1 = managed.orderLines.find { it.id == l1.id }
+        def managedL2 = managed.orderLines.find { it.id == l2.id }
+
+        expect: "clean right after the initial merge"
+        context.getModifiedAttributes(managed).empty
+
+        when: "the DB side drops l2 (no user edit involved) and a fresh copy is merged in"
+        dataManager.remove(l2)
+        context.merge(dataManager.load(Id.of(order))
+                .fetchPlan { it.addAll('number', 'orderLines.quantity') }.one(),
+                new io.jmix.flowui.model.MergeOptions().setFresh(true))
+
+        then: "the managed collection reflects the DB and stays clean -- merge legitimately changed a clean collection"
+        managed.orderLines*.id == [l1.id]
+        context.getModifiedAttributes(managed).empty
+
+        when: "the user removes l1"
+        managed.orderLines.remove(managedL1)
+
+        then: "dirty, measured against the fresh post-merge baseline [l1]"
+        'orderLines' in context.getModifiedAttributes(managed)
+
+        when: "the user re-adds l1"
+        managed.orderLines.add(managedL1)
+
+        then: "clean again: current membership [l1] matches the fresh post-merge baseline, not the stale pre-merge [l1, l2]"
+        context.getModifiedAttributes(managed).empty
+
+        when: "the user also adds l2 back (it was dropped from the DB and is not part of the merged baseline)"
+        managed.orderLines.add(managedL2)
+
+        then: "dirty -- under a stale [l1, l2] baseline this would be a false clean (N1 pin)"
+        'orderLines' in context.getModifiedAttributes(managed)
+
+        cleanup:
+        dataManager.remove(order, customer)
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergePolicyTest.groovy
@@ -618,6 +618,45 @@ class DataContextMergePolicyTest extends DataContextSpec {
         dataManager.remove(param, line, order, customer)
     }
 
+    def "a deep composition edit marks the intermediate owner modified in the parent (#4907 half ii)"() {
+        given: "a parent context holding an order whose lines are loaded WITHOUT their params"
+        DataContext parent = factory.createDataContext()
+        Customer customer = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order = dataManager.save(new Order(number: 'o1', customer: customer))
+        OrderLine line = dataManager.save(new OrderLine(quantity: 1, order: order))
+        OrderLineParam param = dataManager.save(new OrderLineParam(name: 'p1', value: 'v1', orderLine: line))
+
+        def shallowPlan = fetchPlans.builder(Order)
+                .addFetchPlan('_local')
+                .add('customer', '_local')
+                .add('orderLines', '_local')
+                .build()
+        Order parentOrder = parent.merge(dataManager.load(Id.of(order)).fetchPlan(shallowPlan).one())
+        OrderLine parentLine = parentOrder.orderLines[0]
+
+        when: "a child edits ONLY the nested param (not the line, not the order) and saves back"
+        def deepPlan = fetchPlans.builder(Order)
+                .addFetchPlan('_local')
+                .add('customer', '_local')
+                .add('orderLines', { b -> b
+                        .addFetchPlan('_local')
+                        .add('order', '_local')
+                        .add('params', { p -> p.addFetchPlan('_local').add('orderLine', '_local') }) })
+                .build()
+        DataContext child = factory.createDataContext()
+        child.setParent(parent)
+        Order childOrder = child.merge(dataManager.load(Id.of(order)).fetchPlan(deepPlan).one())
+        childOrder.orderLines[0].params[0].value = 'v2'
+        child.save()
+
+        then: "the intermediate owner (the line) is marked modified in the parent, and so is the root order"
+        parent.isModified(parentLine)
+        parent.isModified(parentOrder)
+
+        cleanup:
+        dataManager.remove(param, line, order, customer)
+    }
+
     def "merge bidirectional graph with two java instances of same id does not duplicate collection (#5331)"() {
         given: "two java instances of the same user id, joined by a bidirectional user <-> userRoles graph"
         DataContext context = factory.createDataContext()

--- a/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergeTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/data_components/DataContextMergeTest.groovy
@@ -1044,6 +1044,59 @@ class DataContextMergeTest extends DataContextSpec {
         dataManager.remove(order1, customer1, customer2)
     }
 
+    @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
+    def "root non-fresh merge of a fuller copy applies newly loaded datatype values"() {
+        DataContext context = factory.createDataContext()
+
+        given: "an order first merged from a slim copy that loads only 'number'"
+        Customer customer1 = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order1 = dataManager.save(new Order(number: '1', description: 'd1', customer: customer1))
+
+        def orderSlim = dataManager.load(Id.of(order1)).fetchPlan { it.add('number') }.one()
+        Order managedOrder = context.merge(orderSlim)
+
+        expect: "'description' is not loaded on the managed instance yet"
+        !entityStates.isLoaded(managedOrder, 'description')
+
+        when: "a fuller copy that also loads 'description' is merged as root, non-fresh"
+        def orderFull = dataManager.load(Id.of(order1)).fetchPlan { it.addAll('number', 'description') }.one()
+        context.merge(orderFull)
+
+        then: "the newly loaded value is applied - not left null while reporting loaded"
+        entityStates.isLoaded(managedOrder, 'description')
+        managedOrder.description == 'd1'
+
+        cleanup:
+        dataManager.remove(order1, customer1)
+    }
+
+    @IgnoreIf({Boolean.valueOf(System.getenv("JMIX_ECLIPSELINK_DISABLELAZYLOADING"))})
+    def "root non-fresh merge does not let a later save null out a newly loaded value"() {
+        DataContext context = factory.createDataContext()
+
+        given: "an order merged from a slim copy (only 'number'), then a fuller copy (adds 'description')"
+        Customer customer1 = dataManager.save(new Customer(name: 'c1', address: new Address()))
+        Order order1 = dataManager.save(new Order(number: '1', description: 'd1', customer: customer1))
+
+        def orderSlim = dataManager.load(Id.of(order1)).fetchPlan { it.add('number') }.one()
+        Order managedOrder = context.merge(orderSlim)
+
+        def orderFull = dataManager.load(Id.of(order1)).fetchPlan { it.addAll('number', 'description') }.one()
+        context.merge(orderFull)
+
+        when: "the user edits another attribute and saves"
+        managedOrder.number = '2'
+        context.save()
+
+        then: "the untouched 'description' keeps its real database value (not overwritten with null)"
+        def reloaded = dataManager.load(Id.of(order1)).fetchPlan { it.addAll('number', 'description') }.one()
+        reloaded.number == '2'
+        reloaded.description == 'd1'
+
+        cleanup:
+        dataManager.remove(reloaded, customer1)
+    }
+
     private UUID uuid(int val) {
         new UUID(val, 0)
     }

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/sales/Address.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/sales/Address.java
@@ -21,6 +21,14 @@ import io.jmix.core.metamodel.annotation.JmixEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 
+/**
+ * Used by {@code data_components.DataContextInvariantFuzzTest} (embedded in {@link Customer} and
+ * part of each scenario's persisted baseline), whose deterministic regression baseline depends on
+ * this entity's persistent attribute set. Adding, removing, or renaming attributes here shifts the
+ * fuzz violation counts and can break the gate. If such a change is unavoidable, re-run the fuzz
+ * test with {@code -PincludeSlowTests=true} and update the baseline in
+ * {@code docs/features/data-context/tests/coverage.md}.
+ */
 @Embeddable
 @JmixEntity(name = "test_Address")
 public class Address {

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/sales/Customer.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/sales/Customer.java
@@ -26,6 +26,14 @@ import jakarta.persistence.*;
 
 import java.util.List;
 
+/**
+ * Used by {@code data_components.DataContextInvariantFuzzTest}, whose deterministic regression
+ * baseline depends on this entity's persistent attribute set and setter shape (the harness
+ * enumerates attributes). Adding, removing, or renaming attributes here — or changing a setter
+ * between void and fluent — shifts the fuzz violation counts and can break the gate. If such a
+ * change is unavoidable, re-run the fuzz test with {@code -PincludeSlowTests=true} and update the
+ * baseline in {@code docs/features/data-context/tests/coverage.md}.
+ */
 @Entity(name = "test_Customer")
 @JmixEntity
 @Table(name = "TEST_CUSTOMER")

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/sales/Order.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/sales/Order.java
@@ -31,6 +31,14 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
+/**
+ * Used by {@code data_components.DataContextInvariantFuzzTest}, whose deterministic regression
+ * baseline depends on this entity's persistent attribute set and setter shape (the harness
+ * enumerates attributes). Adding, removing, or renaming attributes here — or changing a setter
+ * between void and fluent — shifts the fuzz violation counts and can break the gate. If such a
+ * change is unavoidable, re-run the fuzz test with {@code -PincludeSlowTests=true} and update the
+ * baseline in {@code docs/features/data-context/tests/coverage.md}.
+ */
 @Entity(name = "test_Order")
 @JmixEntity
 @Table(name = "TEST_ORDER")

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/sales/OrderLine.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/sales/OrderLine.java
@@ -25,6 +25,14 @@ import test_support.entity.TestBaseEntity;
 import jakarta.persistence.*;
 import java.util.List;
 
+/**
+ * Used by {@code data_components.DataContextInvariantFuzzTest}, whose deterministic regression
+ * baseline depends on this entity's persistent attribute set and setter shape (the harness
+ * enumerates attributes). Adding, removing, or renaming attributes here — or changing a setter
+ * between void and fluent — shifts the fuzz violation counts and can break the gate. If such a
+ * change is unavoidable, re-run the fuzz test with {@code -PincludeSlowTests=true} and update the
+ * baseline in {@code docs/features/data-context/tests/coverage.md}.
+ */
 @Table(name = "TEST_ORDER_LINE")
 @Entity(name = "test_OrderLine")
 @JmixEntity

--- a/jmix-flowui/flowui/src/test/resources/component/standarddetailview/view/order-detail-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/standarddetailview/view/order-detail-test-view.xml
@@ -18,7 +18,7 @@
     <data>
         <instance id="orderDc"
                   class="test_support.entity.sales.Order">
-            <fetchPlan extends="_instance_name"/>
+            <fetchPlan extends="_base"/>
             <loader id="orderDl"/>
         </instance>
     </data>


### PR DESCRIPTION
## Summary

This branch reworks `DataContextImpl` change tracking and merge so that unsaved
user edits are no longer lost or spuriously reported. Tracking becomes
per-attribute (with baselines) instead of per-entity, the merge now protects
dirty attributes from being overwritten, and several long-standing merge and
loaded-state defects are fixed. Targets the 3.1 line.

## What changed

- **Attribute-level change tracking.** A new internal `DataContextChangeTracker`
  records, per managed instance, which attributes the user changed and the
  baseline each change is measured against (scalar value, reference id, embedded
  dotted path, or an order-insensitive membership bag for collections).
  Reverting an attribute to its baseline un-dirties it; when the last dirty
  attribute of an entity reverts, the entity leaves `getModified()` (unless kept
  via `setModified(entity, true)`).

- **Merge conflict rule: user edits win over incoming state.** For a dirty
  attribute on an already-managed instance, a non-fresh merge skips the copy and
  a fresh merge keeps the user value but rebaselines it (un-dirtying only if the
  incoming value is now equal). Clean attributes copy as before. Reloads and
  stale copies no longer clobber unsaved edits.

- **Loaded-state correctness and durability.** The merge resets a pre-existing
  managed instance's loaded-state cache before its copy loops (recomputed from
  the unioned fetch group) instead of copying the source's cache, so a save no
  longer writes null over a loaded value. A value that becomes present because it
  was set or merge-installed is now marked loaded, and set/fetched loaded-state
  stays durable across a fresh narrower merge.

- **Event model split.** Merge-triggered `ChangeEvent`s are deferred and fired
  when the outermost merge unwinds; an edit injected by a listener during a merge
  is now recognized and tracked instead of being swallowed. Replaces the old
  `disableListeners` boolean.

- **Composition and child→parent saves.** `DataContextInternal.mergeFromChild`
  lets a child context's edits win over the parent and unions the child's dirty
  attributes into the parent's tracker. A child save marks the composition owner
  chain modified (reopen protection only, not persisted).

- **Identity map on merge-transplant.** A merge that brings a
  reference/collection loaded onto an instance the context tracked unfetched now
  merges the reached nodes into the context instead of transplanting source
  copies.

## New public API

- `DataContext.getModifiedAttributes(Object entity)` — default method returning
  the names of the entity's modified, not-yet-saved attributes.
- Diagnostics log category `io.jmix.flowui.datacontext.diagnostics` (DEBUG):
  reports every dirty/revert/rebaseline transition, merge-skips of dirty
  attributes, and a once-per-instance notice when a read-only `NoopDataContext`
  receives a `merge()` call.

`isModified`, `getModified`, `setModified`, `clearChanges`, and `hasChanges`
keep their signatures; `isModified` membership is now exact.

## Fixed issues

- #5331 — merge duplicates the owner collection on a bidirectional graph
- #4906 — changes lost when reopening a nested detail view
- #4907 — changes not preserved with deep composition
- #4071 — composition child edit fires no `ChangeEvent`
- #1258 — changes made inside a listener during merge are dropped
- #1409 — detail view always suggests to save after an edit-and-revert
- #532 — adds diagnostics for unwanted "unsaved changes"

## Tests

New `data_components` suites cover the tracker, the merge conflict policy,
diagnostics, and loaded-state behavior, plus `StandardDetailView` cases for the
unsaved-changes prompt. A `DataContextInvariantFuzzTest` generates random
load/merge/edit scenarios and enforces a tiered regression gate over the merge
invariants (slow test, run with `-PincludeSlowTests=true`).
