### PR TITLE
GenericFilter builder should check that getEmptyConfiguration methods are not used in definition  #5455

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/RunTimeConfigurationBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/RunTimeConfigurationBuilder.java
@@ -214,6 +214,10 @@ public class RunTimeConfigurationBuilder {
             throw new IllegalStateException(
                     "RunTimeConfigurationBuilder: 'id' is required — call .id(\"...\") before .buildAndRegister()");
         }
+        if (id.equals(filter.getEmptyConfiguration().getId())) {
+            throw new IllegalStateException(String.format(
+                    "RunTimeConfigurationBuilder: 'id' must not be the reserved empty-configuration id '%s'", id));
+        }
         if (filter.getConfiguration(id) != null) {
             throw new IllegalStateException(String.format(
                     "RunTimeConfigurationBuilder: a configuration with id '%s' is already registered in this filter", id));

--- a/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterBuilderApiTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterBuilderApiTest.groovy
@@ -624,6 +624,20 @@ class GenericFilterBuilderApiTest extends FlowuiTestSpecification {
         thrown(IllegalStateException)
     }
 
+    def "RunTimeConfigurationBuilder.buildAndRegister() throws when id is the reserved empty-configuration id"() {
+        given: "A DataLoader-bound filter"
+        GenericFilter filter = filterWithLoader()
+
+        when: "Registering a configuration whose id equals the reserved empty-configuration id"
+        filter.runtimeConfigurationBuilder()
+                .id(filter.getEmptyConfiguration().getId())
+                .name("With reserved id")
+                .buildAndRegister()
+
+        then:
+        thrown(IllegalStateException)
+    }
+
     def "RunTimeConfigurationBuilder.buildAndRegister() throws when called twice on the same instance"() {
         given: "A DataLoader-bound filter so the first build succeeds and sets the one-shot flag"
         GenericFilter filter = filterWithLoader()


### PR DESCRIPTION
fixes #5455

### Problem

`RunTimeConfigurationBuilder.buildAndRegister()` accepted an `id` equal to the filter's reserved empty-configuration id (`empty_configuration`). The resulting configuration collides with the empty one — since configurations are compared by id, its name is not shown and the "is this the empty/new configuration?" checks (`getEmptyConfiguration().equals(...)`) misfire.

### Root cause

The builder's duplicate guard `filter.getConfiguration(id) != null` only searches the `configurations` list. The empty configuration is kept in a separate field and is never added to that list, so `getConfiguration("empty_configuration")` returns `null` — the duplicate guard cannot see this particular collision.

### Fix

Add a dedicated guard in `buildAndRegister()` that rejects the reserved empty-configuration id, next to the builder's existing guards (already built, `id` null, duplicate id, no `DataLoader`). The two id checks are complementary: the duplicate guard covers every registered configuration, the new one covers the single reserved id that lives outside the list.

### Tests

Added a regression test to `GenericFilterBuilderApiTest` asserting that `buildAndRegister()` throws `IllegalStateException` when `id` equals the reserved empty-configuration id. Verified it fails on the unpatched code and passes with the fix; the full `GenericFilterBuilderApiTest` class stays green.
