### PR TITLE
Programmatic GenericFilter prompts for a configuration name when opened for editing  #5451

### DIFF
--- a/jmix-flowui/flowui-data/src/test/java/filter_configuration_persistence/GenericFilterConfigurationNamePrefillTest.java
+++ b/jmix-flowui/flowui-data/src/test/java/filter_configuration_persistence/GenericFilterConfigurationNamePrefillTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filter_configuration_persistence;
+
+import filter_configuration_persistence.view.FilterConfigurationPersistenceTestView;
+import io.jmix.core.DataManager;
+import io.jmix.core.EntityStates;
+import io.jmix.core.querycondition.PropertyConditionUtils;
+import io.jmix.flowui.component.genericfilter.Configuration;
+import io.jmix.flowui.component.genericfilter.FilterConfigurationPersistence;
+import io.jmix.flowui.component.genericfilter.GenericFilter;
+import io.jmix.flowui.component.genericfilter.GenericFilterSupport;
+import io.jmix.flowui.component.genericfilter.model.FilterConfigurationModel;
+import io.jmix.flowui.component.logicalfilter.LogicalFilterComponent;
+import io.jmix.flowui.component.propertyfilter.PropertyFilter;
+import io.jmix.flowui.component.propertyfilter.SingleFilterSupport;
+import io.jmix.flowui.component.textfield.TypedTextField;
+import io.jmix.flowui.entity.filter.FilterValueComponent;
+import io.jmix.flowui.entity.filter.GroupFilterCondition;
+import io.jmix.flowui.entity.filter.PropertyFilterCondition;
+import io.jmix.flowui.testassist.FlowuiTestAssistConfiguration;
+import io.jmix.flowui.testassist.UiTest;
+import io.jmix.flowui.testassist.UiTestUtils;
+import io.jmix.flowui.view.navigation.ViewNavigationSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import test_support.FlowuiDataTestConfiguration;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+@UiTest(viewBasePackages = "filter_configuration_persistence.view", authenticator = FilterConfigurationPersistenceTestAuthenticator.class)
+@SpringBootTest(classes = {FlowuiDataTestConfiguration.class, FlowuiTestAssistConfiguration.class})
+public class GenericFilterConfigurationNamePrefillTest {
+
+    private static final String COMPONENT_ID = "[FilterConfigurationPersistenceTestView]genericFilter";
+
+    @Autowired
+    ViewNavigationSupport navigationSupport;
+    @Autowired
+    GenericFilterSupport genericFilterSupport;
+    @Autowired
+    FilterConfigurationPersistence configurationPersistence;
+    @Autowired
+    SingleFilterSupport singleFilterSupport;
+    @Autowired
+    DataManager dataManager;
+    @Autowired
+    EntityStates entityStates;
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    public void afterEach() {
+        jdbcTemplate.update("delete from FLOWUI_FILTER_CONFIGURATION");
+    }
+
+    @Test
+    @DisplayName("Existing in-memory configuration (not in DB): the editor model is pre-filled from it (#5451)")
+    public void inMemoryConfigurationPrefillsNameAndId() throws Exception {
+        GenericFilter filter = navigateAndGetFilter();
+
+        // A named run-time configuration that is never persisted to the database.
+        PropertyFilter<String> nameFilter = filter.filterComponentBuilder()
+                .<String>propertyFilter()
+                .property("name")
+                .operation(PropertyFilter.Operation.CONTAINS)
+                .build();
+        Configuration configuration = filter.runtimeConfigurationBuilder()
+                .id("openProjects")
+                .name("Open Projects")
+                .add(nameFilter)
+                .makeCurrent()
+                .buildAndRegister();
+
+        // isNewConfiguration = false, not found in the DB -> fallback model, pre-filled from the configuration.
+        FilterConfigurationModel model = loadEditorModel(false, configuration);
+
+        Assertions.assertTrue(entityStates.isNew(model), "expected a freshly created fallback model");
+        Assertions.assertEquals("Open Projects", model.getName());
+        Assertions.assertEquals("openProjects", model.getConfigurationId());
+    }
+
+    @Test
+    @DisplayName("Existing persisted configuration: the stored model is returned unchanged (configurationModel != null)")
+    public void persistedConfigurationReturnsStoredModel() throws Exception {
+        String configurationId = "savedConfiguration";
+        String username = FilterConfigurationPersistenceTestAuthenticator.simpleUser;
+
+        configurationPersistence.save(createPersistedConfiguration(configurationId, username, "Saved configuration"));
+
+        GenericFilter filter = navigateAndGetFilter();
+        Configuration configuration = filter.getConfiguration(configurationId);
+        Assertions.assertNotNull(configuration);
+
+        // isNewConfiguration = false, found in the DB -> the stored model is returned, fallback is skipped.
+        FilterConfigurationModel model = loadEditorModel(false, configuration);
+
+        Assertions.assertFalse(entityStates.isNew(model), "expected the model loaded from the database, not a fallback");
+        Assertions.assertEquals("Saved configuration", model.getName());
+        Assertions.assertEquals(configurationId, model.getConfigurationId());
+    }
+
+    @Test
+    @DisplayName("New configuration: the fallback model is left empty (isNewConfiguration = true)")
+    public void newConfigurationDoesNotPrefillName() throws Exception {
+        GenericFilter filter = navigateAndGetFilter();
+
+        // Creating a new configuration starts from the empty configuration; the DB load is skipped
+        // and the name/id must stay empty so the editor asks the user for a name.
+        FilterConfigurationModel model = loadEditorModel(true, filter.getEmptyConfiguration());
+
+        Assertions.assertTrue(entityStates.isNew(model));
+        Assertions.assertNull(model.getName());
+        Assertions.assertNull(model.getConfigurationId());
+    }
+
+    protected GenericFilter navigateAndGetFilter() {
+        navigationSupport.navigate(FilterConfigurationPersistenceTestView.class);
+        FilterConfigurationPersistenceTestView view = UiTestUtils.getCurrentView();
+        return view.genericFilter;
+    }
+
+    protected FilterConfigurationModel loadEditorModel(boolean isNewConfiguration, Configuration configuration)
+            throws Exception {
+        Method method = GenericFilterSupport.class.getDeclaredMethod(
+                "loadFilterConfigurationModel", boolean.class, Configuration.class);
+        method.setAccessible(true);
+        return (FilterConfigurationModel) method.invoke(genericFilterSupport, isNewConfiguration, configuration);
+    }
+
+    protected FilterConfigurationModel createPersistedConfiguration(String configurationId, String username, String name) {
+        FilterConfigurationModel model = dataManager.create(FilterConfigurationModel.class);
+        model.setConfigurationId(configurationId);
+        model.setComponentId(COMPONENT_ID);
+        model.setName(name);
+        model.setUsername(username);
+
+        GroupFilterCondition rootCondition = dataManager.create(GroupFilterCondition.class);
+        rootCondition.setOperation(LogicalFilterComponent.Operation.AND);
+
+        PropertyFilterCondition nameCondition = dataManager.create(PropertyFilterCondition.class);
+        nameCondition.setOperation(PropertyFilter.Operation.CONTAINS);
+        nameCondition.setParameterName(PropertyConditionUtils.generateParameterName("name"));
+        nameCondition.setProperty("name");
+        nameCondition.setParent(rootCondition);
+
+        FilterValueComponent valueComponent = dataManager.create(FilterValueComponent.class);
+        valueComponent.setComponentId("testId");
+        //noinspection JmixIncorrectCreateGuiComponent
+        valueComponent.setComponentName(singleFilterSupport.getValueComponentName(new TypedTextField<>()));
+        nameCondition.setValueComponent(valueComponent);
+
+        rootCondition.setOwnFilterConditions(List.of(nameCondition));
+        model.setRootCondition(rootCondition);
+
+        return model;
+    }
+}

--- a/jmix-flowui/flowui-data/src/test/java/filter_configuration_persistence/GenericFilterConfigurationNamePrefillTest.java
+++ b/jmix-flowui/flowui-data/src/test/java/filter_configuration_persistence/GenericFilterConfigurationNamePrefillTest.java
@@ -20,21 +20,28 @@ import filter_configuration_persistence.view.FilterConfigurationPersistenceTestV
 import io.jmix.core.DataManager;
 import io.jmix.core.EntityStates;
 import io.jmix.core.querycondition.PropertyConditionUtils;
+import io.jmix.flowui.DialogWindows;
 import io.jmix.flowui.component.genericfilter.Configuration;
 import io.jmix.flowui.component.genericfilter.FilterConfigurationPersistence;
 import io.jmix.flowui.component.genericfilter.GenericFilter;
 import io.jmix.flowui.component.genericfilter.GenericFilterSupport;
+import io.jmix.flowui.component.genericfilter.configuration.UiDataFilterConfigurationDetail;
+import io.jmix.flowui.component.genericfilter.converter.FilterConverter;
 import io.jmix.flowui.component.genericfilter.model.FilterConfigurationModel;
+import io.jmix.flowui.component.genericfilter.registration.FilterComponents;
 import io.jmix.flowui.component.logicalfilter.LogicalFilterComponent;
 import io.jmix.flowui.component.propertyfilter.PropertyFilter;
 import io.jmix.flowui.component.propertyfilter.SingleFilterSupport;
 import io.jmix.flowui.component.textfield.TypedTextField;
 import io.jmix.flowui.entity.filter.FilterValueComponent;
 import io.jmix.flowui.entity.filter.GroupFilterCondition;
+import io.jmix.flowui.entity.filter.LogicalFilterCondition;
 import io.jmix.flowui.entity.filter.PropertyFilterCondition;
 import io.jmix.flowui.testassist.FlowuiTestAssistConfiguration;
 import io.jmix.flowui.testassist.UiTest;
 import io.jmix.flowui.testassist.UiTestUtils;
+import io.jmix.flowui.view.DialogWindow;
+import io.jmix.flowui.view.View;
 import io.jmix.flowui.view.navigation.ViewNavigationSupport;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -45,14 +52,19 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import test_support.FlowuiDataTestConfiguration;
 
-import java.lang.reflect.Method;
 import java.util.List;
 
-@UiTest(viewBasePackages = "filter_configuration_persistence.view", authenticator = FilterConfigurationPersistenceTestAuthenticator.class)
+@UiTest(viewBasePackages = {"filter_configuration_persistence.view", "io.jmix.flowui.app.filter.condition"},
+        authenticator = FilterConfigurationPersistenceTestAuthenticator.class)
 @SpringBootTest(classes = {FlowuiDataTestConfiguration.class, FlowuiTestAssistConfiguration.class})
 public class GenericFilterConfigurationNamePrefillTest {
 
     private static final String COMPONENT_ID = "[FilterConfigurationPersistenceTestView]genericFilter";
+
+    private static final String RUNTIME_CONFIGURATION_ID = "openProjects";
+    private static final String RUNTIME_CONFIGURATION_NAME = "Open Projects";
+    private static final String PERSISTED_CONFIGURATION_ID = "savedConfiguration";
+    private static final String PERSISTED_CONFIGURATION_NAME = "Saved configuration";
 
     @Autowired
     ViewNavigationSupport navigationSupport;
@@ -60,6 +72,10 @@ public class GenericFilterConfigurationNamePrefillTest {
     GenericFilterSupport genericFilterSupport;
     @Autowired
     FilterConfigurationPersistence configurationPersistence;
+    @Autowired
+    FilterComponents filterComponents;
+    @Autowired
+    DialogWindows dialogWindows;
     @Autowired
     SingleFilterSupport singleFilterSupport;
     @Autowired
@@ -75,63 +91,71 @@ public class GenericFilterConfigurationNamePrefillTest {
     }
 
     @Test
-    @DisplayName("Existing in-memory configuration (not in DB): the editor model is pre-filled from it (#5451)")
-    public void inMemoryConfigurationPrefillsNameAndId() throws Exception {
+    @DisplayName("Editor pre-fills name and id from a named run-time configuration that is not in the DB (#5451)")
+    public void editorPrefillsNameForInMemoryConfiguration() {
         GenericFilter filter = navigateAndGetFilter();
+        Configuration configuration = registerRuntimeConfiguration(filter);
 
-        // A named run-time configuration that is never persisted to the database.
-        PropertyFilter<String> nameFilter = filter.filterComponentBuilder()
-                .<String>propertyFilter()
-                .property("name")
-                .operation(PropertyFilter.Operation.CONTAINS)
-                .build();
-        Configuration configuration = filter.runtimeConfigurationBuilder()
-                .id("openProjects")
-                .name("Open Projects")
-                .add(nameFilter)
-                .makeCurrent()
-                .buildAndRegister();
-
-        // isNewConfiguration = false, not found in the DB -> fallback model, pre-filled from the configuration.
-        FilterConfigurationModel model = loadEditorModel(false, configuration);
+        UiDataFilterConfigurationDetail detail = openEditor(filter, configuration, false);
+        FilterConfigurationModel model = detail.getConfigurationDc().getItem();
 
         Assertions.assertTrue(entityStates.isNew(model), "expected a freshly created fallback model");
-        Assertions.assertEquals("Open Projects", model.getName());
-        Assertions.assertEquals("openProjects", model.getConfigurationId());
+        Assertions.assertEquals(RUNTIME_CONFIGURATION_NAME, model.getName());
+        Assertions.assertEquals(RUNTIME_CONFIGURATION_ID, model.getConfigurationId());
     }
 
     @Test
-    @DisplayName("Existing persisted configuration: the stored model is returned unchanged (configurationModel != null)")
-    public void persistedConfigurationReturnsStoredModel() throws Exception {
-        String configurationId = "savedConfiguration";
-        String username = FilterConfigurationPersistenceTestAuthenticator.simpleUser;
-
-        configurationPersistence.save(createPersistedConfiguration(configurationId, username, "Saved configuration"));
-
+    @DisplayName("Saving a named run-time configuration reuses its id: no duplicate, no re-created configuration (#5451)")
+    public void savingInMemoryConfigurationReusesIdWithoutDuplicating() {
         GenericFilter filter = navigateAndGetFilter();
-        Configuration configuration = filter.getConfiguration(configurationId);
-        Assertions.assertNotNull(configuration);
+        Configuration configuration = registerRuntimeConfiguration(filter);
 
-        // isNewConfiguration = false, found in the DB -> the stored model is returned, fallback is skipped.
-        FilterConfigurationModel model = loadEditorModel(false, configuration);
+        UiDataFilterConfigurationDetail detail = openEditor(filter, configuration, false);
+        Configuration result = genericFilterSupport.saveCurrentFilterConfiguration(
+                configuration, false, configuration.getRootLogicalFilterComponent(), detail);
 
-        Assertions.assertFalse(entityStates.isNew(model), "expected the model loaded from the database, not a fallback");
-        Assertions.assertEquals("Saved configuration", model.getName());
-        Assertions.assertEquals(configurationId, model.getConfigurationId());
+        // The existing configuration is updated by its own id, not dropped and re-created with a generated one.
+        Assertions.assertEquals(RUNTIME_CONFIGURATION_ID, result.getId());
+        Assertions.assertNotNull(filter.getConfiguration(RUNTIME_CONFIGURATION_ID),
+                "the configuration must not be removed and re-created on save");
+
+        List<FilterConfigurationModel> stored = configurationPersistence.load(
+                COMPONENT_ID, FilterConfigurationPersistenceTestAuthenticator.simpleUser);
+        Assertions.assertEquals(1, stored.size(), "exactly one configuration must be persisted");
+        Assertions.assertEquals(RUNTIME_CONFIGURATION_ID, stored.get(0).getConfigurationId());
+        Assertions.assertEquals(RUNTIME_CONFIGURATION_NAME, stored.get(0).getName());
     }
 
     @Test
-    @DisplayName("New configuration: the fallback model is left empty (isNewConfiguration = true)")
-    public void newConfigurationDoesNotPrefillName() throws Exception {
+    @DisplayName("New configuration: the editor model is left empty so the user is asked for a name")
+    public void editorDoesNotPrefillForNewConfiguration() {
         GenericFilter filter = navigateAndGetFilter();
 
-        // Creating a new configuration starts from the empty configuration; the DB load is skipped
-        // and the name/id must stay empty so the editor asks the user for a name.
-        FilterConfigurationModel model = loadEditorModel(true, filter.getEmptyConfiguration());
+        UiDataFilterConfigurationDetail detail = openEditor(filter, filter.getEmptyConfiguration(), true);
+        FilterConfigurationModel model = detail.getConfigurationDc().getItem();
 
         Assertions.assertTrue(entityStates.isNew(model));
         Assertions.assertNull(model.getName());
         Assertions.assertNull(model.getConfigurationId());
+    }
+
+    @Test
+    @DisplayName("Existing persisted configuration: the stored model is returned unchanged")
+    public void editorReturnsStoredModelForPersistedConfiguration() {
+        String username = FilterConfigurationPersistenceTestAuthenticator.simpleUser;
+
+        configurationPersistence.save(createPersistedConfiguration(username));
+
+        GenericFilter filter = navigateAndGetFilter();
+        Configuration configuration = filter.getConfiguration(PERSISTED_CONFIGURATION_ID);
+        Assertions.assertNotNull(configuration);
+
+        UiDataFilterConfigurationDetail detail = openEditor(filter, configuration, false);
+        FilterConfigurationModel model = detail.getConfigurationDc().getItem();
+
+        Assertions.assertFalse(entityStates.isNew(model), "expected the model loaded from the database, not a fallback");
+        Assertions.assertEquals(PERSISTED_CONFIGURATION_NAME, model.getName());
+        Assertions.assertEquals(PERSISTED_CONFIGURATION_ID, model.getConfigurationId());
     }
 
     protected GenericFilter navigateAndGetFilter() {
@@ -140,19 +164,48 @@ public class GenericFilterConfigurationNamePrefillTest {
         return view.genericFilter;
     }
 
-    protected FilterConfigurationModel loadEditorModel(boolean isNewConfiguration, Configuration configuration)
-            throws Exception {
-        Method method = GenericFilterSupport.class.getDeclaredMethod(
-                "loadFilterConfigurationModel", boolean.class, Configuration.class);
-        method.setAccessible(true);
-        return (FilterConfigurationModel) method.invoke(genericFilterSupport, isNewConfiguration, configuration);
+    protected Configuration registerRuntimeConfiguration(GenericFilter filter) {
+        PropertyFilter<String> nameFilter = filter.filterComponentBuilder()
+                .<String>propertyFilter()
+                .property("name")
+                .operation(PropertyFilter.Operation.CONTAINS)
+                .build();
+        return filter.runtimeConfigurationBuilder()
+                .id(RUNTIME_CONFIGURATION_ID)
+                .name(RUNTIME_CONFIGURATION_NAME)
+                .add(nameFilter)
+                .makeCurrent()
+                .buildAndRegister();
     }
 
-    protected FilterConfigurationModel createPersistedConfiguration(String configurationId, String username, String name) {
+    /**
+     * Opens the configuration editor the way {@code GenericFilterEditAction} does and returns the detail fragment, so
+     * the editor model can be inspected through the public {@code getConfigurationDc()} API instead of reaching into
+     * the private {@code loadFilterConfigurationModel} method.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected UiDataFilterConfigurationDetail openEditor(GenericFilter filter, Configuration configuration,
+                                                         boolean isNewConfiguration) {
+        View<?> parent = UiTestUtils.getCurrentView();
+        LogicalFilterComponent<?> rootComponent = configuration.getRootLogicalFilterComponent();
+        Class modelClass = filterComponents.getModelClass(rootComponent.getClass());
+        FilterConverter converter = filterComponents.getConverterByComponentClass(rootComponent.getClass(), filter);
+        LogicalFilterCondition model = (LogicalFilterCondition) converter.convertToModel(rootComponent);
+
+        DialogWindow dialog = dialogWindows.detail(parent, modelClass)
+                .withViewId(filterComponents.getDetailViewId(modelClass))
+                .editEntity(model)
+                .build();
+
+        return (UiDataFilterConfigurationDetail) genericFilterSupport.createFilterConfigurationDetail(
+                dialog, isNewConfiguration, configuration);
+    }
+
+    protected FilterConfigurationModel createPersistedConfiguration(String username) {
         FilterConfigurationModel model = dataManager.create(FilterConfigurationModel.class);
-        model.setConfigurationId(configurationId);
+        model.setConfigurationId(PERSISTED_CONFIGURATION_ID);
         model.setComponentId(COMPONENT_ID);
-        model.setName(name);
+        model.setName(PERSISTED_CONFIGURATION_NAME);
         model.setUsername(username);
 
         GroupFilterCondition rootCondition = dataManager.create(GroupFilterCondition.class);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilterSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilterSupport.java
@@ -365,6 +365,13 @@ public class GenericFilterSupport {
         if (configurationModel == null) {
             configurationModel = metadata.create(FilterConfigurationModel.class);
             configurationModel.setUsername(currentUserSubstitution.getEffectiveUser().getUsername());
+            // An existing in-memory configuration that was never persisted: carry its id and name over
+            // so the editor pre-fills the name and a subsequent save updates this configuration by id
+            // instead of creating a duplicate.
+            if (!isNewConfiguration) {
+                configurationModel.setConfigurationId(currentConfiguration.getId());
+                configurationModel.setName(currentConfiguration.getName());
+            }
         }
 
         return configurationModel;

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilterSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilterSupport.java
@@ -365,9 +365,8 @@ public class GenericFilterSupport {
         if (configurationModel == null) {
             configurationModel = metadata.create(FilterConfigurationModel.class);
             configurationModel.setUsername(currentUserSubstitution.getEffectiveUser().getUsername());
-            // An existing in-memory configuration that was never persisted: carry its id and name over
-            // so the editor pre-fills the name and a subsequent save updates this configuration by id
-            // instead of creating a duplicate.
+            // Carry id and name from an existing but unpersisted configuration, so the editor
+            // pre-fills the name and a later save updates it by id instead of creating a duplicate.
             if (!isNewConfiguration) {
                 configurationModel.setConfigurationId(currentConfiguration.getId());
                 configurationModel.setName(currentConfiguration.getName());


### PR DESCRIPTION
Fixes #5451

### Problem

Opening the configuration editor for a named run-time configuration that exists only in memory (created programmatically, or added via `addConfiguration`, and never persisted) shows an empty "Configuration name" field and the "Configuration name required" error, even though the name is visible in the filter header. The conditions are transferred correctly; only the name is lost.

### Root cause

`GenericFilterSupport.loadFilterConfigurationModel(boolean isNewConfiguration, Configuration currentConfiguration)` loads the model from the database by id whenever `isNewConfiguration` is `false` (i.e. the id is not the empty-configuration id). For an in-memory configuration there is no database row, so the load returns `null` and the fallback creates an empty `FilterConfigurationModel` carrying only the username — the name (and id) are not copied. The editor binds to that empty model.

### Fix

In the fallback, when the configuration is not new, copy its `id` and `name` into the model. The id is required as well: on save, `saveCurrentFilterConfiguration` builds the result configuration from `configurationModel.getConfigurationId()`, and `initFilterConfiguration` replaces the existing configuration when the ids differ — so without the id the save would drop the original and create a broken/duplicate configuration. The `isNewConfiguration` guard leaves both empty for a genuinely new configuration.

### Notes

- Pre-existing editor bug, independent of the programmatic-configuration API (#5351): it reproduces for any in-memory named run-time configuration not present in the database, regardless of how it was created.
- The persistence path lives in `flowui-data`, so the regression test lives there too.

### Tests

Added `GenericFilterConfigurationNamePrefillTest` (`flowui-data`) covering all three branches of `loadFilterConfigurationModel(boolean, Configuration)`:

- **Existing in-memory configuration, not in the DB** (`isNewConfiguration == false`, load returns `null`): the fallback model is pre-filled with the configuration's id and name. This is the fixed case — it fails on the unpatched code (`expected: <Open Projects> but was: <null>`) and passes with the fix.
- **Existing persisted configuration** (`isNewConfiguration == false`, `configurationModel != null`): the stored model is returned unchanged, the fallback is not entered.
- **New configuration** (`isNewConfiguration == true`): the fallback model stays empty (no id/name), so creating a new configuration still asks the user for a name — this guards the `!isNewConfiguration` guard.

The branch actually taken is asserted via `EntityStates.isNew` (a model loaded from the database is not new; a `metadata.create` fallback model is). The existing `FilterConfigurationPersistenceTest` stays green.