### PR TITLE
LookupField annotation

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/entity/annotation/LookupField.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/entity/annotation/LookupField.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core.entity.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines which UI component is used for selecting references to an entity.
+ * <p>
+ * On an entity class, applies whenever a reference to this entity is selected in generated UI
+ * (form fields, property filters, etc.). Propagates to subclasses. On a reference attribute,
+ * applies to this attribute only and takes precedence over both the class-level annotation on
+ * the referenced entity and the {@code jmix.ui.component.entity-field-fqn} /
+ * {@code entity-field-actions} application properties. The application properties in turn take
+ * precedence over the class-level annotation.
+ * <p>
+ * With {@link LookupType#DROPDOWN} and no {@link #itemsQuery()}, all instances are loaded
+ * eagerly — suitable for small dictionary entities only. For larger tables configure lazy
+ * loading via {@link #itemsQuery()}. Items are loaded through {@code DataManager}, so
+ * row-level security constraints apply.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.FIELD})
+@MetaAnnotation
+public @interface LookupField {
+
+    LookupType type();
+
+    /**
+     * Optional list of picker action ids registered in the UI module's actions registry,
+     * for example:
+     * <pre>@LookupField(type = LookupType.DROPDOWN, actions = {"entity_lookup", "entity_open"})</pre>
+     */
+    String[] actions() default {};
+
+    /**
+     * Optional query configuration for lazy loading of {@link LookupType#DROPDOWN} items.
+     * Ignored (with a warning in the log) for {@link LookupType#VIEW}.
+     */
+    LookupItemsQuery itemsQuery() default @LookupItemsQuery;
+}

--- a/jmix-core/core/src/main/java/io/jmix/core/entity/annotation/LookupItemsQuery.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/entity/annotation/LookupItemsQuery.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core.entity.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Configures lazy loading of drop-down items for {@link LookupField} with
+ * {@link LookupType#DROPDOWN}. Usable only as the {@link LookupField#itemsQuery()} member.
+ * <p>
+ * Either set an explicit {@link #query()}, or set {@link #byInstanceName()} to match items by
+ * query conditions built from the instance-name metadata of the referenced entity. If neither
+ * is set, items are loaded eagerly.
+ */
+@Target({})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LookupItemsQuery {
+
+    /**
+     * If true, drop-down items are matched by query conditions
+     * ({@link io.jmix.core.querycondition.Condition}) built from the instance-name metadata of
+     * the referenced entity: string-typed instance-name-related attributes are matched with a
+     * case-insensitive {@code contains} condition, combined with {@code or} if there are
+     * several. Works with any data store capable of loading instances, including
+     * non-persistent DTO entities in custom stores. Mutually exclusive with an explicit
+     * {@link #query()} — if both are set, the explicit query wins and a warning is logged.
+     * {@link #searchStringFormat()} and {@link #escapeValueForLike()} do not apply in this mode:
+     * matching is always a case-insensitive substring search with the value escaped for the
+     * underlying {@code like}.
+     */
+    boolean byInstanceName() default false;
+
+    /**
+     * JPQL query with a mandatory {@code :searchString} parameter, for example:
+     * <pre>select e from Customer e where e.name like :searchString escape '\\' order by e.name</pre>
+     * Empty string means "not set". Applies only when {@link #byInstanceName()} is false.
+     */
+    String query() default "";
+
+    /**
+     * Format of the {@code :searchString} parameter value with the {@code ${inputString}}
+     * placeholder for the user input, for example {@code "(?i)%${inputString}%"}.
+     * Empty string means "not set" (raw user input is used). Applies to the explicit
+     * {@link #query()} only; if set together with {@link #byInstanceName()}, it is ignored and
+     * a warning is logged.
+     */
+    String searchStringFormat() default "";
+
+    /**
+     * Whether to escape the user input for use in a {@code like} clause. The query must then
+     * contain the matching {@code escape '\\'} clause. Applies to the explicit {@link #query()}
+     * only; ignored (silently) when {@link #byInstanceName()} is true, where escaping is always
+     * on.
+     */
+    boolean escapeValueForLike() default false;
+
+    /**
+     * Name of a fetch plan of the referenced entity to load items with.
+     * Empty string means "not set" (default is the loader's default fetch plan with an
+     * explicit query; {@code _instance_name} with {@link #byInstanceName()}).
+     */
+    String fetchPlan() default "";
+}

--- a/jmix-core/core/src/main/java/io/jmix/core/entity/annotation/LookupType.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/entity/annotation/LookupType.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.core.entity.annotation;
+
+public enum LookupType {
+    /**
+     * Lookup from a drop-down list.
+     */
+    DROPDOWN,
+    /**
+     * Lookup from a separate view.
+     */
+    VIEW
+}

--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/element/StudioElements.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/element/StudioElements.java
@@ -700,6 +700,10 @@ interface StudioElements {
                     StudioPropertyGroups.RequiredEntityClass.class,
                     StudioPropertyGroups.BaseComboBoxItemsQuery.class,
                     StudioPropertyGroups.FetchPlan.class
+            },
+            properties = {
+                    @StudioProperty(xmlAttribute = "byInstanceName", type = StudioPropertyType.BOOLEAN,
+                            defaultValue = "false", category = StudioProperty.Category.GENERAL)
             })
     void entityItemsQuery();
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/EffectiveLookupConfig.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/EffectiveLookupConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.jmix.flowui.component.factory;
+
+import io.jmix.core.entity.annotation.LookupType;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+/**
+ * The effective, precedence-resolved {@code @LookupField} configuration for one entity reference.
+ * Produced by {@link LookupFieldSupport}; consumed by {@code EntityFieldCreationSupport} (live
+ * component) and {@code ComponentXmlFactory} (XML descriptor).
+ *
+ * @param componentType      resolved component intent, or {@code null} if no {@code @LookupField} applies
+ * @param fieldLevel         {@code true} if the component config came from a field-level annotation
+ * @param actions            resolved action ids (field annotation, then property, then class annotation)
+ * @param itemsMode          items behavior for a {@code DROPDOWN}; ignored for {@code VIEW}
+ * @param query              explicit JPQL for {@link ItemsMode#QUERY}
+ * @param searchStringFormat search-string format for {@link ItemsMode#QUERY}
+ * @param escapeValueForLike escape flag for {@link ItemsMode#QUERY}
+ * @param fetchPlanName       optional fetch plan name for lazy items
+ */
+public record EffectiveLookupConfig(@Nullable LookupType componentType,
+                                    boolean fieldLevel,
+                                    List<String> actions,
+                                    ItemsMode itemsMode,
+                                    @Nullable String query,
+                                    @Nullable String searchStringFormat,
+                                    boolean escapeValueForLike,
+                                    @Nullable String fetchPlanName) {
+
+    /**
+     * How the items of a {@code DROPDOWN} are loaded.
+     */
+    public enum ItemsMode {
+        /** Load all items (no lazy query configured). */
+        EAGER,
+        /** Lazy load via an explicit JPQL query with {@code :searchString}. */
+        QUERY,
+        /** Lazy load via instance-name query conditions. */
+        BY_INSTANCE_NAME
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/EntityFieldCreationSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/EntityFieldCreationSupport.java
@@ -16,11 +16,18 @@
 
 package io.jmix.flowui.component.factory;
 
+import com.google.common.base.Strings;
 import com.vaadin.flow.component.Component;
 import io.jmix.core.*;
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupItemsQuery;
+import io.jmix.core.entity.annotation.LookupType;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.core.metamodel.model.MetaPropertyPath;
+import io.jmix.core.querycondition.Condition;
+import io.jmix.core.querycondition.LogicalCondition;
+import io.jmix.core.querycondition.PropertyCondition;
 import io.jmix.flowui.Actions;
 import io.jmix.flowui.UiComponentProperties;
 import io.jmix.flowui.UiComponents;
@@ -29,20 +36,28 @@ import io.jmix.flowui.action.entitypicker.EntityLookupAction;
 import io.jmix.flowui.action.entitypicker.EntityOpenCompositionAction;
 import io.jmix.flowui.component.ComponentGenerationContext;
 import io.jmix.flowui.component.EntityPickerComponent;
+import io.jmix.flowui.component.SupportsItemsFetchCallback;
 import io.jmix.flowui.component.combobox.EntityComboBox;
 import io.jmix.flowui.component.valuepicker.EntityPicker;
 import io.jmix.flowui.data.SupportsItemsContainer;
 import io.jmix.flowui.model.CollectionContainer;
 import io.jmix.flowui.model.DataComponents;
-import org.springframework.context.ApplicationContext;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationContext;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @SuppressWarnings({"rawtypes"})
 @org.springframework.stereotype.Component("flowui_EntityFieldCreationSupport")
 public class EntityFieldCreationSupport {
+
+    private static final Logger log = LoggerFactory.getLogger(EntityFieldCreationSupport.class);
+
+    protected static final String SEARCH_STRING_PARAMETER_REF = ":searchString";
 
     protected final UiComponents uiComponents;
     protected final Actions actions;
@@ -51,13 +66,17 @@ public class EntityFieldCreationSupport {
     protected final DataComponents dataComponents;
     protected final DataManager dataManager;
     protected final ApplicationContext applicationContext;
+    protected final ItemsFetchCallbackSupport itemsFetchCallbackSupport;
+    protected final FetchPlanRepository fetchPlanRepository;
 
     public EntityFieldCreationSupport(UiComponents uiComponents,
                                       Actions actions,
                                       MetadataTools metadataTools,
                                       UiComponentProperties componentProperties,
                                       DataComponents dataComponents,
-                                      DataManager dataManager, ApplicationContext applicationContext) {
+                                      DataManager dataManager, ApplicationContext applicationContext,
+                                      ItemsFetchCallbackSupport itemsFetchCallbackSupport,
+                                      FetchPlanRepository fetchPlanRepository) {
         this.uiComponents = uiComponents;
         this.actions = actions;
         this.metadataTools = metadataTools;
@@ -65,6 +84,8 @@ public class EntityFieldCreationSupport {
         this.dataComponents = dataComponents;
         this.dataManager = dataManager;
         this.applicationContext = applicationContext;
+        this.itemsFetchCallbackSupport = itemsFetchCallbackSupport;
+        this.fetchPlanRepository = fetchPlanRepository;
     }
 
     @Nullable
@@ -89,11 +110,26 @@ public class EntityFieldCreationSupport {
         MetaClass propertyMetaClass = metaPropertyPath.getMetaProperty().getRange().asClass();
         CollectionContainer<?> collectionItems = context.getCollectionItems();
 
-        EntityPickerComponent field;
-
+        LookupFieldSettings fieldSettings =
+                resolveLookupFieldSettings(metaPropertyPath.getMetaProperty().getAnnotations());
+        LookupFieldSettings classSettings = resolveLookupFieldSettings(propertyMetaClass.getAnnotations());
         String componentFqn = componentProperties.getEntityFieldFqn().get(propertyMetaClass.getName());
 
-        if (componentFqn != null) {
+        // Precedence: field-level annotation > application property > class-level annotation > defaults
+        LookupFieldSettings settings = fieldSettings != null
+                ? fieldSettings
+                : (componentFqn == null ? classSettings : null);
+
+        EntityPickerComponent field;
+        DropdownItemsConfig itemsConfig = null;
+
+        if (settings != null) {
+            itemsConfig = settings.type == LookupType.DROPDOWN && collectionItems == null
+                    ? resolveDropdownItemsConfig(settings.itemsQuery, propertyMetaClass)
+                    : null;
+            field = createComponentByLookupType(
+                    resolveEffectiveLookupType(settings, propertyMetaClass, collectionItems != null));
+        } else if (componentFqn != null) {
             Class<?> aClass = applicationContext.getBean(ClassManager.class).loadClass(componentFqn);
             if (!Component.class.isAssignableFrom(aClass)) {
                 throw new DevelopmentException("Class '%s' is not a component".formatted(componentFqn));
@@ -109,29 +145,40 @@ public class EntityFieldCreationSupport {
         }
 
         if (field instanceof SupportsItemsContainer supportsItemsContainer) {
-            if (collectionItems != null && !collectionItems.getEntityMetaClass().equals(propertyMetaClass)) {
-                throw new IllegalStateException("Wrong collection metaClass provided for container");
+            if (collectionItems != null) {
+                if (!collectionItems.getEntityMetaClass().equals(propertyMetaClass)) {
+                    throw new IllegalStateException("Wrong collection metaClass provided for container");
+                }
+                supportsItemsContainer.setItems(collectionItems);
+            } else if (itemsConfig instanceof QueryItemsConfig queryConfig
+                    && field instanceof SupportsItemsFetchCallback fetchCallbackField) {
+                //noinspection unchecked
+                fetchCallbackField.setItemsFetchCallback(itemsFetchCallbackSupport.createEntityFetchCallback(
+                        propertyMetaClass.getJavaClass(), queryConfig.query(), queryConfig.searchStringFormat(),
+                        queryConfig.escapeValueForLike(), queryConfig.fetchPlan()));
+            } else if (itemsConfig instanceof ConditionItemsConfig conditionConfig
+                    && field instanceof SupportsItemsFetchCallback fetchCallbackField) {
+                //noinspection unchecked
+                fetchCallbackField.setItemsFetchCallback(itemsFetchCallbackSupport.createEntityFetchCallback(
+                        propertyMetaClass.getJavaClass(),
+                        searchString -> buildInstanceNameCondition(conditionConfig.searchProperties(), searchString),
+                        conditionConfig.sort(), conditionConfig.fetchPlan()));
+            } else {
+                supportsItemsContainer.setItems(createCollectionContainer(propertyMetaClass));
             }
-
-            supportsItemsContainer.setItems(
-                    collectionItems != null
-                            ? collectionItems
-                            : createCollectionContainer(propertyMetaClass)
-
-            );
         }
 
         field.setMetaClass(propertyMetaClass);
-        createFieldActions(propertyMetaClass, metaPropertyPath.getMetaProperty().getType(), field, considerComposition);
+        createFieldActions(propertyMetaClass, metaPropertyPath.getMetaProperty().getType(), field,
+                considerComposition, resolveLookupActions(fieldSettings, classSettings, propertyMetaClass));
 
         return (Component) field;
     }
 
     protected void createFieldActions(MetaClass metaClass, MetaProperty.Type metaPropertyType,
-                                      EntityPickerComponent field, boolean considerComposition) {
-        List<String> actionIds = componentProperties.getEntityFieldActions().get(metaClass.getName());
-
-        if (actionIds == null || actionIds.isEmpty()) {
+                                      EntityPickerComponent field, boolean considerComposition,
+                                      List<String> resolvedActionIds) {
+        if (resolvedActionIds.isEmpty()) {
             if (!(field instanceof EntityComboBox)) {
                 if (metaPropertyType == MetaProperty.Type.ASSOCIATION || considerComposition) {
                     field.addAction(actions.create(EntityLookupAction.ID));
@@ -142,10 +189,153 @@ public class EntityFieldCreationSupport {
                 }
             }
         } else {
-            for (String actionId : actionIds) {
+            for (String actionId : resolvedActionIds) {
                 field.addAction(actions.create(actionId));
             }
         }
+    }
+
+    // Precedence: field annotation actions > application property > class annotation actions
+    protected List<String> resolveLookupActions(@Nullable LookupFieldSettings fieldSettings,
+                                                @Nullable LookupFieldSettings classSettings,
+                                                MetaClass propertyMetaClass) {
+        if (fieldSettings != null && !fieldSettings.actions.isEmpty()) {
+            return fieldSettings.actions;
+        }
+        List<String> propertyActions = componentProperties.getEntityFieldActions()
+                .get(propertyMetaClass.getName());
+        if (propertyActions != null && !propertyActions.isEmpty()) {
+            return propertyActions;
+        }
+        if (classSettings != null && !classSettings.actions.isEmpty()) {
+            return classSettings.actions;
+        }
+        return List.of();
+    }
+
+    protected EntityPickerComponent<?> createComponentByLookupType(LookupType type) {
+        return type == LookupType.DROPDOWN
+                ? uiComponents.create(EntityComboBox.class)
+                : uiComponents.create(EntityPicker.class);
+    }
+
+    protected LookupType resolveEffectiveLookupType(LookupFieldSettings settings,
+                                                    MetaClass propertyMetaClass,
+                                                    boolean hasCollectionItems) {
+        if (settings.type == LookupType.VIEW) {
+            if (isItemsQueryConfigured(settings.itemsQuery)) {
+                log.warn("itemsQuery of @LookupField is ignored for type VIEW (entity '{}')",
+                        propertyMetaClass.getName());
+            }
+            return LookupType.VIEW;
+        }
+
+        // DROPDOWN: if the entity has no usable store, items cannot be loaded at all
+        // (eagerly or lazily), degrade to a view lookup which requires no items source
+        if (!hasCollectionItems
+                && Stores.NOOP.equals(propertyMetaClass.getStore().getName())) {
+            log.warn("@LookupField DROPDOWN for entity '{}' degraded to a view lookup: " +
+                    "the entity has no data store to load items from", propertyMetaClass.getName());
+            return LookupType.VIEW;
+        }
+
+        return LookupType.DROPDOWN;
+    }
+
+    protected boolean isItemsQueryConfigured(@Nullable LookupItemsQuery itemsQuery) {
+        return itemsQuery != null && (itemsQuery.byInstanceName() || !itemsQuery.query().isEmpty());
+    }
+
+    @Nullable
+    protected DropdownItemsConfig resolveDropdownItemsConfig(@Nullable LookupItemsQuery itemsQuery,
+                                                             MetaClass metaClass) {
+        if (itemsQuery == null || !isItemsQueryConfigured(itemsQuery)) {
+            return null;
+        }
+
+        String explicitQuery = itemsQuery.query();
+
+        if (itemsQuery.byInstanceName() && !explicitQuery.isEmpty()) {
+            log.warn("Both 'byInstanceName' and 'query' are set in @LookupField itemsQuery " +
+                    "for entity '{}', the explicit query is used", metaClass.getName());
+        }
+
+        if (!explicitQuery.isEmpty()) {
+            if (!explicitQuery.contains(SEARCH_STRING_PARAMETER_REF)) {
+                log.warn("Query in @LookupField itemsQuery for entity '{}' has no {} parameter, " +
+                        "items are loaded eagerly", metaClass.getName(), SEARCH_STRING_PARAMETER_REF);
+                return null;
+            }
+            return new QueryItemsConfig(explicitQuery,
+                    Strings.emptyToNull(itemsQuery.searchStringFormat()),
+                    itemsQuery.escapeValueForLike(),
+                    loadItemsFetchPlan(metaClass, itemsQuery.fetchPlan(), null));
+        }
+
+        // byInstanceName
+        if (!Strings.isNullOrEmpty(itemsQuery.searchStringFormat())) {
+            log.warn("searchStringFormat of @LookupField itemsQuery for entity '{}' is ignored " +
+                    "in byInstanceName mode: matching is always a case-insensitive substring search",
+                    metaClass.getName());
+        }
+        List<String> searchProperties = resolveInstanceNameSearchProperties(metaClass);
+        if (searchProperties.isEmpty()) {
+            log.warn("Cannot build @LookupField items condition for entity '{}': its instance name " +
+                    "is not based on string attributes, items are loaded eagerly", metaClass.getName());
+            return null;
+        }
+        return new ConditionItemsConfig(searchProperties, Sort.by(getInstanceNameSortOrders(metaClass)),
+                loadItemsFetchPlan(metaClass, itemsQuery.fetchPlan(), FetchPlan.INSTANCE_NAME));
+    }
+
+    @Nullable
+    protected FetchPlan loadItemsFetchPlan(MetaClass metaClass, String fetchPlanName,
+                                           @Nullable String defaultFetchPlanName) {
+        String name = Strings.isNullOrEmpty(fetchPlanName) ? defaultFetchPlanName : fetchPlanName;
+        return name == null ? null : fetchPlanRepository.getFetchPlan(metaClass, name);
+    }
+
+    /**
+     * Returns names of string-typed instance-name-related properties of the given metaClass,
+     * used as the search properties for a byInstanceName condition.
+     */
+    protected List<String> resolveInstanceNameSearchProperties(MetaClass metaClass) {
+        return metadataTools.getInstanceNameRelatedProperties(metaClass, true)
+                .stream()
+                .filter(property -> property.getRange().isDatatype()
+                        && String.class.equals(property.getRange().asDatatype().getJavaClass()))
+                .map(MetaProperty::getName)
+                .toList();
+    }
+
+    /**
+     * Builds a case-insensitive substring-match condition over the given search properties,
+     * combined with "or" if there are several.
+     */
+    protected Condition buildInstanceNameCondition(List<String> searchProperties, String searchString) {
+        String escaped = QueryUtils.escapeForLike(searchString);
+        if (searchProperties.size() == 1) {
+            return PropertyCondition.contains(searchProperties.get(0), escaped);
+        }
+        return LogicalCondition.or(searchProperties.stream()
+                .map(property -> (Condition) PropertyCondition.contains(property, escaped))
+                .toArray(Condition[]::new));
+    }
+
+    @Nullable
+    protected LookupFieldSettings resolveLookupFieldSettings(Map<String, Object> annotations) {
+        Map<String, Object> attributes = metadataTools.getMetaAnnotationAttributes(annotations, LookupField.class);
+        if (attributes.isEmpty()) {
+            return null;
+        }
+
+        LookupType type = (LookupType) attributes.get("type");
+        String[] actions = (String[]) attributes.get("actions");
+        LookupItemsQuery itemsQuery = (LookupItemsQuery) attributes.get("itemsQuery");
+
+        return new LookupFieldSettings(type,
+                actions != null ? List.of(actions) : List.of(),
+                itemsQuery);
     }
 
     @SuppressWarnings("unchecked")
@@ -167,5 +357,39 @@ public class EntityFieldCreationSupport {
                 .filter(metaProperty -> !metaProperty.getRange().isClass())
                 .map(metaProperty -> Sort.Order.asc(metaProperty.getName()))
                 .collect(Collectors.toList());
+    }
+
+    protected static class LookupFieldSettings {
+
+        protected final LookupType type;
+        protected final List<String> actions;
+        @Nullable
+        protected final LookupItemsQuery itemsQuery;
+
+        public LookupFieldSettings(LookupType type, List<String> actions, @Nullable LookupItemsQuery itemsQuery) {
+            this.type = type;
+            this.actions = actions;
+            this.itemsQuery = itemsQuery;
+        }
+    }
+
+    /**
+     * Configuration of lazily loaded DROPDOWN items, either built from an explicit JPQL query
+     * ({@link QueryItemsConfig}) or from instance-name-based query conditions
+     * ({@link ConditionItemsConfig}).
+     */
+    protected sealed interface DropdownItemsConfig {
+
+        @Nullable
+        FetchPlan fetchPlan();
+    }
+
+    protected record QueryItemsConfig(String query, @Nullable String searchStringFormat,
+                                      boolean escapeValueForLike, @Nullable FetchPlan fetchPlan)
+            implements DropdownItemsConfig {
+    }
+
+    protected record ConditionItemsConfig(List<String> searchProperties, Sort sort, @Nullable FetchPlan fetchPlan)
+            implements DropdownItemsConfig {
     }
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/EntityFieldCreationSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/EntityFieldCreationSupport.java
@@ -19,15 +19,10 @@ package io.jmix.flowui.component.factory;
 import com.google.common.base.Strings;
 import com.vaadin.flow.component.Component;
 import io.jmix.core.*;
-import io.jmix.core.entity.annotation.LookupField;
-import io.jmix.core.entity.annotation.LookupItemsQuery;
 import io.jmix.core.entity.annotation.LookupType;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.core.metamodel.model.MetaPropertyPath;
-import io.jmix.core.querycondition.Condition;
-import io.jmix.core.querycondition.LogicalCondition;
-import io.jmix.core.querycondition.PropertyCondition;
 import io.jmix.flowui.Actions;
 import io.jmix.flowui.UiComponentProperties;
 import io.jmix.flowui.UiComponents;
@@ -38,6 +33,7 @@ import io.jmix.flowui.component.ComponentGenerationContext;
 import io.jmix.flowui.component.EntityPickerComponent;
 import io.jmix.flowui.component.SupportsItemsFetchCallback;
 import io.jmix.flowui.component.combobox.EntityComboBox;
+import io.jmix.flowui.component.factory.EffectiveLookupConfig.ItemsMode;
 import io.jmix.flowui.component.valuepicker.EntityPicker;
 import io.jmix.flowui.data.SupportsItemsContainer;
 import io.jmix.flowui.model.CollectionContainer;
@@ -48,16 +44,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.ApplicationContext;
 
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @SuppressWarnings({"rawtypes"})
 @org.springframework.stereotype.Component("flowui_EntityFieldCreationSupport")
 public class EntityFieldCreationSupport {
 
     private static final Logger log = LoggerFactory.getLogger(EntityFieldCreationSupport.class);
-
-    protected static final String SEARCH_STRING_PARAMETER_REF = ":searchString";
 
     protected final UiComponents uiComponents;
     protected final Actions actions;
@@ -68,6 +60,7 @@ public class EntityFieldCreationSupport {
     protected final ApplicationContext applicationContext;
     protected final ItemsFetchCallbackSupport itemsFetchCallbackSupport;
     protected final FetchPlanRepository fetchPlanRepository;
+    protected final LookupFieldSupport lookupFieldSupport;
 
     public EntityFieldCreationSupport(UiComponents uiComponents,
                                       Actions actions,
@@ -76,7 +69,8 @@ public class EntityFieldCreationSupport {
                                       DataComponents dataComponents,
                                       DataManager dataManager, ApplicationContext applicationContext,
                                       ItemsFetchCallbackSupport itemsFetchCallbackSupport,
-                                      FetchPlanRepository fetchPlanRepository) {
+                                      FetchPlanRepository fetchPlanRepository,
+                                      LookupFieldSupport lookupFieldSupport) {
         this.uiComponents = uiComponents;
         this.actions = actions;
         this.metadataTools = metadataTools;
@@ -86,6 +80,7 @@ public class EntityFieldCreationSupport {
         this.applicationContext = applicationContext;
         this.itemsFetchCallbackSupport = itemsFetchCallbackSupport;
         this.fetchPlanRepository = fetchPlanRepository;
+        this.lookupFieldSupport = lookupFieldSupport;
     }
 
     @Nullable
@@ -110,25 +105,24 @@ public class EntityFieldCreationSupport {
         MetaClass propertyMetaClass = metaPropertyPath.getMetaProperty().getRange().asClass();
         CollectionContainer<?> collectionItems = context.getCollectionItems();
 
-        LookupFieldSettings fieldSettings =
-                resolveLookupFieldSettings(metaPropertyPath.getMetaProperty().getAnnotations());
-        LookupFieldSettings classSettings = resolveLookupFieldSettings(propertyMetaClass.getAnnotations());
+        EffectiveLookupConfig config = lookupFieldSupport.resolve(
+                metaPropertyPath.getMetaProperty(), propertyMetaClass);
         String componentFqn = componentProperties.getEntityFieldFqn().get(propertyMetaClass.getName());
 
-        // Precedence: field-level annotation > application property > class-level annotation > defaults
-        LookupFieldSettings settings = fieldSettings != null
-                ? fieldSettings
-                : (componentFqn == null ? classSettings : null);
+        // Field-level annotation wins over the entity-field-fqn property; the property wins over a
+        // class-level annotation.
+        boolean useAnnotationComponent = config.componentType() != null
+                && (config.fieldLevel() || componentFqn == null);
 
         EntityPickerComponent field;
         DropdownItemsConfig itemsConfig = null;
 
-        if (settings != null) {
-            itemsConfig = settings.type == LookupType.DROPDOWN && collectionItems == null
-                    ? resolveDropdownItemsConfig(settings.itemsQuery, propertyMetaClass)
+        if (useAnnotationComponent) {
+            itemsConfig = config.componentType() == LookupType.DROPDOWN && collectionItems == null
+                    ? resolveDropdownItemsConfig(config, propertyMetaClass)
                     : null;
             field = createComponentByLookupType(
-                    resolveEffectiveLookupType(settings, propertyMetaClass, collectionItems != null));
+                    resolveEffectiveLookupType(config, propertyMetaClass, collectionItems != null));
         } else if (componentFqn != null) {
             Class<?> aClass = applicationContext.getBean(ClassManager.class).loadClass(componentFqn);
             if (!Component.class.isAssignableFrom(aClass)) {
@@ -161,7 +155,8 @@ public class EntityFieldCreationSupport {
                 //noinspection unchecked
                 fetchCallbackField.setItemsFetchCallback(itemsFetchCallbackSupport.createEntityFetchCallback(
                         propertyMetaClass.getJavaClass(),
-                        searchString -> buildInstanceNameCondition(conditionConfig.searchProperties(), searchString),
+                        searchString -> itemsFetchCallbackSupport.buildInstanceNameCondition(
+                                conditionConfig.searchProperties(), searchString),
                         conditionConfig.sort(), conditionConfig.fetchPlan()));
             } else {
                 supportsItemsContainer.setItems(createCollectionContainer(propertyMetaClass));
@@ -170,7 +165,7 @@ public class EntityFieldCreationSupport {
 
         field.setMetaClass(propertyMetaClass);
         createFieldActions(propertyMetaClass, metaPropertyPath.getMetaProperty().getType(), field,
-                considerComposition, resolveLookupActions(fieldSettings, classSettings, propertyMetaClass));
+                considerComposition, config.actions());
 
         return (Component) field;
     }
@@ -195,38 +190,16 @@ public class EntityFieldCreationSupport {
         }
     }
 
-    // Precedence: field annotation actions > application property > class annotation actions
-    protected List<String> resolveLookupActions(@Nullable LookupFieldSettings fieldSettings,
-                                                @Nullable LookupFieldSettings classSettings,
-                                                MetaClass propertyMetaClass) {
-        if (fieldSettings != null && !fieldSettings.actions.isEmpty()) {
-            return fieldSettings.actions;
-        }
-        List<String> propertyActions = componentProperties.getEntityFieldActions()
-                .get(propertyMetaClass.getName());
-        if (propertyActions != null && !propertyActions.isEmpty()) {
-            return propertyActions;
-        }
-        if (classSettings != null && !classSettings.actions.isEmpty()) {
-            return classSettings.actions;
-        }
-        return List.of();
-    }
-
     protected EntityPickerComponent<?> createComponentByLookupType(LookupType type) {
         return type == LookupType.DROPDOWN
                 ? uiComponents.create(EntityComboBox.class)
                 : uiComponents.create(EntityPicker.class);
     }
 
-    protected LookupType resolveEffectiveLookupType(LookupFieldSettings settings,
+    protected LookupType resolveEffectiveLookupType(EffectiveLookupConfig config,
                                                     MetaClass propertyMetaClass,
                                                     boolean hasCollectionItems) {
-        if (settings.type == LookupType.VIEW) {
-            if (isItemsQueryConfigured(settings.itemsQuery)) {
-                log.warn("itemsQuery of @LookupField is ignored for type VIEW (entity '{}')",
-                        propertyMetaClass.getName());
-            }
+        if (config.componentType() == LookupType.VIEW) {
             return LookupType.VIEW;
         }
 
@@ -242,50 +215,26 @@ public class EntityFieldCreationSupport {
         return LookupType.DROPDOWN;
     }
 
-    protected boolean isItemsQueryConfigured(@Nullable LookupItemsQuery itemsQuery) {
-        return itemsQuery != null && (itemsQuery.byInstanceName() || !itemsQuery.query().isEmpty());
-    }
-
     @Nullable
-    protected DropdownItemsConfig resolveDropdownItemsConfig(@Nullable LookupItemsQuery itemsQuery,
-                                                             MetaClass metaClass) {
-        if (itemsQuery == null || !isItemsQueryConfigured(itemsQuery)) {
-            return null;
+    protected DropdownItemsConfig resolveDropdownItemsConfig(EffectiveLookupConfig config, MetaClass metaClass) {
+        if (config.itemsMode() == ItemsMode.QUERY) {
+            return new QueryItemsConfig(config.query(),
+                    config.searchStringFormat(),
+                    config.escapeValueForLike(),
+                    loadItemsFetchPlan(metaClass, config.fetchPlanName(), null));
         }
-
-        String explicitQuery = itemsQuery.query();
-
-        if (itemsQuery.byInstanceName() && !explicitQuery.isEmpty()) {
-            log.warn("Both 'byInstanceName' and 'query' are set in @LookupField itemsQuery " +
-                    "for entity '{}', the explicit query is used", metaClass.getName());
-        }
-
-        if (!explicitQuery.isEmpty()) {
-            if (!explicitQuery.contains(SEARCH_STRING_PARAMETER_REF)) {
-                log.warn("Query in @LookupField itemsQuery for entity '{}' has no {} parameter, " +
-                        "items are loaded eagerly", metaClass.getName(), SEARCH_STRING_PARAMETER_REF);
+        if (config.itemsMode() == ItemsMode.BY_INSTANCE_NAME) {
+            List<String> searchProperties = itemsFetchCallbackSupport.resolveInstanceNameSearchProperties(metaClass);
+            if (searchProperties.isEmpty()) {
+                log.warn("Cannot build @LookupField items condition for entity '{}': its instance name " +
+                        "is not based on string attributes, items are loaded eagerly", metaClass.getName());
                 return null;
             }
-            return new QueryItemsConfig(explicitQuery,
-                    Strings.emptyToNull(itemsQuery.searchStringFormat()),
-                    itemsQuery.escapeValueForLike(),
-                    loadItemsFetchPlan(metaClass, itemsQuery.fetchPlan(), null));
+            return new ConditionItemsConfig(searchProperties,
+                    Sort.by(itemsFetchCallbackSupport.getInstanceNameSortOrders(metaClass)),
+                    loadItemsFetchPlan(metaClass, config.fetchPlanName(), FetchPlan.INSTANCE_NAME));
         }
-
-        // byInstanceName
-        if (!Strings.isNullOrEmpty(itemsQuery.searchStringFormat())) {
-            log.warn("searchStringFormat of @LookupField itemsQuery for entity '{}' is ignored " +
-                    "in byInstanceName mode: matching is always a case-insensitive substring search",
-                    metaClass.getName());
-        }
-        List<String> searchProperties = resolveInstanceNameSearchProperties(metaClass);
-        if (searchProperties.isEmpty()) {
-            log.warn("Cannot build @LookupField items condition for entity '{}': its instance name " +
-                    "is not based on string attributes, items are loaded eagerly", metaClass.getName());
-            return null;
-        }
-        return new ConditionItemsConfig(searchProperties, Sort.by(getInstanceNameSortOrders(metaClass)),
-                loadItemsFetchPlan(metaClass, itemsQuery.fetchPlan(), FetchPlan.INSTANCE_NAME));
+        return null; // EAGER
     }
 
     @Nullable
@@ -295,49 +244,6 @@ public class EntityFieldCreationSupport {
         return name == null ? null : fetchPlanRepository.getFetchPlan(metaClass, name);
     }
 
-    /**
-     * Returns names of string-typed instance-name-related properties of the given metaClass,
-     * used as the search properties for a byInstanceName condition.
-     */
-    protected List<String> resolveInstanceNameSearchProperties(MetaClass metaClass) {
-        return metadataTools.getInstanceNameRelatedProperties(metaClass, true)
-                .stream()
-                .filter(property -> property.getRange().isDatatype()
-                        && String.class.equals(property.getRange().asDatatype().getJavaClass()))
-                .map(MetaProperty::getName)
-                .toList();
-    }
-
-    /**
-     * Builds a case-insensitive substring-match condition over the given search properties,
-     * combined with "or" if there are several.
-     */
-    protected Condition buildInstanceNameCondition(List<String> searchProperties, String searchString) {
-        String escaped = QueryUtils.escapeForLike(searchString);
-        if (searchProperties.size() == 1) {
-            return PropertyCondition.contains(searchProperties.get(0), escaped);
-        }
-        return LogicalCondition.or(searchProperties.stream()
-                .map(property -> (Condition) PropertyCondition.contains(property, escaped))
-                .toArray(Condition[]::new));
-    }
-
-    @Nullable
-    protected LookupFieldSettings resolveLookupFieldSettings(Map<String, Object> annotations) {
-        Map<String, Object> attributes = metadataTools.getMetaAnnotationAttributes(annotations, LookupField.class);
-        if (attributes.isEmpty()) {
-            return null;
-        }
-
-        LookupType type = (LookupType) attributes.get("type");
-        String[] actions = (String[]) attributes.get("actions");
-        LookupItemsQuery itemsQuery = (LookupItemsQuery) attributes.get("itemsQuery");
-
-        return new LookupFieldSettings(type,
-                actions != null ? List.of(actions) : List.of(),
-                itemsQuery);
-    }
-
     @SuppressWarnings("unchecked")
     protected CollectionContainer createCollectionContainer(MetaClass metaClass) {
         CollectionContainer container = dataComponents.createCollectionContainer(metaClass.getJavaClass());
@@ -345,32 +251,10 @@ public class EntityFieldCreationSupport {
         List list = dataManager.load(metaClass.getJavaClass())
                 .all()
                 .fetchPlan(FetchPlan.INSTANCE_NAME)
-                .sort(Sort.by(getInstanceNameSortOrders(metaClass)))
+                .sort(Sort.by(itemsFetchCallbackSupport.getInstanceNameSortOrders(metaClass)))
                 .list();
         container.setItems(list);
         return container;
-    }
-
-    protected List<Sort.Order> getInstanceNameSortOrders(MetaClass metaClass) {
-        return metadataTools.getInstanceNameRelatedProperties(metaClass, true)
-                .stream()
-                .filter(metaProperty -> !metaProperty.getRange().isClass())
-                .map(metaProperty -> Sort.Order.asc(metaProperty.getName()))
-                .collect(Collectors.toList());
-    }
-
-    protected static class LookupFieldSettings {
-
-        protected final LookupType type;
-        protected final List<String> actions;
-        @Nullable
-        protected final LookupItemsQuery itemsQuery;
-
-        public LookupFieldSettings(LookupType type, List<String> actions, @Nullable LookupItemsQuery itemsQuery) {
-            this.type = type;
-            this.actions = actions;
-            this.itemsQuery = itemsQuery;
-        }
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/ItemsFetchCallbackSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/ItemsFetchCallbackSupport.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.component.factory;
+
+import com.google.common.base.Strings;
+import com.vaadin.flow.data.provider.Query;
+import io.jmix.core.DataManager;
+import io.jmix.core.FetchPlan;
+import io.jmix.core.FluentLoader;
+import io.jmix.core.QueryUtils;
+import io.jmix.core.Sort;
+import io.jmix.core.common.util.ParamsMap;
+import io.jmix.core.querycondition.Condition;
+import io.jmix.flowui.component.SupportsItemsFetchCallback;
+import io.jmix.flowui.sys.substitutor.StringSubstitutor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.util.function.Function;
+
+/**
+ * Creates items fetch callbacks that load entities or scalar values through {@link DataManager}
+ * with offset/limit paging, either from a JPQL query with a {@code :searchString} parameter or
+ * from a {@link Condition} built for each search string.
+ */
+@Component("flowui_ItemsFetchCallbackSupport")
+public class ItemsFetchCallbackSupport {
+
+    protected static final String VALUE_PARAMETER = "value";
+    protected static final String SEARCH_STRING_PARAMETER = "searchString";
+
+    protected final DataManager dataManager;
+    protected final StringSubstitutor stringSubstitutor;
+
+    public ItemsFetchCallbackSupport(DataManager dataManager, StringSubstitutor stringSubstitutor) {
+        this.dataManager = dataManager;
+        this.stringSubstitutor = stringSubstitutor;
+    }
+
+    public <E> SupportsItemsFetchCallback.FetchCallback<E, String> createEntityFetchCallback(
+            Class<E> entityClass, String queryString, @Nullable String searchStringFormat,
+            boolean escapeValueForLike, @Nullable FetchPlan fetchPlan) {
+        return query -> {
+            String searchString = getSearchString(query, searchStringFormat, escapeValueForLike);
+
+            FluentLoader.ByQuery<E> loader = dataManager.load(entityClass)
+                    .query(queryString)
+                    .parameter(SEARCH_STRING_PARAMETER, searchString)
+                    .firstResult(query.getOffset())
+                    .maxResults(query.getLimit());
+            if (fetchPlan != null) {
+                loader.fetchPlan(fetchPlan);
+            }
+
+            return loader.list().stream();
+        };
+    }
+
+    public <E> SupportsItemsFetchCallback.FetchCallback<E, String> createEntityFetchCallback(
+            Class<E> entityClass, Function<String, Condition> conditionBuilder,
+            @Nullable Sort sort, @Nullable FetchPlan fetchPlan) {
+        return query -> {
+            Condition condition = conditionBuilder.apply(query.getFilter().orElse(""));
+
+            FluentLoader.ByCondition<E> loader = dataManager.load(entityClass)
+                    .condition(condition)
+                    .firstResult(query.getOffset())
+                    .maxResults(query.getLimit());
+            if (sort != null) {
+                loader.sort(sort);
+            }
+            if (fetchPlan != null) {
+                loader.fetchPlan(fetchPlan);
+            }
+
+            return loader.list().stream();
+        };
+    }
+
+    public SupportsItemsFetchCallback.FetchCallback<Object, String> createValuesFetchCallback(
+            String queryString, @Nullable String searchStringFormat, boolean escapeValueForLike) {
+        return query -> {
+            String searchString = getSearchString(query, searchStringFormat, escapeValueForLike);
+
+            return dataManager.loadValues(queryString)
+                    .properties(VALUE_PARAMETER)
+                    .parameter(SEARCH_STRING_PARAMETER, searchString)
+                    .firstResult(query.getOffset())
+                    .maxResults(query.getLimit())
+                    .list().stream()
+                    .map(entity -> entity.getValue(VALUE_PARAMETER));
+        };
+    }
+
+    protected String getSearchString(Query<?, String> query,
+                                     @Nullable String searchStringFormat, boolean escapeValue) {
+        String searchString = query.getFilter().orElse("");
+        if (escapeValue) {
+            searchString = QueryUtils.escapeForLike(searchString);
+        }
+
+        if (!Strings.isNullOrEmpty(searchStringFormat)) {
+            searchString = stringSubstitutor.substitute(searchStringFormat,
+                    ParamsMap.of("inputString", searchString));
+        }
+
+        return searchString;
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/ItemsFetchCallbackSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/ItemsFetchCallbackSupport.java
@@ -21,15 +21,21 @@ import com.vaadin.flow.data.provider.Query;
 import io.jmix.core.DataManager;
 import io.jmix.core.FetchPlan;
 import io.jmix.core.FluentLoader;
+import io.jmix.core.MetadataTools;
 import io.jmix.core.QueryUtils;
 import io.jmix.core.Sort;
 import io.jmix.core.common.util.ParamsMap;
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.core.querycondition.Condition;
+import io.jmix.core.querycondition.LogicalCondition;
+import io.jmix.core.querycondition.PropertyCondition;
 import io.jmix.flowui.component.SupportsItemsFetchCallback;
 import io.jmix.flowui.sys.substitutor.StringSubstitutor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -45,10 +51,13 @@ public class ItemsFetchCallbackSupport {
 
     protected final DataManager dataManager;
     protected final StringSubstitutor stringSubstitutor;
+    protected final MetadataTools metadataTools;
 
-    public ItemsFetchCallbackSupport(DataManager dataManager, StringSubstitutor stringSubstitutor) {
+    public ItemsFetchCallbackSupport(DataManager dataManager, StringSubstitutor stringSubstitutor,
+                                     MetadataTools metadataTools) {
         this.dataManager = dataManager;
         this.stringSubstitutor = stringSubstitutor;
+        this.metadataTools = metadataTools;
     }
 
     public <E> SupportsItemsFetchCallback.FetchCallback<E, String> createEntityFetchCallback(
@@ -119,5 +128,43 @@ public class ItemsFetchCallbackSupport {
         }
 
         return searchString;
+    }
+
+    /**
+     * Returns names of string-typed instance-name-related properties of the given metaClass,
+     * used as the search properties for a byInstanceName condition.
+     */
+    public List<String> resolveInstanceNameSearchProperties(MetaClass metaClass) {
+        return metadataTools.getInstanceNameRelatedProperties(metaClass, true)
+                .stream()
+                .filter(property -> property.getRange().isDatatype()
+                        && String.class.equals(property.getRange().asDatatype().getJavaClass()))
+                .map(MetaProperty::getName)
+                .toList();
+    }
+
+    /**
+     * Builds a case-insensitive substring-match condition over the given search properties,
+     * combined with "or" if there are several.
+     */
+    public Condition buildInstanceNameCondition(List<String> searchProperties, String searchString) {
+        String escaped = QueryUtils.escapeForLike(searchString);
+        if (searchProperties.size() == 1) {
+            return PropertyCondition.contains(searchProperties.get(0), escaped);
+        }
+        return LogicalCondition.or(searchProperties.stream()
+                .map(property -> (Condition) PropertyCondition.contains(property, escaped))
+                .toArray(Condition[]::new));
+    }
+
+    /**
+     * Returns ascending sort orders over the non-class instance-name-related properties.
+     */
+    public List<Sort.Order> getInstanceNameSortOrders(MetaClass metaClass) {
+        return metadataTools.getInstanceNameRelatedProperties(metaClass, true)
+                .stream()
+                .filter(metaProperty -> !metaProperty.getRange().isClass())
+                .map(metaProperty -> Sort.Order.asc(metaProperty.getName()))
+                .toList();
     }
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/LookupFieldSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/LookupFieldSupport.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.jmix.flowui.component.factory;
+
+import com.google.common.base.Strings;
+import io.jmix.core.MetadataTools;
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupItemsQuery;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.metamodel.model.MetaProperty;
+import io.jmix.flowui.UiComponentProperties;
+import io.jmix.flowui.component.factory.EffectiveLookupConfig.ItemsMode;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Resolves the effective {@code @LookupField} configuration for an entity reference: annotation
+ * precedence (field annotation, then the {@code entity-field-actions} property, then class
+ * annotation) and the validations that do not depend on runtime context. The single source of truth
+ * shared by {@code EntityFieldCreationSupport} and {@code ComponentXmlFactory}.
+ */
+@Component("flowui_LookupFieldSupport")
+public class LookupFieldSupport {
+
+    private static final Logger log = LoggerFactory.getLogger(LookupFieldSupport.class);
+
+    protected static final String SEARCH_STRING_PARAMETER_REF = ":searchString";
+
+    protected final MetadataTools metadataTools;
+    protected final UiComponentProperties componentProperties;
+
+    public LookupFieldSupport(MetadataTools metadataTools, UiComponentProperties componentProperties) {
+        this.metadataTools = metadataTools;
+        this.componentProperties = componentProperties;
+    }
+
+    /**
+     * Resolves the effective configuration for a reference attribute.
+     *
+     * @param referencingProperty   the attribute that references an entity
+     * @param referencedEntityClass the referenced entity's metaClass
+     */
+    public EffectiveLookupConfig resolve(MetaProperty referencingProperty, MetaClass referencedEntityClass) {
+        LookupFieldSettings fieldSettings = readSettings(referencingProperty.getAnnotations());
+        LookupFieldSettings classSettings = readSettings(referencedEntityClass.getAnnotations());
+        LookupFieldSettings componentSettings = fieldSettings != null ? fieldSettings : classSettings;
+        boolean fieldLevel = fieldSettings != null;
+
+        List<String> actions = resolveActions(fieldSettings, classSettings, referencedEntityClass);
+
+        if (componentSettings == null) {
+            return new EffectiveLookupConfig(null, false, actions, ItemsMode.EAGER,
+                    null, null, false, null);
+        }
+
+        if (componentSettings.type == LookupType.VIEW) {
+            if (isItemsQueryConfigured(componentSettings.itemsQuery)) {
+                log.warn("itemsQuery of @LookupField is ignored for type VIEW (entity '{}')",
+                        referencedEntityClass.getName());
+            }
+            return new EffectiveLookupConfig(LookupType.VIEW, fieldLevel, actions, ItemsMode.EAGER,
+                    null, null, false, null);
+        }
+
+        // DROPDOWN
+        return resolveDropdown(componentSettings.itemsQuery, referencedEntityClass, fieldLevel, actions);
+    }
+
+    protected EffectiveLookupConfig resolveDropdown(@Nullable LookupItemsQuery itemsQuery,
+                                                    MetaClass metaClass, boolean fieldLevel,
+                                                    List<String> actions) {
+        if (itemsQuery == null || !isItemsQueryConfigured(itemsQuery)) {
+            return dropdown(fieldLevel, actions, ItemsMode.EAGER, null, null, false, null);
+        }
+
+        String explicitQuery = itemsQuery.query();
+        if (itemsQuery.byInstanceName() && !explicitQuery.isEmpty()) {
+            log.warn("Both 'byInstanceName' and 'query' are set in @LookupField itemsQuery " +
+                    "for entity '{}', the explicit query is used", metaClass.getName());
+        }
+
+        if (!explicitQuery.isEmpty()) {
+            if (!explicitQuery.contains(SEARCH_STRING_PARAMETER_REF)) {
+                log.warn("Query in @LookupField itemsQuery for entity '{}' has no {} parameter, " +
+                        "items are loaded eagerly", metaClass.getName(), SEARCH_STRING_PARAMETER_REF);
+                return dropdown(fieldLevel, actions, ItemsMode.EAGER, null, null, false, null);
+            }
+            return dropdown(fieldLevel, actions, ItemsMode.QUERY, explicitQuery,
+                    Strings.emptyToNull(itemsQuery.searchStringFormat()),
+                    itemsQuery.escapeValueForLike(),
+                    Strings.emptyToNull(itemsQuery.fetchPlan()));
+        }
+
+        // byInstanceName
+        if (!Strings.isNullOrEmpty(itemsQuery.searchStringFormat())) {
+            log.warn("searchStringFormat of @LookupField itemsQuery for entity '{}' is ignored " +
+                    "in byInstanceName mode: matching is always a case-insensitive substring search",
+                    metaClass.getName());
+        }
+        return dropdown(fieldLevel, actions, ItemsMode.BY_INSTANCE_NAME, null, null, false,
+                Strings.emptyToNull(itemsQuery.fetchPlan()));
+    }
+
+    protected EffectiveLookupConfig dropdown(boolean fieldLevel, List<String> actions, ItemsMode mode,
+                                             @Nullable String query, @Nullable String searchStringFormat,
+                                             boolean escapeValueForLike, @Nullable String fetchPlanName) {
+        return new EffectiveLookupConfig(LookupType.DROPDOWN, fieldLevel, actions, mode,
+                query, searchStringFormat, escapeValueForLike, fetchPlanName);
+    }
+
+    // Precedence: field annotation actions > entity-field-actions property > class annotation actions
+    protected List<String> resolveActions(@Nullable LookupFieldSettings fieldSettings,
+                                          @Nullable LookupFieldSettings classSettings,
+                                          MetaClass referencedEntityClass) {
+        if (fieldSettings != null && !fieldSettings.actions.isEmpty()) {
+            return fieldSettings.actions;
+        }
+        List<String> propertyActions = componentProperties.getEntityFieldActions()
+                .get(referencedEntityClass.getName());
+        if (propertyActions != null && !propertyActions.isEmpty()) {
+            return propertyActions;
+        }
+        if (classSettings != null && !classSettings.actions.isEmpty()) {
+            return classSettings.actions;
+        }
+        return List.of();
+    }
+
+    protected boolean isItemsQueryConfigured(@Nullable LookupItemsQuery itemsQuery) {
+        return itemsQuery != null && (itemsQuery.byInstanceName() || !itemsQuery.query().isEmpty());
+    }
+
+    @Nullable
+    protected LookupFieldSettings readSettings(Map<String, Object> annotations) {
+        Map<String, Object> attributes = metadataTools.getMetaAnnotationAttributes(annotations, LookupField.class);
+        if (attributes.isEmpty()) {
+            return null;
+        }
+        LookupType type = (LookupType) attributes.get("type");
+        String[] actions = (String[]) attributes.get("actions");
+        LookupItemsQuery itemsQuery = (LookupItemsQuery) attributes.get("itemsQuery");
+        return new LookupFieldSettings(type, actions != null ? List.of(actions) : List.of(), itemsQuery);
+    }
+
+    protected static class LookupFieldSettings {
+
+        protected final LookupType type;
+        protected final List<String> actions;
+        @Nullable
+        protected final LookupItemsQuery itemsQuery;
+
+        public LookupFieldSettings(LookupType type, List<String> actions, @Nullable LookupItemsQuery itemsQuery) {
+            this.type = type;
+            this.actions = actions;
+            this.itemsQuery = itemsQuery;
+        }
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/impl/ComponentXmlFactory.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/impl/ComponentXmlFactory.java
@@ -17,15 +17,24 @@
 package io.jmix.flowui.view.template.impl;
 
 import io.jmix.core.FileRef;
+import io.jmix.core.Stores;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.core.metamodel.model.Range;
 import io.jmix.flowui.action.entitypicker.EntityClearAction;
 import io.jmix.flowui.action.entitypicker.EntityLookupAction;
 import io.jmix.flowui.action.entitypicker.EntityOpenCompositionAction;
+import io.jmix.flowui.component.factory.EffectiveLookupConfig;
+import io.jmix.flowui.component.factory.EffectiveLookupConfig.ItemsMode;
+import io.jmix.flowui.component.factory.ItemsFetchCallbackSupport;
+import io.jmix.flowui.component.factory.LookupFieldSupport;
 import jakarta.persistence.Lob;
 import org.dom4j.DocumentHelper;
 import org.dom4j.Element;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.sql.Time;
@@ -35,6 +44,7 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.OffsetTime;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -45,11 +55,24 @@ import java.util.UUID;
 @Component("flowui_ComponentXmlFactory")
 public class ComponentXmlFactory {
 
+    private static final Logger log = LoggerFactory.getLogger(ComponentXmlFactory.class);
+
+    protected final LookupFieldSupport lookupFieldSupport;
+    protected final ItemsFetchCallbackSupport itemsFetchCallbackSupport;
+
+    public ComponentXmlFactory(LookupFieldSupport lookupFieldSupport,
+                                ItemsFetchCallbackSupport itemsFetchCallbackSupport) {
+        this.lookupFieldSupport = lookupFieldSupport;
+        this.itemsFetchCallbackSupport = itemsFetchCallbackSupport;
+    }
+
     /**
      * Creates an XML representation of a UI component for the given entity property.
      * <p>
      * The component type is determined based on the property's range and type. For entity properties,
-     * appropriate actions are added to the entity picker component.
+     * the effective {@code @LookupField} configuration is resolved and used to choose between an
+     * {@code entityComboBox} (with an {@code itemsQuery}) and an {@code entityPicker}, with actions
+     * added accordingly.
      *
      * @param metaProperty    the entity property for which to create a component
      * @param dataContainerId optional data container identifier for data binding, may be null
@@ -68,14 +91,101 @@ public class ComponentXmlFactory {
             return "";
         }
 
-        Element element = createElement(metaProperty);
-        initDataBinding(element, metaProperty, dataContainerId);
-
         if (range.isClass()) {
-            addEntityPickerActions(element, metaProperty);
+            return createReferenceComponentXml(metaProperty, range.asClass(), dataContainerId);
         }
 
+        Element element = createElement(metaProperty);
+        initDataBinding(element, metaProperty, dataContainerId);
         return element.asXML();
+    }
+
+    protected String createReferenceComponentXml(MetaProperty metaProperty, MetaClass referencedEntity,
+                                                  @Nullable String dataContainerId) {
+        EffectiveLookupConfig config = lookupFieldSupport.resolve(metaProperty, referencedEntity);
+
+        if (isDropdown(config, referencedEntity)) {
+            Element element = DocumentHelper.createElement("entityComboBox");
+            initDataBinding(element, metaProperty, dataContainerId);
+            addItemsQuery(element, config, referencedEntity);
+            addResolvedActions(element, config.actions());
+            return element.asXML();
+        }
+
+        Element element = DocumentHelper.createElement("entityPicker");
+        initDataBinding(element, metaProperty, dataContainerId);
+        if (config.actions().isEmpty()) {
+            addDefaultPickerActions(element, metaProperty);
+        } else {
+            addResolvedActions(element, config.actions());
+        }
+        return element.asXML();
+    }
+
+    /**
+     * A DROPDOWN renders as a combobox only when it can source items in XML: the entity must have a
+     * usable store and (for the eager/byInstanceName modes) string instance-name properties. Otherwise
+     * it degrades to a view lookup.
+     */
+    protected boolean isDropdown(EffectiveLookupConfig config, MetaClass referencedEntity) {
+        if (config.componentType() != LookupType.DROPDOWN) {
+            return false;
+        }
+        if (Stores.NOOP.equals(referencedEntity.getStore().getName())) {
+            log.warn("@LookupField DROPDOWN for entity '{}' degraded to a view lookup in a generated view: " +
+                    "the entity has no data store to load items from", referencedEntity.getName());
+            return false;
+        }
+        if (config.itemsMode() != ItemsMode.QUERY
+                && itemsFetchCallbackSupport.resolveInstanceNameSearchProperties(referencedEntity).isEmpty()) {
+            log.warn("@LookupField DROPDOWN for entity '{}' degraded to a view lookup in a generated view: " +
+                    "its instance name is not based on string attributes for lazy loading", referencedEntity.getName());
+            return false;
+        }
+        return true;
+    }
+
+    protected void addItemsQuery(Element element, EffectiveLookupConfig config, MetaClass referencedEntity) {
+        Element itemsQuery = element.addElement("itemsQuery");
+        itemsQuery.addAttribute("class", referencedEntity.getJavaClass().getName());
+        if (config.fetchPlanName() != null) {
+            itemsQuery.addAttribute("fetchPlan", config.fetchPlanName());
+        }
+
+        if (config.itemsMode() == ItemsMode.QUERY) {
+            if (config.searchStringFormat() != null) {
+                itemsQuery.addAttribute("searchStringFormat", config.searchStringFormat());
+            }
+            if (config.escapeValueForLike()) {
+                itemsQuery.addAttribute("escapeValueForLike", Boolean.TRUE.toString());
+            }
+            itemsQuery.addElement("query").addCDATA(config.query());
+        } else {
+            // EAGER and BY_INSTANCE_NAME both render as an instance-name lazy query
+            itemsQuery.addAttribute("byInstanceName", Boolean.TRUE.toString());
+        }
+    }
+
+    protected void addResolvedActions(Element element, List<String> actionIds) {
+        if (actionIds.isEmpty()) {
+            return;
+        }
+        Element actions = element.addElement("actions");
+        for (String actionId : actionIds) {
+            addAction(actions, actionId, actionId);
+        }
+    }
+
+    protected void addDefaultPickerActions(Element element, MetaProperty metaProperty) {
+        if (metaProperty.getType() == MetaProperty.Type.ASSOCIATION) {
+            Element actions = element.addElement("actions");
+            addAction(actions, "entityLookup", EntityLookupAction.ID);
+            addAction(actions, "entityClear", EntityClearAction.ID);
+        } else if (metaProperty.getType() == MetaProperty.Type.COMPOSITION) {
+            Element actions = element.addElement("actions");
+            addAction(actions, "entityOpenComposition", EntityOpenCompositionAction.ID);
+            addAction(actions, "entityClear", EntityClearAction.ID);
+        }
     }
 
     protected Element createElement(MetaProperty metaProperty) {
@@ -83,8 +193,6 @@ public class ComponentXmlFactory {
 
         if (range.isDatatype()) {
             return DocumentHelper.createElement(getDatatypeComponentName(metaProperty));
-        } else if (range.isClass()) {
-            return DocumentHelper.createElement("entityPicker");
         } else if (range.isEnum()) {
             return DocumentHelper.createElement("select");
         }
@@ -131,18 +239,6 @@ public class ComponentXmlFactory {
         if ("fileStorageUploadField".equals(element.getName()) || "fileUploadField".equals(element.getName())) {
             element.addAttribute("fileNameVisible", Boolean.TRUE.toString());
             element.addAttribute("clearButtonVisible", Boolean.TRUE.toString());
-        }
-    }
-
-    protected void addEntityPickerActions(Element element, MetaProperty metaProperty) {
-        if (metaProperty.getType() == MetaProperty.Type.ASSOCIATION) {
-            Element actions = element.addElement("actions");
-            addAction(actions, "entityLookup", EntityLookupAction.ID);
-            addAction(actions, "entityClear", EntityClearAction.ID);
-        } else if (metaProperty.getType() == MetaProperty.Type.COMPOSITION) {
-            Element actions = element.addElement("actions");
-            addAction(actions, "entityOpenComposition", EntityOpenCompositionAction.ID);
-            addAction(actions, "entityClear", EntityClearAction.ID);
         }
     }
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/impl/ComponentXmlFactory.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/impl/ComponentXmlFactory.java
@@ -17,6 +17,7 @@
 package io.jmix.flowui.view.template.impl;
 
 import io.jmix.core.FileRef;
+import io.jmix.core.MetadataTools;
 import io.jmix.core.Stores;
 import io.jmix.core.entity.annotation.LookupType;
 import io.jmix.core.metamodel.model.MetaClass;
@@ -46,6 +47,7 @@ import java.time.OffsetTime;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Factory for creating XML representations of UI components based on entity metadata properties.
@@ -59,11 +61,14 @@ public class ComponentXmlFactory {
 
     protected final LookupFieldSupport lookupFieldSupport;
     protected final ItemsFetchCallbackSupport itemsFetchCallbackSupport;
+    protected final MetadataTools metadataTools;
 
     public ComponentXmlFactory(LookupFieldSupport lookupFieldSupport,
-                                ItemsFetchCallbackSupport itemsFetchCallbackSupport) {
+                                ItemsFetchCallbackSupport itemsFetchCallbackSupport,
+                                MetadataTools metadataTools) {
         this.lookupFieldSupport = lookupFieldSupport;
         this.itemsFetchCallbackSupport = itemsFetchCallbackSupport;
+        this.metadataTools = metadataTools;
     }
 
     /**
@@ -71,8 +76,9 @@ public class ComponentXmlFactory {
      * <p>
      * The component type is determined based on the property's range and type. For entity properties,
      * the effective {@code @LookupField} configuration is resolved and used to choose between an
-     * {@code entityComboBox} (with an {@code itemsQuery}) and an {@code entityPicker}, with actions
-     * added accordingly.
+     * {@code entityComboBox} and an {@code entityPicker}, with actions added accordingly. An eager
+     * {@code entityComboBox} is bound to a data container via {@code itemsContainer} (see
+     * {@link #createItemsContainerXml(MetaProperty)}); a lazy one carries an {@code itemsQuery}.
      *
      * @param metaProperty    the entity property for which to create a component
      * @param dataContainerId optional data container identifier for data binding, may be null
@@ -107,7 +113,11 @@ public class ComponentXmlFactory {
         if (isDropdown(config, referencedEntity)) {
             Element element = DocumentHelper.createElement("entityComboBox");
             initDataBinding(element, metaProperty, dataContainerId);
-            addItemsQuery(element, config, referencedEntity);
+            if (config.itemsMode() == ItemsMode.EAGER) {
+                element.addAttribute("itemsContainer", itemsContainerId(metaProperty));
+            } else {
+                addItemsQuery(element, config, referencedEntity);
+            }
             addResolvedActions(element, config.actions());
             return element.asXML();
         }
@@ -124,8 +134,8 @@ public class ComponentXmlFactory {
 
     /**
      * A DROPDOWN renders as a combobox only when it can source items in XML: the entity must have a
-     * usable store and (for the eager/byInstanceName modes) string instance-name properties. Otherwise
-     * it degrades to a view lookup.
+     * usable store and, for the byInstanceName mode, string instance-name properties. Otherwise it
+     * degrades to a view lookup.
      */
     protected boolean isDropdown(EffectiveLookupConfig config, MetaClass referencedEntity) {
         if (config.componentType() != LookupType.DROPDOWN) {
@@ -136,13 +146,65 @@ public class ComponentXmlFactory {
                     "the entity has no data store to load items from", referencedEntity.getName());
             return false;
         }
-        if (config.itemsMode() != ItemsMode.QUERY
+        if (config.itemsMode() == ItemsMode.BY_INSTANCE_NAME
                 && itemsFetchCallbackSupport.resolveInstanceNameSearchProperties(referencedEntity).isEmpty()) {
-            log.warn("@LookupField DROPDOWN for entity '{}' degraded to a view lookup in a generated view: " +
-                    "its instance name is not based on string attributes for lazy loading", referencedEntity.getName());
+            log.warn("@LookupField byInstanceName DROPDOWN for entity '{}' degraded to a view lookup in a " +
+                    "generated view: its instance name is not based on string attributes", referencedEntity.getName());
             return false;
         }
         return true;
+    }
+
+    protected boolean isEagerDropdown(EffectiveLookupConfig config, MetaClass referencedEntity) {
+        return config.itemsMode() == ItemsMode.EAGER && isDropdown(config, referencedEntity);
+    }
+
+    protected String itemsContainerId(MetaProperty metaProperty) {
+        return metaProperty.getName() + "ItemsDc";
+    }
+
+    /**
+     * Creates the top-level {@code collection} data container XML that backs an eager
+     * {@code entityComboBox} generated for the given reference property, or an empty string if the
+     * property is not an eager dropdown. For JPA entities the loader carries a JPQL query ordered by the
+     * instance name; for non-JPA entities the query is omitted and the store loads all instances.
+     *
+     * @param metaProperty a single-value entity reference property
+     * @return the {@code <collection>} XML, or {@code ""} if not an eager dropdown
+     */
+    public String createItemsContainerXml(MetaProperty metaProperty) {
+        Range range = metaProperty.getRange();
+        if (!range.isClass()) {
+            return "";
+        }
+        MetaClass referencedEntity = range.asClass();
+        EffectiveLookupConfig config = lookupFieldSupport.resolve(metaProperty, referencedEntity);
+        if (!isEagerDropdown(config, referencedEntity)) {
+            return "";
+        }
+
+        String containerId = itemsContainerId(metaProperty);
+        Element collection = DocumentHelper.createElement("collection");
+        collection.addAttribute("id", containerId);
+        collection.addAttribute("class", referencedEntity.getJavaClass().getName());
+        collection.addElement("fetchPlan").addAttribute("extends", "_instance_name");
+
+        Element loader = collection.addElement("loader");
+        loader.addAttribute("id", metaProperty.getName() + "ItemsDl");
+        loader.addAttribute("readOnly", Boolean.TRUE.toString());
+
+        if (metadataTools.isJpaEntity(referencedEntity)) {
+            loader.addElement("query").addCDATA(buildItemsQuery(referencedEntity));
+        }
+        return collection.asXML();
+    }
+
+    protected String buildItemsQuery(MetaClass referencedEntity) {
+        String orderBy = itemsFetchCallbackSupport.getInstanceNameSortOrders(referencedEntity).stream()
+                .map(order -> "e." + order.getProperty())
+                .collect(Collectors.joining(", "));
+        String query = "select e from " + referencedEntity.getName() + " e";
+        return orderBy.isEmpty() ? query : query + " order by " + orderBy;
     }
 
     protected void addItemsQuery(Element element, EffectiveLookupConfig config, MetaClass referencedEntity) {
@@ -161,7 +223,7 @@ public class ComponentXmlFactory {
             }
             itemsQuery.addElement("query").addCDATA(config.query());
         } else {
-            // EAGER and BY_INSTANCE_NAME both render as an instance-name lazy query
+            // BY_INSTANCE_NAME
             itemsQuery.addAttribute("byInstanceName", Boolean.TRUE.toString());
         }
     }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/support/DataLoaderSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/support/DataLoaderSupport.java
@@ -33,6 +33,7 @@ import io.jmix.flowui.model.CollectionContainer;
 import io.jmix.flowui.model.InstanceContainer;
 import io.jmix.flowui.xml.layout.ComponentLoader.Context;
 import io.jmix.flowui.xml.layout.LoaderResolver;
+import io.jmix.core.metamodel.model.MetaClass;
 import org.dom4j.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,7 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.annotation.Scope;
 import org.jspecify.annotations.Nullable;
 
+import java.util.List;
 import java.util.Optional;
 
 @org.springframework.stereotype.Component("flowui_DataLoaderSupport")
@@ -191,15 +193,51 @@ public class DataLoaderSupport implements ApplicationContextAware {
     @SuppressWarnings({"rawtypes", "unchecked"})
     protected void loadEntityItemsQueryInternal(SupportsItemsFetchCallback<?, String> component,
                                                 Element itemsElement, Class<?> entityClass) {
+        ItemsFetchCallbackSupport callbackSupport = applicationContext.getBean(ItemsFetchCallbackSupport.class);
+        boolean byInstanceName = loaderSupport.loadBoolean(itemsElement, "byInstanceName").orElse(false);
+
+        if (byInstanceName) {
+            loadByInstanceNameItemsQuery(component, itemsElement, entityClass, callbackSupport);
+            return;
+        }
+
         String queryString = loadQuery((Component) component, itemsElement);
         String searchStringFormat = loadSearchStringFormat(itemsElement);
         boolean escapeValue = loadEscapeValueForLike(itemsElement);
-
         FetchPlan fetchPlan = loadFetchPlan(itemsElement, entityClass);
 
-        ItemsFetchCallbackSupport callbackSupport = applicationContext.getBean(ItemsFetchCallbackSupport.class);
         component.setItemsFetchCallback((SupportsItemsFetchCallback.FetchCallback) callbackSupport
                 .createEntityFetchCallback(entityClass, queryString, searchStringFormat, escapeValue, fetchPlan));
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    protected void loadByInstanceNameItemsQuery(SupportsItemsFetchCallback<?, String> component,
+                                                Element itemsElement, Class<?> entityClass,
+                                                ItemsFetchCallbackSupport callbackSupport) {
+        if (loadSearchStringFormat(itemsElement) != null || loadEscapeValueForLike(itemsElement)) {
+            log.warn("'searchStringFormat' and 'escapeValueForLike' are ignored for a byInstanceName " +
+                    "itemsQuery of component '{}'", ((Component) component).getId().orElse("null"));
+        }
+
+        MetaClass metaClass = metadata.getClass(entityClass);
+        List<String> searchProperties = callbackSupport.resolveInstanceNameSearchProperties(metaClass);
+        if (searchProperties.isEmpty()) {
+            log.warn("byInstanceName itemsQuery of component '{}' for entity '{}' has no string " +
+                    "instance-name properties, items are not loaded lazily",
+                    ((Component) component).getId().orElse("null"), metaClass.getName());
+            return;
+        }
+
+        FetchPlan fetchPlan = loadFetchPlan(itemsElement, entityClass);
+        if (fetchPlan == null) {
+            fetchPlan = fetchPlanRepository.getFetchPlan(metaClass, FetchPlan.INSTANCE_NAME);
+        }
+        Sort sort = Sort.by(callbackSupport.getInstanceNameSortOrders(metaClass));
+
+        component.setItemsFetchCallback((SupportsItemsFetchCallback.FetchCallback) callbackSupport
+                .createEntityFetchCallback(entityClass,
+                        searchString -> callbackSupport.buildInstanceNameCondition(searchProperties, searchString),
+                        sort, fetchPlan));
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/support/DataLoaderSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/support/DataLoaderSupport.java
@@ -18,13 +18,12 @@ package io.jmix.flowui.xml.layout.support;
 
 import com.google.common.base.Strings;
 import com.vaadin.flow.component.Component;
-import com.vaadin.flow.data.provider.Query;
 import io.jmix.core.*;
-import io.jmix.core.common.util.ParamsMap;
 import io.jmix.core.common.util.ReflectionHelper;
 import io.jmix.core.impl.FetchPlanLoader;
 import io.jmix.flowui.component.HasDataComponents;
 import io.jmix.flowui.component.SupportsItemsFetchCallback;
+import io.jmix.flowui.component.factory.ItemsFetchCallbackSupport;
 import io.jmix.flowui.data.SupportsItemsContainer;
 import io.jmix.flowui.data.SupportsItemsEnum;
 import io.jmix.flowui.data.SupportsValueSource;
@@ -32,7 +31,6 @@ import io.jmix.flowui.data.value.ContainerValueSource;
 import io.jmix.flowui.exception.GuiDevelopmentException;
 import io.jmix.flowui.model.CollectionContainer;
 import io.jmix.flowui.model.InstanceContainer;
-import io.jmix.flowui.sys.substitutor.StringSubstitutor;
 import io.jmix.flowui.xml.layout.ComponentLoader.Context;
 import io.jmix.flowui.xml.layout.LoaderResolver;
 import org.dom4j.Element;
@@ -54,7 +52,6 @@ public class DataLoaderSupport implements ApplicationContextAware {
     private static final Logger log = LoggerFactory.getLogger(DataLoaderSupport.class);
 
     protected static final String ITEMS_QUERY_ELEMENT = "itemsQuery";
-    protected static final String VALUE_PARAMETER = "value";
 
     protected Context context;
     protected ApplicationContext applicationContext;
@@ -200,21 +197,9 @@ public class DataLoaderSupport implements ApplicationContextAware {
 
         FetchPlan fetchPlan = loadFetchPlan(itemsElement, entityClass);
 
-        DataManager dataManager = applicationContext.getBean(DataManager.class);
-        component.setItemsFetchCallback(query -> {
-            String searchString = getSearchString(query, searchStringFormat, escapeValue);
-
-            FluentLoader.ByQuery loader = dataManager.load(entityClass)
-                    .query(queryString)
-                    .parameter("searchString", searchString)
-                    .firstResult(query.getOffset())
-                    .maxResults(query.getLimit());
-            if (fetchPlan != null) {
-                loader.fetchPlan(fetchPlan);
-            }
-
-            return loader.list().stream();
-        });
+        ItemsFetchCallbackSupport callbackSupport = applicationContext.getBean(ItemsFetchCallbackSupport.class);
+        component.setItemsFetchCallback((SupportsItemsFetchCallback.FetchCallback) callbackSupport
+                .createEntityFetchCallback(entityClass, queryString, searchStringFormat, escapeValue, fetchPlan));
     }
 
     /**
@@ -234,24 +219,16 @@ public class DataLoaderSupport implements ApplicationContextAware {
         loadValueItemsQueryInternal(component, itemsElement);
     }
 
+    @SuppressWarnings("unchecked")
     protected void loadValueItemsQueryInternal(SupportsItemsFetchCallback<?, String> component,
                                                Element itemsElement) {
         String queryString = loadQuery((Component) component, itemsElement);
         String searchStringFormat = loadSearchStringFormat(itemsElement);
         boolean escapeValue = loadEscapeValueForLike(itemsElement);
 
-        DataManager dataManager = applicationContext.getBean(DataManager.class);
-        component.setItemsFetchCallback(query -> {
-            String searchString = getSearchString(query, searchStringFormat, escapeValue);
-
-            return dataManager.loadValues(queryString)
-                    .properties(VALUE_PARAMETER)
-                    .parameter("searchString", searchString)
-                    .firstResult(query.getOffset())
-                    .maxResults(query.getLimit())
-                    .list().stream()
-                    .map(entity -> entity.getValue(VALUE_PARAMETER));
-        });
+        ItemsFetchCallbackSupport callbackSupport = applicationContext.getBean(ItemsFetchCallbackSupport.class);
+        ((SupportsItemsFetchCallback<Object, String>) component).setItemsFetchCallback(
+                callbackSupport.createValuesFetchCallback(queryString, searchStringFormat, escapeValue));
     }
 
     protected String loadQuery(Component component, Element itemsElement) {
@@ -303,21 +280,6 @@ public class DataLoaderSupport implements ApplicationContextAware {
                         fetchPlanRepository.getFetchPlan(metaClass, fetchPlanName));
 
         return builder.build();
-    }
-
-    protected String getSearchString(Query<?, String> query,
-                                     @Nullable String searchStringFormat, boolean escapeValue) {
-        String searchString = query.getFilter().orElse("");
-        if (escapeValue) {
-            searchString = QueryUtils.escapeForLike(searchString);
-        }
-
-        if (!Strings.isNullOrEmpty(searchStringFormat)) {
-            StringSubstitutor substitutor = applicationContext.getBean(StringSubstitutor.class);
-            searchString = substitutor.substitute(searchStringFormat, ParamsMap.of("inputString", searchString));
-        }
-
-        return searchString;
     }
 
     public <E> void loadItemsContainer(SupportsItemsContainer<E> component, Element element) {

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
@@ -3031,7 +3031,7 @@
 
     <xs:complexType name="baseComboBoxItemsQueryType">
         <xs:sequence>
-            <xs:element name="query"/>
+            <xs:element name="query" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="searchStringFormat" type="xs:string"/>
         <xs:attribute name="escapeValueForLike" type="xs:boolean"/>
@@ -3051,6 +3051,7 @@
                 </xs:sequence>
                 <xs:attribute name="class" type="xs:string" use="required"/>
                 <xs:attribute name="fetchPlan" type="xs:string"/>
+                <xs:attribute name="byInstanceName" type="xs:boolean"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/template/detail-view.ftl
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/template/detail-view.ftl
@@ -27,6 +27,9 @@
             </#list>
             <loader/>
         </instance>
+        <#list properties as property>
+        ${componentXmlFactory.createItemsContainerXml(property)}
+        </#list>
     </data>
     <facets>
         <dataLoadCoordinator auto="true"/>

--- a/jmix-flowui/flowui/src/test/groovy/component_xml_load/EntityComboBoxByInstanceNameXmlLoadTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component_xml_load/EntityComboBoxByInstanceNameXmlLoadTest.groovy
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component_xml_load
+
+import com.vaadin.flow.data.provider.BackEndDataProvider
+import com.vaadin.flow.data.provider.Query
+import component_xml_load.screen.LfProductByInstanceNameView
+import io.jmix.core.DataManager
+import io.jmix.core.security.SystemAuthenticator
+import io.jmix.flowui.component.combobox.EntityComboBox
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import test_support.entity.lookup_field.LfProduct
+import test_support.spec.FlowuiTestSpecification
+
+@SpringBootTest
+class EntityComboBoxByInstanceNameXmlLoadTest extends FlowuiTestSpecification {
+
+    @Autowired
+    DataManager dataManager
+
+    @Autowired
+    SystemAuthenticator systemAuthenticator
+
+    @Autowired
+    JdbcTemplate jdbcTemplate
+
+    @Override
+    void setup() {
+        registerViewBasePackages("component_xml_load.screen")
+    }
+
+    @Override
+    void cleanup() {
+        jdbcTemplate.execute("delete from TEST_LF_PRODUCT")
+    }
+
+    def "byInstanceName itemsQuery loaded from XML produces lazy callback that filters by instance name"() {
+        setup:
+        systemAuthenticator.runWithSystem {
+            ['Apple', 'Apricot', 'Banana'].each { name ->
+                def p = dataManager.create(LfProduct)
+                p.name = name
+                dataManager.save(p)
+            }
+        }
+
+        when: "Open the view containing an entityComboBox with a byInstanceName itemsQuery"
+        def view = navigateToView(LfProductByInstanceNameView)
+        def field = view.productField as EntityComboBox<LfProduct>
+
+        then: "the field uses a back-end data provider"
+        field.dataProvider instanceof BackEndDataProvider
+
+        when: "fetching with a search string"
+        def items = systemAuthenticator.withSystem {
+            field.dataProvider.fetch(new Query(0, 10, null, null, 'ap')).toList()
+        }
+
+        then: "only items whose instance name matches the search string are returned"
+        items*.name == ['Apple', 'Apricot']
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/generation_strategy/ItemsFetchCallbackSupportTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/generation_strategy/ItemsFetchCallbackSupportTest.groovy
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generation_strategy
+
+import com.vaadin.flow.data.provider.Query
+import io.jmix.core.DataManager
+import io.jmix.core.security.SystemAuthenticator
+import io.jmix.flowui.component.factory.ItemsFetchCallbackSupport
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import test_support.entity.sales.Customer
+import test_support.spec.FlowuiTestSpecification
+
+@SpringBootTest
+class ItemsFetchCallbackSupportTest extends FlowuiTestSpecification {
+
+    @Autowired
+    ItemsFetchCallbackSupport itemsFetchCallbackSupport
+    @Autowired
+    DataManager dataManager
+    @Autowired
+    SystemAuthenticator systemAuthenticator
+    @Autowired
+    JdbcTemplate jdbcTemplate
+
+    void setup() {
+        systemAuthenticator.runWithSystem {
+            ['Mario', 'Maria', 'Bruno'].each { name ->
+                def customer = dataManager.create(Customer)
+                customer.name = name
+                dataManager.save(customer)
+            }
+        }
+    }
+
+    void cleanup() {
+        jdbcTemplate.execute('delete from TEST_CUSTOMER')
+    }
+
+    def "entity fetch callback filters and pages"() {
+        def callback = itemsFetchCallbackSupport.createEntityFetchCallback(
+                Customer,
+                "select e from test_Customer e where e.name like :searchString escape '\\' order by e.name",
+                '(?i)%${inputString}%',
+                true,
+                null)
+
+        when: "filtering by substring"
+        def items = systemAuthenticator.withSystem {
+            callback.fetch(new Query<Customer, String>(0, 10, null, null, 'mar')).toList()
+        }
+
+        then:
+        items*.name == ['Maria', 'Mario']
+
+        when: "paging is applied"
+        def page = systemAuthenticator.withSystem {
+            callback.fetch(new Query<Customer, String>(1, 1, null, null, 'mar')).toList()
+        }
+
+        then:
+        page*.name == ['Mario']
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/generation_strategy/LookupFieldAnnotationGenerationTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/generation_strategy/LookupFieldAnnotationGenerationTest.groovy
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generation_strategy
+
+import com.vaadin.flow.data.provider.BackEndDataProvider
+import com.vaadin.flow.data.provider.Query
+import io.jmix.core.DataManager
+import io.jmix.core.Metadata
+import io.jmix.core.security.SystemAuthenticator
+import io.jmix.flowui.UiComponentProperties
+import io.jmix.flowui.component.ComponentGenerationContext
+import io.jmix.flowui.component.UiComponentsGenerator
+import io.jmix.flowui.component.combobox.EntityComboBox
+import io.jmix.flowui.component.valuepicker.EntityPicker
+import io.jmix.flowui.data.value.ContainerValueSource
+import io.jmix.flowui.model.DataComponents
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import test_support.entity.lookup_field.LfMemNote
+import test_support.entity.lookup_field.LfMemNoteHolder
+import test_support.entity.lookup_field.LfNoteHolder
+import test_support.entity.lookup_field.LfOrder
+import test_support.entity.lookup_field.LfPerson
+import test_support.entity.lookup_field.LfProduct
+import test_support.entity.lookup_field.LfSupplier
+import test_support.spec.FlowuiTestSpecification
+
+@SpringBootTest
+class LookupFieldAnnotationGenerationTest extends FlowuiTestSpecification {
+
+    @Autowired
+    UiComponentsGenerator uiComponentsGenerator
+    @Autowired
+    Metadata metadata
+    @Autowired
+    DataComponents dataComponents
+    @Autowired
+    UiComponentProperties componentProperties
+    @Autowired
+    DataManager dataManager
+    @Autowired
+    SystemAuthenticator systemAuthenticator
+    @Autowired
+    JdbcTemplate jdbcTemplate
+
+    void cleanup() {
+        componentProperties.entityFieldFqn.remove('test_LfCity')
+        componentProperties.entityFieldActions.remove('test_LfCity')
+    }
+
+    protected generate(String property) {
+        def metaClass = metadata.getClass(LfOrder)
+        def context = new ComponentGenerationContext(metaClass, property)
+        def container = dataComponents.createInstanceContainer(LfOrder)
+        context.setValueSource(new ContainerValueSource(container, property))
+        return uiComponentsGenerator.generate(context)
+    }
+
+    def "class-level DROPDOWN produces EntityComboBox"() {
+        expect:
+        generate('country') instanceof EntityComboBox
+    }
+
+    def "field-level annotation beats class-level annotation"() {
+        expect:
+        generate('viewCountry') instanceof EntityPicker
+        generate('dropdownCity') instanceof EntityComboBox
+    }
+
+    def "class-level VIEW produces EntityPicker with annotation actions"() {
+        when:
+        def field = generate('city')
+
+        then:
+        field instanceof EntityPicker
+        (field as EntityPicker).actions*.id == ['entity_lookup', 'entity_open', 'entity_clear']
+    }
+
+    def "application property beats class-level annotation"() {
+        when:
+        componentProperties.entityFieldFqn['test_LfCity'] =
+                'io.jmix.flowui.component.combobox.EntityComboBox'
+        def field = generate('city')
+
+        then:
+        field instanceof EntityComboBox
+    }
+
+    def "field-level annotation beats application property"() {
+        when:
+        componentProperties.entityFieldFqn['test_LfCity'] =
+                'io.jmix.flowui.component.combobox.EntityComboBox'
+        def field = generate('viewCity')
+
+        then:
+        field instanceof EntityPicker
+        (field as EntityPicker).actions*.id == ['entity_open']
+    }
+
+    def "property actions beat class-level annotation actions"() {
+        when:
+        componentProperties.entityFieldActions['test_LfCity'] = ['entity_clear']
+        def field = generate('city')
+
+        then:
+        (field as EntityPicker).actions*.id == ['entity_clear']
+    }
+
+    def "field-level annotation actions beat property actions"() {
+        when:
+        componentProperties.entityFieldActions['test_LfCity'] = ['entity_clear']
+        def field = generate('viewCity')
+
+        then:
+        (field as EntityPicker).actions*.id == ['entity_open']
+    }
+
+    def "byInstanceName produces lazy callback that filters by instance name"() {
+        setup:
+        systemAuthenticator.runWithSystem {
+            ['Apple', 'Apricot', 'Banana'].each { name ->
+                def p = dataManager.create(LfProduct)
+                p.name = name
+                dataManager.save(p)
+            }
+        }
+
+        when:
+        def field = generate('product') as EntityComboBox
+
+        then:
+        field.dataProvider instanceof BackEndDataProvider
+
+        when:
+        def items = systemAuthenticator.withSystem {
+            field.dataProvider.fetch(new Query(0, 10, null, null, 'ap')).toList()
+        }
+
+        then:
+        items*.name == ['Apple', 'Apricot']
+
+        cleanup:
+        jdbcTemplate.execute('delete from TEST_LF_PRODUCT')
+    }
+
+    def "byInstanceName with searchStringFormat ignores the format"() {
+        setup: "LfProduct also configures a searchStringFormat, which must be ignored"
+        systemAuthenticator.runWithSystem {
+            ['Apple', 'Apricot', 'Banana'].each { name ->
+                def p = dataManager.create(LfProduct)
+                p.name = name
+                dataManager.save(p)
+            }
+        }
+
+        when:
+        def field = generate('product') as EntityComboBox
+        def items = systemAuthenticator.withSystem {
+            field.dataProvider.fetch(new Query(0, 10, null, null, 'ap')).toList()
+        }
+
+        then: "matching is a plain case-insensitive substring search regardless of searchStringFormat"
+        items*.name == ['Apple', 'Apricot']
+
+        cleanup:
+        jdbcTemplate.execute('delete from TEST_LF_PRODUCT')
+    }
+
+    def "byInstanceName works for DTO entity in a custom data store"() {
+        setup:
+        def notes = []
+        systemAuthenticator.runWithSystem {
+            ['Alpha note', 'Beta note', 'Alphabet'].each { t ->
+                def n = dataManager.create(LfMemNote)
+                n.title = t
+                dataManager.save(n)
+                notes << n
+            }
+        }
+
+        when:
+        def metaClass = metadata.getClass(LfMemNoteHolder)
+        def context = new ComponentGenerationContext(metaClass, 'note')
+        def container = dataComponents.createInstanceContainer(LfMemNoteHolder)
+        context.setValueSource(new ContainerValueSource(container, 'note'))
+        def field = uiComponentsGenerator.generate(context) as EntityComboBox
+
+        then:
+        field.dataProvider instanceof BackEndDataProvider
+
+        when:
+        def items = systemAuthenticator.withSystem {
+            field.dataProvider.fetch(new Query(0, 10, null, null, 'alpha')).toList()
+        }
+
+        then:
+        items*.title == ['Alpha note', 'Alphabet']
+
+        cleanup: "remove mem1 instances"
+        systemAuthenticator.runWithSystem {
+            notes.each { dataManager.remove(it) }
+        }
+    }
+
+    def "byInstanceName infers query from method-based instance name over string properties"() {
+        setup:
+        systemAuthenticator.runWithSystem {
+            [['John', 'Smith'], ['Jane', 'Brown'], ['Jack', 'Jones']].each { first, last ->
+                def p = dataManager.create(LfPerson)
+                p.firstName = first
+                p.lastName = last
+                dataManager.save(p)
+            }
+        }
+
+        when: "search matches either firstName or lastName"
+        def field = generate('person') as EntityComboBox
+        def items = systemAuthenticator.withSystem {
+            field.dataProvider.fetch(new Query(0, 10, null, null, 'j')).toList()
+        }
+
+        then:
+        items.size() == 3
+
+        cleanup:
+        jdbcTemplate.execute('delete from TEST_LF_PERSON')
+    }
+
+    def "explicit query wins over byInstanceName and filters as written"() {
+        setup:
+        systemAuthenticator.runWithSystem {
+            [['Acme', true], ['Apex', false]].each { name, active ->
+                def s = dataManager.create(LfSupplier)
+                s.name = name
+                s.active = active
+                dataManager.save(s)
+            }
+        }
+
+        when:
+        def field = generate('supplier') as EntityComboBox
+        def items = systemAuthenticator.withSystem {
+            field.dataProvider.fetch(new Query(0, 10, null, null, 'a')).toList()
+        }
+
+        then: "inactive supplier is excluded by the explicit query"
+        items*.name == ['Acme']
+
+        cleanup:
+        jdbcTemplate.execute('delete from TEST_LF_SUPPLIER')
+    }
+
+    def "byInstanceName with no string instance-name properties degrades to eager"() {
+        when:
+        def field = generate('event') as EntityComboBox
+
+        then:
+        !(field.dataProvider instanceof BackEndDataProvider)
+    }
+
+    def "explicit query without searchString parameter degrades to eager"() {
+        when:
+        def field = generate('broken') as EntityComboBox
+
+        then:
+        !(field.dataProvider instanceof BackEndDataProvider)
+    }
+
+    def "itemsQuery on VIEW type is ignored"() {
+        expect:
+        generate('tag') instanceof EntityPicker
+    }
+
+    def "DROPDOWN on noop-store entity degrades to view lookup"() {
+        // LfNote has a byInstanceName itemsQuery configured, degradation must happen
+        // regardless of it, because the noop store cannot load items at all
+        when:
+        def metaClass = metadata.getClass(LfNoteHolder)
+        def context = new ComponentGenerationContext(metaClass, 'note')
+        def container = dataComponents.createInstanceContainer(LfNoteHolder)
+        context.setValueSource(new ContainerValueSource(container, 'note'))
+        def field = uiComponentsGenerator.generate(context)
+
+        then:
+        field instanceof EntityPicker
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/generation_strategy/LookupFieldSupportTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/generation_strategy/LookupFieldSupportTest.groovy
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package generation_strategy
+
+import io.jmix.core.Metadata
+import io.jmix.core.entity.annotation.LookupType
+import io.jmix.flowui.component.factory.EffectiveLookupConfig
+import io.jmix.flowui.component.factory.EffectiveLookupConfig.ItemsMode
+import io.jmix.flowui.UiComponentProperties
+import io.jmix.flowui.component.factory.LookupFieldSupport
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import test_support.entity.lookup_field.LfOrder
+import test_support.spec.FlowuiTestSpecification
+
+@SpringBootTest
+class LookupFieldSupportTest extends FlowuiTestSpecification {
+
+    @Autowired
+    Metadata metadata
+    @Autowired
+    LookupFieldSupport lookupFieldSupport
+    @Autowired
+    UiComponentProperties componentProperties
+
+    void cleanup() {
+        componentProperties.entityFieldActions.remove('test_LfCity')
+    }
+
+    EffectiveLookupConfig resolve(String property) {
+        def prop = metadata.getClass(LfOrder).getProperty(property)
+        return lookupFieldSupport.resolve(prop, prop.range.asClass())
+    }
+
+    def "class-level DROPDOWN with no itemsQuery resolves to EAGER"() {
+        when:
+        def c = resolve('country')
+
+        then:
+        c.componentType() == LookupType.DROPDOWN
+        !c.fieldLevel()
+        c.itemsMode() == ItemsMode.EAGER
+        c.actions().isEmpty()
+    }
+
+    def "field-level VIEW beats class-level annotation and is marked fieldLevel"() {
+        when:
+        def c = resolve('viewCountry')
+
+        then:
+        c.componentType() == LookupType.VIEW
+        c.fieldLevel()
+    }
+
+    def "class-level VIEW carries annotation actions"() {
+        when:
+        def c = resolve('city')
+
+        then:
+        c.componentType() == LookupType.VIEW
+        c.actions() == ['entity_lookup', 'entity_open', 'entity_clear']
+    }
+
+    def "field-level VIEW actions win"() {
+        when:
+        def c = resolve('viewCity')
+
+        then:
+        c.componentType() == LookupType.VIEW
+        c.fieldLevel()
+        c.actions() == ['entity_open']
+    }
+
+    def "byInstanceName itemsQuery resolves to BY_INSTANCE_NAME"() {
+        when:
+        def c = resolve('product')
+
+        then:
+        c.componentType() == LookupType.DROPDOWN
+        c.itemsMode() == ItemsMode.BY_INSTANCE_NAME
+        c.searchStringFormat() == null
+    }
+
+    def "explicit query with searchString resolves to QUERY"() {
+        when:
+        def c = resolve('supplier')
+
+        then:
+        c.componentType() == LookupType.DROPDOWN
+        c.itemsMode() == ItemsMode.QUERY
+        c.query().contains(':searchString')
+    }
+
+    def "explicit query without searchString downgrades to EAGER"() {
+        when:
+        def c = resolve('broken')
+
+        then:
+        c.componentType() == LookupType.DROPDOWN
+        c.itemsMode() == ItemsMode.EAGER
+    }
+
+    def "itemsQuery on VIEW type is ignored"() {
+        when:
+        def c = resolve('tag')
+
+        then:
+        c.componentType() == LookupType.VIEW
+        c.itemsMode() == ItemsMode.EAGER
+        c.query() == null
+    }
+
+    def "entity-field-actions property beats class-level annotation actions"() {
+        given:
+        componentProperties.entityFieldActions['test_LfCity'] = ['entity_clear']
+
+        when:
+        def c = resolve('city')
+
+        then:
+        c.componentType() == LookupType.VIEW
+        c.actions() == ['entity_clear']
+    }
+
+    def "field-level annotation actions beat entity-field-actions property"() {
+        given:
+        componentProperties.entityFieldActions['test_LfCity'] = ['entity_clear']
+
+        when:
+        def c = resolve('viewCity')
+
+        then:
+        c.componentType() == LookupType.VIEW
+        c.fieldLevel()
+        c.actions() == ['entity_open']
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/view_template/ComponentXmlFactoryTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/view_template/ComponentXmlFactoryTest.groovy
@@ -27,6 +27,8 @@ import org.dom4j.DocumentHelper
 import org.dom4j.Element
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import test_support.entity.lookup_field.LfNoteHolder
+import test_support.entity.lookup_field.LfOrder
 import test_support.entity.sales.Customer
 import test_support.entity.sales.Order
 import test_support.entity.viewtemplate.ComponentXmlDatatypesEntity
@@ -176,6 +178,115 @@ class ComponentXmlFactoryTest extends FlowuiTestSpecification {
 
         then:
         thrown(UnsupportedOperationException)
+    }
+
+    def "VIEW annotation produces entityPicker with default association actions"() {
+        when:
+        def element = lfElement('viewCountry')
+
+        then:
+        element.name == 'entityPicker'
+        element.element('actions').elements('action')*.attributeValue('id') == ['entityLookup', 'entityClear']
+    }
+
+    def "class VIEW annotation actions are used on entityPicker"() {
+        when:
+        def element = lfElement('city')
+
+        then:
+        element.name == 'entityPicker'
+        element.element('actions').elements('action')*.attributeValue('type') ==
+                ['entity_lookup', 'entity_open', 'entity_clear']
+    }
+
+    def "field DROPDOWN overrides class VIEW and produces entityComboBox with byInstanceName itemsQuery and inherited class actions"() {
+        when:
+        def element = lfElement('dropdownCity')
+
+        then:
+        element.name == 'entityComboBox'
+        def iq = element.element('itemsQuery')
+        iq.attributeValue('class') == 'test_support.entity.lookup_field.LfCity'
+        iq.attributeValue('byInstanceName') == 'true'
+
+        and:
+        def actions = element.element('actions').elements('action')
+        actions*.attributeValue('id') == ['entity_lookup', 'entity_open', 'entity_clear']
+        actions*.attributeValue('type') == ['entity_lookup', 'entity_open', 'entity_clear']
+    }
+
+    def "eager class DROPDOWN maps to byInstanceName itemsQuery"() {
+        when:
+        def element = lfElement('country')
+
+        then:
+        element.name == 'entityComboBox'
+        element.element('itemsQuery').attributeValue('byInstanceName') == 'true'
+    }
+
+    def "byInstanceName class DROPDOWN produces byInstanceName itemsQuery ignoring searchStringFormat"() {
+        when:
+        def element = lfElement('product')
+
+        then:
+        element.name == 'entityComboBox'
+        def iq = element.element('itemsQuery')
+        iq.attributeValue('byInstanceName') == 'true'
+        iq.attributeValue('searchStringFormat') == null
+    }
+
+    def "explicit query class DROPDOWN produces query itemsQuery"() {
+        when:
+        def element = lfElement('supplier')
+
+        then:
+        element.name == 'entityComboBox'
+        def iq = element.element('itemsQuery')
+        iq.attributeValue('byInstanceName') == null
+        iq.element('query').text.contains(':searchString')
+        iq.attributeValue('searchStringFormat') == '(?i)%${inputString}%'
+        iq.attributeValue('escapeValueForLike') == 'true'
+    }
+
+    def "explicit query without searchString degrades to byInstanceName itemsQuery"() {
+        when:
+        def element = lfElement('broken')
+
+        then:
+        element.name == 'entityComboBox'
+        element.element('itemsQuery').attributeValue('byInstanceName') == 'true'
+    }
+
+    def "byInstanceName with no string instance-name properties degrades to entityPicker"() {
+        when:
+        def element = lfElement('event')
+
+        then:
+        element.name == 'entityPicker'
+    }
+
+    def "itemsQuery on VIEW type produces entityPicker"() {
+        when:
+        def element = lfElement('tag')
+
+        then:
+        element.name == 'entityPicker'
+    }
+
+    def "DROPDOWN on noop-store entity degrades to entityPicker"() {
+        given:
+        def property = metadata.getClass(LfNoteHolder).getProperty('note')
+
+        when:
+        def element = createElement(property, null)
+
+        then:
+        element.name == 'entityPicker'
+    }
+
+    Element lfElement(String propertyName) {
+        def property = metadata.getClass(LfOrder).getProperty(propertyName)
+        return createElement(property, null)
     }
 
     Element createElement(String propertyName, String dataContainerId = null) {

--- a/jmix-flowui/flowui/src/test/groovy/view_template/ComponentXmlFactoryTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/view_template/ComponentXmlFactoryTest.groovy
@@ -27,6 +27,7 @@ import org.dom4j.DocumentHelper
 import org.dom4j.Element
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import test_support.entity.lookup_field.LfMemNoteHolder
 import test_support.entity.lookup_field.LfNoteHolder
 import test_support.entity.lookup_field.LfOrder
 import test_support.entity.sales.Customer
@@ -199,29 +200,71 @@ class ComponentXmlFactoryTest extends FlowuiTestSpecification {
                 ['entity_lookup', 'entity_open', 'entity_clear']
     }
 
-    def "field DROPDOWN overrides class VIEW and produces entityComboBox with byInstanceName itemsQuery and inherited class actions"() {
+    def "field DROPDOWN overrides class VIEW and produces entityComboBox bound to an items container with inherited class actions"() {
         when:
         def element = lfElement('dropdownCity')
 
         then:
         element.name == 'entityComboBox'
-        def iq = element.element('itemsQuery')
-        iq.attributeValue('class') == 'test_support.entity.lookup_field.LfCity'
-        iq.attributeValue('byInstanceName') == 'true'
-
-        and:
-        def actions = element.element('actions').elements('action')
-        actions*.attributeValue('id') == ['entity_lookup', 'entity_open', 'entity_clear']
-        actions*.attributeValue('type') == ['entity_lookup', 'entity_open', 'entity_clear']
+        element.attributeValue('itemsContainer') == 'dropdownCityItemsDc'
+        element.element('itemsQuery') == null
+        element.element('actions').elements('action')*.attributeValue('id') ==
+                ['entity_lookup', 'entity_open', 'entity_clear']
     }
 
-    def "eager class DROPDOWN maps to byInstanceName itemsQuery"() {
+    def "eager class DROPDOWN produces entityComboBox bound to a generated items container"() {
         when:
         def element = lfElement('country')
 
         then:
         element.name == 'entityComboBox'
-        element.element('itemsQuery').attributeValue('byInstanceName') == 'true'
+        element.attributeValue('itemsContainer') == 'countryItemsDc'
+        element.element('itemsQuery') == null
+    }
+
+    def "createItemsContainerXml emits a JPA collection with an instance-name-ordered loader"() {
+        when:
+        def property = metadata.getClass(LfOrder).getProperty('country')
+        def xml = componentXmlFactory.createItemsContainerXml(property)
+        def collection = DocumentHelper.parseText(xml).rootElement
+
+        then:
+        collection.name == 'collection'
+        collection.attributeValue('id') == 'countryItemsDc'
+        collection.attributeValue('class') == 'test_support.entity.lookup_field.LfCountry'
+        collection.element('fetchPlan').attributeValue('extends') == '_instance_name'
+        def loader = collection.element('loader')
+        loader.attributeValue('readOnly') == 'true'
+        loader.element('query').text.trim() == 'select e from test_LfCountry e order by e.name'
+    }
+
+    def "createItemsContainerXml omits the query element for a non-JPA entity"() {
+        when:
+        def property = metadata.getClass(LfMemNoteHolder).getProperty('dict')
+        def xml = componentXmlFactory.createItemsContainerXml(property)
+        def collection = DocumentHelper.parseText(xml).rootElement
+
+        then:
+        collection.name == 'collection'
+        collection.attributeValue('id') == 'dictItemsDc'
+        collection.attributeValue('class') == 'test_support.entity.lookup_field.LfMemDict'
+        collection.element('fetchPlan').attributeValue('extends') == '_instance_name'
+        def loader = collection.element('loader')
+        loader != null
+        loader.element('query') == null
+    }
+
+    def "createItemsContainerXml returns empty for non-eager reference properties"() {
+        expect:
+        componentXmlFactory.createItemsContainerXml(metadata.getClass(LfOrder).getProperty(propertyName)) == ''
+
+        where:
+        propertyName << ['product', 'supplier', 'tag', 'viewCountry']
+    }
+
+    def "createItemsContainerXml returns empty for a non-reference property"() {
+        expect:
+        componentXmlFactory.createItemsContainerXml(datatypesMetaClass.getProperty('stringValue')) == ''
     }
 
     def "byInstanceName class DROPDOWN produces byInstanceName itemsQuery ignoring searchStringFormat"() {
@@ -248,13 +291,14 @@ class ComponentXmlFactoryTest extends FlowuiTestSpecification {
         iq.attributeValue('escapeValueForLike') == 'true'
     }
 
-    def "explicit query without searchString degrades to byInstanceName itemsQuery"() {
+    def "explicit query without searchString degrades to an eager items container"() {
         when:
         def element = lfElement('broken')
 
         then:
         element.name == 'entityComboBox'
-        element.element('itemsQuery').attributeValue('byInstanceName') == 'true'
+        element.attributeValue('itemsContainer') == 'brokenItemsDc'
+        element.element('itemsQuery') == null
     }
 
     def "byInstanceName with no string instance-name properties degrades to entityPicker"() {

--- a/jmix-flowui/flowui/src/test/java/component_xml_load/screen/LfProductByInstanceNameView.java
+++ b/jmix-flowui/flowui/src/test/java/component_xml_load/screen/LfProductByInstanceNameView.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component_xml_load.screen;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.component.combobox.EntityComboBox;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import test_support.entity.lookup_field.LfProduct;
+
+@Route("lf-product-by-instance-name-view")
+@ViewController("LfProductByInstanceNameView")
+@ViewDescriptor("lf-product-by-instance-name-view.xml")
+public class LfProductByInstanceNameView extends StandardView {
+
+    @ViewComponent
+    public EntityComboBox<LfProduct> productField;
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/TestInMemoryDataStore.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/TestInMemoryDataStore.java
@@ -19,11 +19,15 @@ package test_support;
 import io.jmix.core.*;
 import io.jmix.core.entity.EntityValues;
 import io.jmix.core.entity.KeyValueEntity;
+import io.jmix.core.querycondition.Condition;
+import io.jmix.core.querycondition.LogicalCondition;
+import io.jmix.core.querycondition.PropertyCondition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.jspecify.annotations.Nullable;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 public class TestInMemoryDataStore implements DataStore {
 
@@ -57,10 +61,82 @@ public class TestInMemoryDataStore implements DataStore {
     @Override
     public List<Object> loadList(LoadContext<?> context) {
         Map<Object, Object> instances = entities.get(context.getEntityMetaClass().getName());
-        if (instances == null)
-            return Collections.emptyList();
-        else
-            return new ArrayList<>(instances.values());
+        List<Object> result = instances == null ? new ArrayList<>() : new ArrayList<>(instances.values());
+
+        LoadContext.Query query = context.getQuery();
+        if (query == null) {
+            return result;
+        }
+
+        Condition condition = query.getCondition();
+        if (condition != null) {
+            result = result.stream()
+                    .filter(entity -> matches(entity, condition))
+                    .collect(Collectors.toList());
+        }
+
+        Sort sort = query.getSort();
+        if (sort != null && !sort.getOrders().isEmpty()) {
+            result.sort(createComparator(sort));
+        }
+
+        return applyPaging(result, query.getFirstResult(), query.getMaxResults());
+    }
+
+    /**
+     * Minimal query support for tests: filters by {@link PropertyCondition} with the
+     * {@code CONTAINS} operation on string properties (case-insensitive substring match, with
+     * backslash-escapes of the search value stripped), and by {@link LogicalCondition} AND/OR
+     * nesting. Any other condition type matches everything (no filtering is applied for it),
+     * which is sufficient for the current test suite.
+     */
+    protected boolean matches(Object entity, Condition condition) {
+        if (condition instanceof PropertyCondition propertyCondition) {
+            if (PropertyCondition.Operation.CONTAINS.equals(propertyCondition.getOperation())) {
+                Object rawValue = EntityValues.getValue(entity, propertyCondition.getProperty());
+                String value = rawValue == null ? "" : rawValue.toString();
+                String search = unescapeForLike(String.valueOf(propertyCondition.getParameterValue()));
+                return value.toLowerCase(Locale.ROOT).contains(search.toLowerCase(Locale.ROOT));
+            }
+            return true;
+        }
+        if (condition instanceof LogicalCondition logicalCondition) {
+            List<Condition> nested = logicalCondition.getConditions();
+            if (nested.isEmpty()) {
+                return true;
+            }
+            return logicalCondition.getType() == LogicalCondition.Type.AND
+                    ? nested.stream().allMatch(nestedCondition -> matches(entity, nestedCondition))
+                    : nested.stream().anyMatch(nestedCondition -> matches(entity, nestedCondition));
+        }
+        return true;
+    }
+
+    protected String unescapeForLike(String value) {
+        return value.replace("\\_", "_")
+                .replace("\\%", "%")
+                .replace("\\\\", "\\");
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    protected Comparator<Object> createComparator(Sort sort) {
+        Comparator<Object> comparator = null;
+        for (Sort.Order order : sort.getOrders()) {
+            Comparator<Object> propertyComparator = Comparator.comparing(
+                    entity -> (Comparable) EntityValues.getValue(entity, order.getProperty()),
+                    Comparator.nullsFirst(Comparator.naturalOrder()));
+            if (order.getDirection() == Sort.Direction.DESC) {
+                propertyComparator = propertyComparator.reversed();
+            }
+            comparator = comparator == null ? propertyComparator : comparator.thenComparing(propertyComparator);
+        }
+        return comparator;
+    }
+
+    protected List<Object> applyPaging(List<Object> list, int firstResult, int maxResults) {
+        int from = Math.min(Math.max(firstResult, 0), list.size());
+        int to = maxResults > 0 ? Math.min(from + maxResults, list.size()) : list.size();
+        return new ArrayList<>(list.subList(from, to));
     }
 
     @Override

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfBroken.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfBroken.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupItemsQuery;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+
+@LookupField(type = LookupType.DROPDOWN, itemsQuery = @LookupItemsQuery(
+        query = "select e from test_LfBroken e order by e.name"))
+@JmixEntity
+@Entity(name = "test_LfBroken")
+@Table(name = "TEST_LF_BROKEN")
+public class LfBroken extends TestBaseEntity {
+
+    @InstanceName
+    @Column(name = "NAME")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfCity.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfCity.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+
+@LookupField(type = LookupType.VIEW, actions = {"entity_lookup", "entity_open", "entity_clear"})
+@JmixEntity
+@Entity(name = "test_LfCity")
+@Table(name = "TEST_LF_CITY")
+public class LfCity extends TestBaseEntity {
+
+    @InstanceName
+    @Column(name = "NAME")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfCountry.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfCountry.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+
+@LookupField(type = LookupType.DROPDOWN)
+@JmixEntity
+@Entity(name = "test_LfCountry")
+@Table(name = "TEST_LF_COUNTRY")
+public class LfCountry extends TestBaseEntity {
+
+    @InstanceName
+    @Column(name = "NAME")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfEvent.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfEvent.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupItemsQuery;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.DependsOnProperties;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+
+import java.time.LocalDate;
+
+@LookupField(type = LookupType.DROPDOWN, itemsQuery = @LookupItemsQuery(byInstanceName = true))
+@JmixEntity
+@Entity(name = "test_LfEvent")
+@Table(name = "TEST_LF_EVENT")
+public class LfEvent extends TestBaseEntity {
+
+    @Column(name = "START_DATE")
+    private LocalDate startDate;
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    @InstanceName
+    @DependsOnProperties({"startDate"})
+    public String getCaption() {
+        return String.valueOf(startDate);
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfMemDict.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfMemDict.java
@@ -16,20 +16,31 @@
 
 package test_support.entity.lookup_field;
 
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
 import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.InstanceName;
 import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.core.metamodel.annotation.Store;
 
 import java.util.UUID;
 
-@JmixEntity(name = "test_LfMemNoteHolder")
-public class LfMemNoteHolder {
+/**
+ * Non-persistent DTO in the {@code mem1} store with an eager DROPDOWN {@code @LookupField},
+ * used to verify that a generated items container omits the JPQL query for non-JPA entities.
+ */
+@LookupField(type = LookupType.DROPDOWN)
+@Store(name = "mem1")
+@JmixEntity(name = "test_LfMemDict")
+public class LfMemDict {
 
     @JmixId
+    @JmixGeneratedValue
     private UUID id;
 
-    private LfMemNote note;
-
-    private LfMemDict dict;
+    @InstanceName
+    private String name;
 
     public UUID getId() {
         return id;
@@ -39,19 +50,11 @@ public class LfMemNoteHolder {
         this.id = id;
     }
 
-    public LfMemNote getNote() {
-        return note;
+    public String getName() {
+        return name;
     }
 
-    public void setNote(LfMemNote note) {
-        this.note = note;
-    }
-
-    public LfMemDict getDict() {
-        return dict;
-    }
-
-    public void setDict(LfMemDict dict) {
-        this.dict = dict;
+    public void setName(String name) {
+        this.name = name;
     }
 }

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfMemNote.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfMemNote.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupItemsQuery;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.core.metamodel.annotation.Store;
+
+import java.util.UUID;
+
+/**
+ * Non-persistent DTO entity bound to the {@code mem1} in-memory data store, used to verify that
+ * {@code byInstanceName} items loading works for any store capable of loading instances.
+ */
+@LookupField(type = LookupType.DROPDOWN, itemsQuery = @LookupItemsQuery(byInstanceName = true))
+@Store(name = "mem1")
+@JmixEntity(name = "test_LfMemNote")
+public class LfMemNote {
+
+    @JmixId
+    @JmixGeneratedValue
+    private UUID id;
+
+    @InstanceName
+    private String title;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfMemNoteHolder.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfMemNoteHolder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+
+import java.util.UUID;
+
+@JmixEntity(name = "test_LfMemNoteHolder")
+public class LfMemNoteHolder {
+
+    @JmixId
+    private UUID id;
+
+    private LfMemNote note;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public LfMemNote getNote() {
+        return note;
+    }
+
+    public void setNote(LfMemNote note) {
+        this.note = note;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfNote.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfNote.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupItemsQuery;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+
+import java.util.UUID;
+
+/**
+ * A non-persistent entity with no assigned data store (the noop store), used to verify that a
+ * DROPDOWN degrades to a view lookup regardless of {@code itemsQuery} configuration.
+ */
+@LookupField(type = LookupType.DROPDOWN, itemsQuery = @LookupItemsQuery(byInstanceName = true))
+@JmixEntity(name = "test_LfNote")
+public class LfNote {
+
+    @JmixId
+    private UUID id;
+
+    @InstanceName
+    private String text;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfNoteHolder.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfNoteHolder.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+
+import java.util.UUID;
+
+@JmixEntity(name = "test_LfNoteHolder")
+public class LfNoteHolder {
+
+    @JmixId
+    private UUID id;
+
+    private LfNote note;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public LfNote getNote() {
+        return note;
+    }
+
+    public void setNote(LfNote note) {
+        this.note = note;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfOrder.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfOrder.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+
+@JmixEntity
+@Entity(name = "test_LfOrder")
+@Table(name = "TEST_LF_ORDER")
+public class LfOrder extends TestBaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "COUNTRY_ID")
+    private LfCountry country;
+
+    @LookupField(type = LookupType.VIEW)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "VIEW_COUNTRY_ID")
+    private LfCountry viewCountry;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "CITY_ID")
+    private LfCity city;
+
+    @LookupField(type = LookupType.DROPDOWN)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "DROPDOWN_CITY_ID")
+    private LfCity dropdownCity;
+
+    @LookupField(type = LookupType.VIEW, actions = {"entity_open"})
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "VIEW_CITY_ID")
+    private LfCity viewCity;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PRODUCT_ID")
+    private LfProduct product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PERSON_ID")
+    private LfPerson person;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "EVENT_ID")
+    private LfEvent event;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "SUPPLIER_ID")
+    private LfSupplier supplier;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "BROKEN_ID")
+    private LfBroken broken;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "TAG_ID")
+    private LfTag tag;
+
+    public LfCountry getCountry() {
+        return country;
+    }
+
+    public void setCountry(LfCountry country) {
+        this.country = country;
+    }
+
+    public LfCountry getViewCountry() {
+        return viewCountry;
+    }
+
+    public void setViewCountry(LfCountry viewCountry) {
+        this.viewCountry = viewCountry;
+    }
+
+    public LfCity getCity() {
+        return city;
+    }
+
+    public void setCity(LfCity city) {
+        this.city = city;
+    }
+
+    public LfCity getDropdownCity() {
+        return dropdownCity;
+    }
+
+    public void setDropdownCity(LfCity dropdownCity) {
+        this.dropdownCity = dropdownCity;
+    }
+
+    public LfCity getViewCity() {
+        return viewCity;
+    }
+
+    public void setViewCity(LfCity viewCity) {
+        this.viewCity = viewCity;
+    }
+
+    public LfProduct getProduct() {
+        return product;
+    }
+
+    public void setProduct(LfProduct product) {
+        this.product = product;
+    }
+
+    public LfPerson getPerson() {
+        return person;
+    }
+
+    public void setPerson(LfPerson person) {
+        this.person = person;
+    }
+
+    public LfEvent getEvent() {
+        return event;
+    }
+
+    public void setEvent(LfEvent event) {
+        this.event = event;
+    }
+
+    public LfSupplier getSupplier() {
+        return supplier;
+    }
+
+    public void setSupplier(LfSupplier supplier) {
+        this.supplier = supplier;
+    }
+
+    public LfBroken getBroken() {
+        return broken;
+    }
+
+    public void setBroken(LfBroken broken) {
+        this.broken = broken;
+    }
+
+    public LfTag getTag() {
+        return tag;
+    }
+
+    public void setTag(LfTag tag) {
+        this.tag = tag;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfPerson.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfPerson.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupItemsQuery;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.DependsOnProperties;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+
+@LookupField(type = LookupType.DROPDOWN, itemsQuery = @LookupItemsQuery(byInstanceName = true))
+@JmixEntity
+@Entity(name = "test_LfPerson")
+@Table(name = "TEST_LF_PERSON")
+public class LfPerson extends TestBaseEntity {
+
+    @Column(name = "FIRST_NAME")
+    private String firstName;
+
+    @Column(name = "LAST_NAME")
+    private String lastName;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    @InstanceName
+    @DependsOnProperties({"firstName", "lastName"})
+    public String getCaption() {
+        return firstName + " " + lastName;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfProduct.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfProduct.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupItemsQuery;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+
+@LookupField(type = LookupType.DROPDOWN, itemsQuery = @LookupItemsQuery(
+        byInstanceName = true,
+        searchStringFormat = "%${inputString}%"))
+@JmixEntity
+@Entity(name = "test_LfProduct")
+@Table(name = "TEST_LF_PRODUCT")
+public class LfProduct extends TestBaseEntity {
+
+    @InstanceName
+    @Column(name = "NAME")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfSupplier.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfSupplier.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupItemsQuery;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+
+@LookupField(type = LookupType.DROPDOWN, itemsQuery = @LookupItemsQuery(
+        byInstanceName = true,
+        query = "select e from test_LfSupplier e where e.active = true "
+                + "and e.name like :searchString escape '\\' order by e.name",
+        searchStringFormat = "(?i)%${inputString}%",
+        escapeValueForLike = true))
+@JmixEntity
+@Entity(name = "test_LfSupplier")
+@Table(name = "TEST_LF_SUPPLIER")
+public class LfSupplier extends TestBaseEntity {
+
+    @InstanceName
+    @Column(name = "NAME")
+    private String name;
+
+    @Column(name = "ACTIVE")
+    private Boolean active;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Boolean getActive() {
+        return active;
+    }
+
+    public void setActive(Boolean active) {
+        this.active = active;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfTag.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/lookup_field/LfTag.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.lookup_field;
+
+import io.jmix.core.entity.annotation.LookupField;
+import io.jmix.core.entity.annotation.LookupItemsQuery;
+import io.jmix.core.entity.annotation.LookupType;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+
+@LookupField(type = LookupType.VIEW, itemsQuery = @LookupItemsQuery(byInstanceName = true))
+@JmixEntity
+@Entity(name = "test_LfTag")
+@Table(name = "TEST_LF_TAG")
+public class LfTag extends TestBaseEntity {
+
+    @InstanceName
+    @Column(name = "NAME")
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateLookupEntity.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateLookupEntity.java
@@ -25,6 +25,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import test_support.entity.TestBaseEntity;
+import test_support.entity.lookup_field.LfCountry;
 import test_support.entity.lookup_field.LfProduct;
 
 /**
@@ -32,6 +33,9 @@ import test_support.entity.lookup_field.LfProduct;
  * {@code @LookupField}-annotated reference ({@link LfProduct}, which carries a class-level
  * {@code @LookupField(type = DROPDOWN, itemsQuery = @LookupItemsQuery(byInstanceName = true))})
  * as an {@code entityComboBox} with a {@code byInstanceName} {@code itemsQuery}, end to end.
+ * It also references {@link LfCountry}, which carries a class-level
+ * {@code @LookupField(type = DROPDOWN)} (eager, query-based), to verify that the template
+ * generates and binds an eager items container for such a reference.
  */
 @JmixEntity
 @Table(name = "TEST_VIEW_TEMPLATE_LOOKUP_ENTITY")
@@ -49,6 +53,10 @@ public class ViewTemplateLookupEntity extends TestBaseEntity {
     @JoinColumn(name = "PRODUCT_ID")
     protected LfProduct product;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "COUNTRY_ID")
+    protected LfCountry country;
+
     public String getName() {
         return name;
     }
@@ -63,5 +71,13 @@ public class ViewTemplateLookupEntity extends TestBaseEntity {
 
     public void setProduct(LfProduct product) {
         this.product = product;
+    }
+
+    public LfCountry getCountry() {
+        return country;
+    }
+
+    public void setCountry(LfCountry country) {
+        this.country = country;
     }
 }

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateLookupEntity.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateLookupEntity.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.viewtemplate;
+
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.flowui.view.template.DetailViewTemplate;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+import test_support.entity.lookup_field.LfProduct;
+
+/**
+ * Test entity used to verify that a detail view generated from a template renders a
+ * {@code @LookupField}-annotated reference ({@link LfProduct}, which carries a class-level
+ * {@code @LookupField(type = DROPDOWN, itemsQuery = @LookupItemsQuery(byInstanceName = true))})
+ * as an {@code entityComboBox} with a {@code byInstanceName} {@code itemsQuery}, end to end.
+ */
+@JmixEntity
+@Table(name = "TEST_VIEW_TEMPLATE_LOOKUP_ENTITY")
+@Entity(name = "test_ViewTemplateLookupEntity")
+@DetailViewTemplate(
+        viewId = "test_ViewTemplateLookupEntity.edit",
+        viewRoute = "templates/view-template-lookup/detail"
+)
+public class ViewTemplateLookupEntity extends TestBaseEntity {
+
+    @Column(name = "NAME")
+    protected String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "PRODUCT_ID")
+    protected LfProduct product;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public LfProduct getProduct() {
+        return product;
+    }
+
+    public void setProduct(LfProduct product) {
+        this.product = product;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/view_template/ViewTemplateIntegrationTest.java
+++ b/jmix-flowui/flowui/src/test/java/view_template/ViewTemplateIntegrationTest.java
@@ -54,6 +54,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import test_support.FlowuiTestConfiguration;
 import test_support.entity.viewtemplate.ViewTemplateBindingsEntity;
 import test_support.entity.viewtemplate.ViewTemplateFilteringEntity;
+import test_support.entity.viewtemplate.ViewTemplateLookupEntity;
 import test_support.entity.viewtemplate.ViewTemplateParamsEntity;
 import test_support.entity.viewtemplate.ViewTemplateTestEntity;
 
@@ -82,6 +83,7 @@ public class ViewTemplateIntegrationTest {
     protected static final String LINE_DETAIL_VIEW_ID = "test_ViewTemplateLineEntity.detail";
     protected static final String MSG_TITLE_LIST_VIEW_ID = "test_ViewTemplateMsgTitleEntity.list";
     protected static final String MSG_TITLE_DETAIL_VIEW_ID = "test_ViewTemplateMsgTitleEntity.detail";
+    protected static final String LOOKUP_DETAIL_VIEW_ID = "test_ViewTemplateLookupEntity.edit";
     protected static final String LIST_VIEW_ROUTE = "templates/view-template/list";
     protected static final String DETAIL_VIEW_BASE_ROUTE = "templates/view-template/detail";
     protected static final String DETAIL_VIEW_ROUTE = DETAIL_VIEW_BASE_ROUTE + "/:id";
@@ -348,6 +350,20 @@ public class ViewTemplateIntegrationTest {
 
         assertFalse(detailDescriptor.contains("<tabSheet"));
         assertTrue(detailDescriptor.contains("<formLayout id=\"form\" dataContainer=\"entityDc\""));
+    }
+
+    @Test
+    void testDetailTemplateRendersLookupFieldAnnotatedReferenceAsEntityComboBox() {
+        String detailDescriptor = getDescriptor(LOOKUP_DETAIL_VIEW_ID);
+
+        // LfProduct carries a class-level @LookupField(type = DROPDOWN,
+        // itemsQuery = @LookupItemsQuery(byInstanceName = true)), so the template-generated
+        // field for the "product" reference must be an entityComboBox with a byInstanceName
+        // itemsQuery, not the default entityPicker.
+        assertTrue(detailDescriptor.contains("id=\"productField\""));
+        assertTrue(detailDescriptor.contains("<entityComboBox"));
+        assertTrue(detailDescriptor.contains("byInstanceName=\"true\""));
+        assertFalse(detailDescriptor.contains("<entityPicker"));
     }
 
     @Test

--- a/jmix-flowui/flowui/src/test/java/view_template/ViewTemplateIntegrationTest.java
+++ b/jmix-flowui/flowui/src/test/java/view_template/ViewTemplateIntegrationTest.java
@@ -364,6 +364,13 @@ public class ViewTemplateIntegrationTest {
         assertTrue(detailDescriptor.contains("<entityComboBox"));
         assertTrue(detailDescriptor.contains("byInstanceName=\"true\""));
         assertFalse(detailDescriptor.contains("<entityPicker"));
+
+        // LfCountry carries a class-level @LookupField(type = DROPDOWN) (eager, query-based),
+        // so the template must also generate a top-level items container for the "country"
+        // reference and bind the entityComboBox to it via itemsContainer.
+        assertTrue(detailDescriptor.contains("<collection id=\"countryItemsDc\""));
+        assertTrue(detailDescriptor.contains("select e from test_LfCountry e"));
+        assertTrue(detailDescriptor.contains("itemsContainer=\"countryItemsDc\""));
     }
 
     @Test

--- a/jmix-flowui/flowui/src/test/resources/component_xml_load/screen/lf-product-by-instance-name-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component_xml_load/screen/lf-product-by-instance-name-view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <layout>
+        <entityComboBox id="productField" metaClass="test_LfProduct">
+            <itemsQuery class="test_support.entity.lookup_field.LfProduct" byInstanceName="true"/>
+        </entityComboBox>
+    </layout>
+</view>


### PR DESCRIPTION
Declarative, data-model-level control over the UI component Jmix generates for entity **reference** attributes: an `EntityComboBox` (dropdown) or an `EntityPicker` (view lookup), the actions on it, and optional opt-in lazy loading of dropdown items. Restores the CUBA `@Lookup` capability dropped in the Jmix migration and extends it with lazy loading that works for any data store, including non-persistent DTO entities. Applications using no annotation are unaffected — the no-annotation code paths are unchanged.

### What's included

- **Core API** (`jmix-core`, `io.jmix.core.entity.annotation`): `@LookupField` (targetable at a class or a reference field), `@LookupItemsQuery` (explicit JPQL `query` or `byInstanceName`), and the `LookupType` enum (`DROPDOWN` / `VIEW`).
- **Shared resolution** (`jmix-flowui`): `LookupFieldSupport` + `EffectiveLookupConfig` — one source of truth for precedence (field annotation → `entity-field-*` properties → class annotation) and validation. Consumed by both generators.
- **Live component generation**: `EntityFieldCreationSupport` builds the picker/combobox and its lazy items callbacks; the items-fetch logic lives in the shared `ItemsFetchCallbackSupport`.
- **Runtime view templates** (builds on #5225 / #5226): template-generated detail views now honor the annotation via `ComponentXmlFactory`. Eager dropdowns render as true eager comboboxes backed by a generated data container; explicit-query and `byInstanceName` dropdowns render as lazy `<itemsQuery>`.
- **XML**: `byInstanceName` is now expressible directly in a hand-written `<entityComboBox><itemsQuery>`, with design-time Studio metadata for the attribute.

### Behavior

- **Items loading**: eager (small dictionaries, client-side filtering), explicit paged JPQL `query` with `:searchString`, or `byInstanceName` (query conditions over the instance-name attributes; works for any store). Items load through `DataManager`, so row-level security applies.
- **Never throws**: invalid configuration logs a warning and degrades (lazy → eager → view lookup) so a field always renders.

### Compatibility

Breaking on the protected/internal surface only (all within `*Support` extension points): `EntityFieldCreationSupport` precedence internals moved to `LookupFieldSupport`; `DataLoaderSupport.getSearchString` / `VALUE_PARAMETER` removed; instance-name helpers moved to `ItemsFetchCallbackSupport`; several bean constructors gained parameters. No released public API is affected.

### Testing

Spock integration tests (in-memory HSQL) over resolver precedence/validation, live-component generation, the XML `byInstanceName` loader, template XML generation with degradation, and an end-to-end template render.

### Follow-ups (non-blocking)

- Create a Studio issue to use `@LookupField` when generating views.
- Support for `@LookupField` meta-annotation in Dynamic Model. May require changes in the way the metadata store nested annotations like `@LookupItemsQuery` (currently they are stored as Java annotation objects).