### PR TITLE
A generic filter created by the programmatic API becomes broken after navigating to the view a second time  #5425

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/filter/BaseConditionSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/filter/BaseConditionSupport.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.component.filter;
+
+import io.jmix.core.annotation.Internal;
+import io.jmix.core.querycondition.Condition;
+import io.jmix.core.querycondition.LogicalCondition;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.UnaryOperator;
+
+/**
+ * Shared composition of a composite filter's output on top of the data loader's base condition, used
+ * by {@code GenericFilter} and {@code GroupFilter}. Keeps the base-condition capture heuristic and the
+ * {@code base AND output} composition in a single place so the two components cannot drift apart.
+ */
+@Internal
+public final class BaseConditionSupport {
+
+    private BaseConditionSupport() {
+    }
+
+    /**
+     * The recomputed state: the (possibly re-captured) base condition and the resulting loader condition.
+     *
+     * @param baseCondition    the base condition to keep (re-captured if the loader condition was replaced)
+     * @param loaderCondition  the composed condition to set on the data loader
+     */
+    public record Result(@Nullable Condition baseCondition, LogicalCondition loaderCondition) {
+    }
+
+    /**
+     * Recomputes the data loader condition as {@code baseCondition AND filterCondition}. The base
+     * condition is re-captured only when the loader condition was replaced externally (a different
+     * object than the filter's last output); the filter never adopts its own output as the base.
+     *
+     * @param currentLoaderCondition   the loader's current condition
+     * @param baseCondition            the base condition captured so far (may be {@code null})
+     * @param baseConditionInitialized whether a base condition has already been captured
+     * @param lastConditionSetByFilter the last condition this filter set on the loader
+     * @param filterCondition          the filter's own output condition
+     * @param copy                     the component's condition-copy function
+     * @return the base condition to keep and the composed loader condition
+     */
+    public static Result recompose(@Nullable Condition currentLoaderCondition,
+                                   @Nullable Condition baseCondition,
+                                   boolean baseConditionInitialized,
+                                   @Nullable Condition lastConditionSetByFilter,
+                                   LogicalCondition filterCondition,
+                                   UnaryOperator<Condition> copy) {
+        Condition base = baseCondition;
+        if (!baseConditionInitialized
+                || (lastConditionSetByFilter != null && currentLoaderCondition != lastConditionSetByFilter)) {
+            base = currentLoaderCondition != null ? copy.apply(currentLoaderCondition) : null;
+        }
+
+        LogicalCondition loaderCondition;
+        if (base instanceof LogicalCondition logicalBase) {
+            loaderCondition = (LogicalCondition) copy.apply(logicalBase);
+            loaderCondition.add(filterCondition);
+        } else if (base != null) {
+            loaderCondition = LogicalCondition.and()
+                    .add(base)
+                    .add(filterCondition);
+        } else {
+            loaderCondition = filterCondition;
+        }
+
+        return new Result(base, loaderCondition);
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilter.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilter.java
@@ -128,6 +128,7 @@ public class GenericFilter extends Composite<JmixDetails>
     protected DropdownButton settingsButton;
     protected List<ResponsiveStep> responsiveSteps;
     protected Registration openedChangeRegistration;
+    protected final List<Registration> conditionOperationChangeRegistrations = new ArrayList<>();
 
     protected LogicalFilterComponent<?> rootLogicalFilterComponent;
     protected Configuration emptyConfiguration;
@@ -715,6 +716,11 @@ public class GenericFilter extends Composite<JmixDetails>
 
         rootLogicalFilterComponent.setAutoApply(isAutoApply());
 
+        // This method runs on every configuration refresh (e.g. each re-navigation); detach the
+        // condition listeners registered on the previous run so they don't accumulate.
+        conditionOperationChangeRegistrations.forEach(Registration::remove);
+        conditionOperationChangeRegistrations.clear();
+
         if (!(getCurrentConfiguration() instanceof DesignTimeConfiguration)) {
             for (FilterComponent filterComponent : rootLogicalFilterComponent.getFilterComponents()) {
                 if (filterComponent instanceof SingleFilterComponentBase) {
@@ -724,10 +730,12 @@ public class GenericFilter extends Composite<JmixDetails>
                 }
 
                 if (filterComponent instanceof PropertyFilter<?> propertyFilter) {
-                    propertyFilter.addOperationChangeListener(operationChangeEvent -> {
-                        updateSingleConditionRemoveButton(propertyFilter);
-                        resetFilterComponentDefaultValue(propertyFilter);
-                    });
+                    Registration operationChangeRegistration =
+                            propertyFilter.addOperationChangeListener(operationChangeEvent -> {
+                                updateSingleConditionRemoveButton(propertyFilter);
+                                resetFilterComponentDefaultValue(propertyFilter);
+                            });
+                    conditionOperationChangeRegistrations.add(operationChangeRegistration);
                 }
             }
         }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilter.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/genericfilter/GenericFilter.java
@@ -46,6 +46,7 @@ import io.jmix.flowui.app.filter.condition.AddConditionView;
 import io.jmix.flowui.component.SupportsResponsiveSteps;
 import io.jmix.flowui.component.UiComponentUtils;
 import io.jmix.flowui.component.details.JmixDetails;
+import io.jmix.flowui.component.filter.BaseConditionSupport;
 import io.jmix.flowui.component.filter.FilterComponent;
 import io.jmix.flowui.component.filter.SingleFilterComponent;
 import io.jmix.flowui.component.filter.SingleFilterComponentBase;
@@ -836,33 +837,19 @@ public class GenericFilter extends Composite<JmixDetails>
     }
 
     protected void updateDataLoaderCondition() {
-        if (dataLoader != null) {
-            Condition currentCondition = dataLoader.getCondition();
-            // Re-capture the loader's own condition only when it was replaced externally (a different
-            // object than the filter's last output); the filter never adopts its own output.
-            if (!initialDataLoaderConditionInitialized
-                    || (lastConditionSetByFilter != null && currentCondition != lastConditionSetByFilter)) {
-                initialDataLoaderCondition = copy(currentCondition);
-                initialDataLoaderConditionInitialized = true;
-            }
-            LogicalFilterComponent<?> logicalFilterComponent = getCurrentConfiguration().getRootLogicalFilterComponent();
-            LogicalCondition filterCondition = logicalFilterComponent.getQueryCondition();
-
-            LogicalCondition resultCondition;
-            if (initialDataLoaderCondition instanceof LogicalCondition initialLogicalCondition) {
-                resultCondition = ((LogicalCondition) copy(initialLogicalCondition));
-                Objects.requireNonNull(resultCondition).add(filterCondition);
-            } else if (initialDataLoaderCondition != null) {
-                resultCondition = LogicalCondition.and()
-                        .add(initialDataLoaderCondition)
-                        .add(filterCondition);
-            } else {
-                resultCondition = filterCondition;
-            }
-
-            dataLoader.setCondition(resultCondition);
-            lastConditionSetByFilter = resultCondition;
+        if (dataLoader == null) {
+            return;
         }
+        // The base-condition capture heuristic and the base-AND-output composition are shared with
+        // GroupFilter.updateDataLoaderCondition via BaseConditionSupport; keep the two in sync there.
+        LogicalCondition filterCondition = getCurrentConfiguration().getRootLogicalFilterComponent().getQueryCondition();
+        BaseConditionSupport.Result result = BaseConditionSupport.recompose(dataLoader.getCondition(),
+                initialDataLoaderCondition, initialDataLoaderConditionInitialized, lastConditionSetByFilter,
+                filterCondition, this::copy);
+        initialDataLoaderCondition = result.baseCondition();
+        initialDataLoaderConditionInitialized = true;
+        dataLoader.setCondition(result.loaderCondition());
+        lastConditionSetByFilter = result.loaderCondition();
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/logicalfilter/GroupFilter.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/logicalfilter/GroupFilter.java
@@ -32,6 +32,7 @@ import io.jmix.flowui.UiComponentProperties;
 import io.jmix.flowui.UiComponents;
 import io.jmix.flowui.component.SupportsResponsiveSteps;
 import io.jmix.flowui.component.WrapperUtils;
+import io.jmix.flowui.component.filter.BaseConditionSupport;
 import io.jmix.flowui.component.filter.FilterComponent;
 import io.jmix.flowui.component.filter.SingleFilterComponent;
 import io.jmix.flowui.component.filter.SingleFilterComponentBase;
@@ -212,29 +213,15 @@ public class GroupFilter extends Composite<VerticalLayout>
             return;
         }
 
-        Condition currentCondition = dataLoader.getCondition();
-        // Re-capture the loader's own condition only when it was replaced externally (a different
-        // object than the filter's last output); the filter never adopts its own output.
-        if (!initialDataLoaderConditionInitialized
-                || (lastConditionSetByFilter != null && currentCondition != lastConditionSetByFilter)) {
-            initialDataLoaderCondition = copy(currentCondition);
-            initialDataLoaderConditionInitialized = true;
-        }
-
-        LogicalCondition resultCondition;
-        if (initialDataLoaderCondition instanceof LogicalCondition initialLogicalCondition) {
-            resultCondition = ((LogicalCondition) copy(initialLogicalCondition));
-            Objects.requireNonNull(resultCondition).add(getQueryCondition());
-        } else if (initialDataLoaderCondition != null) {
-            resultCondition = LogicalCondition.and()
-                    .add(initialDataLoaderCondition)
-                    .add(getQueryCondition());
-        } else {
-            resultCondition = getQueryCondition();
-        }
-
-        dataLoader.setCondition(resultCondition);
-        lastConditionSetByFilter = resultCondition;
+        // The base-condition capture heuristic and the base-AND-output composition are shared with
+        // GenericFilter.updateDataLoaderCondition via BaseConditionSupport; keep the two in sync there.
+        BaseConditionSupport.Result result = BaseConditionSupport.recompose(dataLoader.getCondition(),
+                initialDataLoaderCondition, initialDataLoaderConditionInitialized, lastConditionSetByFilter,
+                getQueryCondition(), this::copy);
+        initialDataLoaderCondition = result.baseCondition();
+        initialDataLoaderConditionInitialized = true;
+        dataLoader.setCondition(result.loaderCondition());
+        lastConditionSetByFilter = result.loaderCondition();
     }
 
     @Override

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/logicalfilter/GroupFilter.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/logicalfilter/GroupFilter.java
@@ -85,6 +85,7 @@ public class GroupFilter extends Composite<VerticalLayout>
 
     protected FormLayout conditionsLayout;
     protected Map<FilterComponent, FormLayout.FormItem> filterComponentFormItemMap;
+    protected Map<FilterComponent, Registration> operationChangeRegistrations = new HashMap<>();
 
     @Override
     public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
@@ -280,7 +281,11 @@ public class GroupFilter extends Composite<VerticalLayout>
         addFilterComponentToConditionsLayout(conditionsLayout, filterComponent);
 
         if (filterComponent instanceof PropertyFilter) {
-            ((PropertyFilter<?>) filterComponent).addOperationChangeListener(operationChangeEvent -> apply());
+            // Keep the registration so remove() can detach it; otherwise re-adding a component
+            // (e.g. on a filter re-navigation restore) would accumulate stale apply() listeners.
+            Registration operationChangeRegistration = ((PropertyFilter<?>) filterComponent)
+                    .addOperationChangeListener(operationChangeEvent -> apply());
+            operationChangeRegistrations.put(filterComponent, operationChangeRegistration);
         }
 
         if (!isConditionModificationDelegated()) {
@@ -309,6 +314,11 @@ public class GroupFilter extends Composite<VerticalLayout>
 
             if (ownFilterComponentsOrder.isEmpty()) {
                 ownFilterComponentsOrder = null;
+            }
+
+            Registration operationChangeRegistration = operationChangeRegistrations.remove(filterComponent);
+            if (operationChangeRegistration != null) {
+                operationChangeRegistration.remove();
             }
 
             FormLayout.FormItem formItem = null;
@@ -341,6 +351,10 @@ public class GroupFilter extends Composite<VerticalLayout>
     @Override
     public void removeAll() {
         ownFilterComponentsOrder = null;
+
+        operationChangeRegistrations.values().forEach(Registration::remove);
+        operationChangeRegistrations.clear();
+
         updateConditionsLayout();
 
         if (!isConditionModificationDelegated()) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/DataGridFilterUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/DataGridFilterUrlQueryParametersBinder.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.grid.Grid;
 import com.vaadin.flow.router.QueryParameters;
+import io.jmix.core.annotation.Internal;
 import io.jmix.flowui.component.UiComponentUtils;
 import io.jmix.flowui.component.grid.DataGrid;
 import io.jmix.flowui.component.grid.DataGridColumn;
@@ -62,6 +63,7 @@ public class DataGridFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
     protected UrlParamSerializer urlParamSerializer;
     protected FilterUrlQueryParametersSupport filterUrlQueryParametersSupport;
     protected RouteSupport routeSupport;
+    protected SingleFilterComponentStateSupport singleFilterComponentStateSupport;
 
     protected List<InitialState> initialStates = new ArrayList<>();
 
@@ -79,6 +81,7 @@ public class DataGridFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
     protected void autowireDependencies() {
         filterUrlQueryParametersSupport = applicationContext.getBean(FilterUrlQueryParametersSupport.class);
         routeSupport = applicationContext.getBean(RouteSupport.class);
+        singleFilterComponentStateSupport = applicationContext.getBean(SingleFilterComponentStateSupport.class);
     }
 
     protected void initComponent(Grid<?> grid) {
@@ -102,8 +105,7 @@ public class DataGridFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
                         new InitialState(
                                 dataGridColumn.getKey(),
                                 Objects.requireNonNull(propertyFilter.getProperty()),
-                                propertyFilter.getOperation(),
-                                propertyFilter.getValue()
+                                singleFilterComponentStateSupport.capture(propertyFilter)
                         )
                 );
             }
@@ -163,8 +165,7 @@ public class DataGridFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
                     && initialState.property.equals(headerFilter.getPropertyFilter().getProperty())) {
                 PropertyFilter propertyFilter = headerFilter.getPropertyFilter();
 
-                propertyFilter.setOperation(initialState.operation);
-                propertyFilter.setValue(initialState.value);
+                singleFilterComponentStateSupport.restore(propertyFilter, initialState.state());
                 headerFilter.apply();
             }
         }
@@ -293,11 +294,11 @@ public class DataGridFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
     /**
      * A POJO class for storing properties of the {@link DataGridHeaderFilter}'s initial state.
      *
-     * @param key       the value of {@code key} of the filter
-     * @param property  the value of {@code property} of the filter
-     * @param operation the value of {@code operation} at initialization
-     * @param value     the value of {@code value} at initialization
+     * @param key      the value of {@code key} of the filter
+     * @param property the value of {@code property} of the filter
+     * @param state    the captured runtime-editable state (operation and value) at initialization
      */
-    protected record InitialState(String key, String property, PropertyFilter.Operation operation, Object value) {
+    @Internal
+    protected record InitialState(String key, String property, SingleFilterComponentStateSupport.State state) {
     }
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/DataGridFilterUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/DataGridFilterUrlQueryParametersBinder.java
@@ -153,7 +153,7 @@ public class DataGridFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
                 parameterValue;
     }
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings({"rawtypes"})
     @Override
     public void applyInitialState() {
         for (InitialState initialState : initialStates) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.shared.Registration;
 import io.jmix.core.AccessManager;
 import io.jmix.core.MetadataTools;
 import io.jmix.core.accesscontext.EntityAttributeContext;
+import io.jmix.core.annotation.Internal;
 import io.jmix.core.entity.annotation.SystemLevel;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaPropertyPath;
@@ -35,6 +36,7 @@ import io.jmix.core.querycondition.PropertyConditionUtils;
 import io.jmix.flowui.UiComponents;
 import io.jmix.flowui.component.UiComponentUtils;
 import io.jmix.flowui.component.filter.FilterComponent;
+import io.jmix.flowui.component.filter.SingleFilterComponentBase;
 import io.jmix.flowui.component.genericfilter.Configuration;
 import io.jmix.flowui.component.genericfilter.FilterUtils;
 import io.jmix.flowui.component.genericfilter.GenericFilter;
@@ -83,6 +85,7 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
     protected ApplicationContext applicationContext;
     protected UrlParamSerializer urlParamSerializer;
     protected UiComponents uiComponents;
+    protected SingleFilterComponentStateSupport singleFilterComponentStateSupport;
     protected SingleFilterSupport singleFilterSupport;
     protected MetadataTools metadataTools;
     protected FilterUrlQueryParametersSupport filterUrlQueryParametersSupport;
@@ -105,6 +108,7 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
 
     protected void autowireDependencies() {
         uiComponents = applicationContext.getBean(UiComponents.class);
+        singleFilterComponentStateSupport = applicationContext.getBean(SingleFilterComponentStateSupport.class);
         filterUrlQueryParametersSupport = applicationContext.getBean(FilterUrlQueryParametersSupport.class);
         accessManager = applicationContext.getBean(AccessManager.class);
     }
@@ -117,7 +121,61 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
 
     @Override
     public void saveInitialState() {
-        initialState = new InitialState(filter.getCurrentConfiguration());
+        Configuration configuration = filter.getCurrentConfiguration();
+        LogicalFilterComponent<?> rootLogicalFilterComponent = configuration.getRootLogicalFilterComponent();
+        initialState = new InitialState(configuration,
+                captureStructure(configuration, rootLogicalFilterComponent),
+                captureInitialStates(rootLogicalFilterComponent),
+                captureInitialDefaultValues(configuration, rootLogicalFilterComponent));
+    }
+
+    protected List<ComponentNode> captureStructure(Configuration configuration,
+                                                   LogicalFilterComponent<?> logicalFilterComponent) {
+        List<ComponentNode> nodes = new ArrayList<>();
+        for (FilterComponent component : logicalFilterComponent.getOwnFilterComponents()) {
+            List<ComponentNode> children = component instanceof LogicalFilterComponent<?> nestedComponent
+                    ? captureStructure(configuration, nestedComponent)
+                    : List.of();
+            nodes.add(new ComponentNode(component,
+                    configuration.isFilterComponentModified(component),
+                    children));
+        }
+        return nodes;
+    }
+
+    protected Map<String, Object> captureInitialDefaultValues(Configuration configuration,
+                                                              LogicalFilterComponent<?> rootLogicalFilterComponent) {
+        Map<String, Object> defaultValues = new HashMap<>();
+        for (FilterComponent component : rootLogicalFilterComponent.getFilterComponents()) {
+            if (component instanceof SingleFilterComponentBase<?> singleFilterComponent) {
+                String parameterName = singleFilterComponent.getParameterName();
+                if (parameterName != null) {
+                    Object defaultValue = configuration.getFilterComponentDefaultValue(parameterName);
+                    if (defaultValue != null) {
+                        defaultValues.put(parameterName, defaultValue);
+                    }
+                }
+            }
+        }
+        return defaultValues;
+    }
+
+    protected Map<SingleFilterComponentBase<?>, SingleFilterComponentStateSupport.State> captureInitialStates(
+            LogicalFilterComponent<?> rootLogicalFilterComponent) {
+        Map<SingleFilterComponentBase<?>, SingleFilterComponentStateSupport.State> states = new IdentityHashMap<>();
+        collectInitialStates(rootLogicalFilterComponent.getOwnFilterComponents(), states);
+        return states;
+    }
+
+    protected void collectInitialStates(Collection<FilterComponent> components,
+                                        Map<SingleFilterComponentBase<?>, SingleFilterComponentStateSupport.State> states) {
+        for (FilterComponent component : components) {
+            if (component instanceof SingleFilterComponentBase<?> singleFilterComponent) {
+                states.put(singleFilterComponent, singleFilterComponentStateSupport.capture(singleFilterComponent));
+            } else if (component instanceof LogicalFilterComponent<?> logicalFilterComponent) {
+                collectInitialStates(logicalFilterComponent.getOwnFilterComponents(), states);
+            }
+        }
     }
 
     protected void bindDataLoaderListener(GenericFilter filter) {
@@ -205,11 +263,64 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
 
     @Override
     public void applyInitialState() {
-        if (initialState.configuration instanceof RunTimeConfiguration runTimeConfiguration) {
-            runTimeConfiguration.getRootLogicalFilterComponent().removeAll();
+        // The reconciliation performs many add/remove operations; each would otherwise fire a
+        // FilterComponentsChangeEvent and trigger a full updateQueryParameters(). Suppress that
+        // storm by unbinding the listener for the duration and rebinding once afterwards.
+        unbindFilterComponentsChange();
+        try {
+            // Structural restore and default-value re-registration apply only to runtime
+            // configurations; a design-time configuration has no such user/URL-driven changes.
+            if (initialState.configuration instanceof RunTimeConfiguration runTimeConfiguration) {
+                restoreStructure(runTimeConfiguration,
+                        runTimeConfiguration.getRootLogicalFilterComponent(),
+                        initialState.structure);
+                restoreInitialDefaultValues(runTimeConfiguration);
+            }
+            // A value or operation changed via the URL must be reset for any configuration type,
+            // including a design-time configuration, whose captured state is restored here too.
+            restoreInitialStates();
+        } finally {
+            bindFilterComponentsChangeListener(filter);
         }
 
         filter.setCurrentConfiguration(initialState.configuration);
+    }
+
+    protected void restoreStructure(Configuration configuration,
+                                    LogicalFilterComponent<?> logicalFilterComponent,
+                                    List<ComponentNode> structure) {
+        // Reconcile this logical component's own children to their initial set, in the original order:
+        // drop components added after initialization (e.g. from the URL) and restore those the user
+        // removed, recursing into nested groups so the whole configuration tree is rebuilt exactly.
+        // Component instances are preserved, so references handed to application code stay valid.
+        // For the empty configuration the initial structure is empty, so this clears the root.
+        for (FilterComponent component : List.copyOf(logicalFilterComponent.getOwnFilterComponents())) {
+            logicalFilterComponent.remove(component);
+            configuration.setFilterComponentModified(component, false);
+        }
+        for (ComponentNode node : structure) {
+            logicalFilterComponent.add(node.component());
+            configuration.setFilterComponentModified(node.component(), node.modified());
+            if (node.component() instanceof LogicalFilterComponent<?> nestedComponent) {
+                restoreStructure(configuration, nestedComponent, node.children());
+            }
+        }
+    }
+
+    protected void restoreInitialDefaultValues(RunTimeConfiguration configuration) {
+        // The condition remove button and URL-driven operation changes reset registered default
+        // values; re-register the initial ones so a later configuration switch restores them
+        // instead of falling back to null.
+        configuration.resetAllDefaultValues();
+        initialState.defaultValues.forEach(configuration::setFilterComponentDefaultValue);
+    }
+
+    protected void restoreInitialStates() {
+        // The resettable fields (operation + value) and their restore order are defined in
+        // SingleFilterComponentStateSupport. A surviving baseline component can be mutated in place
+        // only by #updatePropertyCondition; keep the captured fields in sync if the reconciliation in
+        // #updateFilterComponent is extended to JpqlFilter/GroupFilter.
+        initialState.states.forEach(singleFilterComponentStateSupport::restore);
     }
 
     @Override
@@ -509,10 +620,38 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
     }
 
     /**
-     * A POJO class for storing configuration of the {@link GenericFilter}'s initial state.
+     * A POJO class for storing the {@link GenericFilter}'s initial state.
      *
-     * @param configuration the value of {@code configuration} at initialization
+     * @param configuration the current configuration at initialization
+     * @param structure     the configuration's initial component tree — each root child in order,
+     *                      recursively including nested groups' own children — that a restore
+     *                      reconstructs (re-adding user-removed components, dropping URL-added ones),
+     *                      carrying each component's {@code modified} flag (controls its remove button)
+     * @param states        the initial state (operation and value) of the baseline single filter
+     *                      components, keyed by identity, used to reset components whose operation or
+     *                      value was changed via the URL
+     * @param defaultValues the initial default values registered for the configuration, keyed by
+     *                      parameter name, re-registered on restore so a later configuration switch
+     *                      keeps them instead of falling back to null
      */
-    protected record InitialState(Configuration configuration) {
+    @Internal
+    protected record InitialState(Configuration configuration,
+                                  List<ComponentNode> structure,
+                                  Map<SingleFilterComponentBase<?>, SingleFilterComponentStateSupport.State> states,
+                                  Map<String, Object> defaultValues) {
+    }
+
+    /**
+     * A node of the captured configuration structure: a filter component, its initial {@code modified}
+     * flag, and, for a nested {@link LogicalFilterComponent}, its own ordered child nodes.
+     *
+     * @param component the filter component
+     * @param modified  the component's {@code modified} flag at initialization
+     * @param children  the ordered child nodes for a nested logical component, empty otherwise
+     */
+    @Internal
+    protected record ComponentNode(FilterComponent component,
+                                   boolean modified,
+                                   List<ComponentNode> children) {
     }
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
@@ -93,7 +93,9 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
 
     protected Registration filterComponentsChangeRegistration;
 
-    protected InitialState initialState;
+    protected final List<InitialState> initialStates = new ArrayList<>();
+
+    protected Configuration entryConfiguration;
 
     public GenericFilterUrlQueryParametersBinder(GenericFilter filter,
                                                  UrlParamSerializer urlParamSerializer,
@@ -121,12 +123,25 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
 
     @Override
     public void saveInitialState() {
-        Configuration configuration = filter.getCurrentConfiguration();
-        LogicalFilterComponent<?> rootLogicalFilterComponent = configuration.getRootLogicalFilterComponent();
-        initialState = new InitialState(configuration,
-                captureStructure(configuration, rootLogicalFilterComponent),
-                captureInitialStates(rootLogicalFilterComponent),
-                captureInitialDefaultValues(configuration, rootLogicalFilterComponent));
+        // Snapshot every configuration, not only the entry one, so a clean re-navigation can restore
+        // each configuration the user or the URL touched during the session (not just the current one).
+        initialStates.clear();
+        entryConfiguration = filter.getCurrentConfiguration();
+        for (Configuration configuration : collectConfigurations()) {
+            LogicalFilterComponent<?> rootLogicalFilterComponent = configuration.getRootLogicalFilterComponent();
+            initialStates.add(new InitialState(configuration,
+                    captureStructure(configuration, rootLogicalFilterComponent),
+                    captureInitialStates(rootLogicalFilterComponent),
+                    captureInitialDefaultValues(configuration, rootLogicalFilterComponent)));
+        }
+    }
+
+    protected List<Configuration> collectConfigurations() {
+        List<Configuration> configurations = new ArrayList<>(filter.getConfigurations());
+        if (!configurations.contains(filter.getEmptyConfiguration())) {
+            configurations.add(filter.getEmptyConfiguration());
+        }
+        return configurations;
     }
 
     protected List<ComponentNode> captureStructure(Configuration configuration,
@@ -268,22 +283,26 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
         // storm by unbinding the listener for the duration and rebinding once afterwards.
         unbindFilterComponentsChange();
         try {
-            // Structural restore and default-value re-registration apply only to runtime
-            // configurations; a design-time configuration has no such user/URL-driven changes.
-            if (initialState.configuration instanceof RunTimeConfiguration runTimeConfiguration) {
-                restoreStructure(runTimeConfiguration,
-                        runTimeConfiguration.getRootLogicalFilterComponent(),
-                        initialState.structure);
-                restoreInitialDefaultValues(runTimeConfiguration);
+            // Restore every snapshotted configuration, not only the entry one, so changes made to
+            // other configurations during the session are reverted as well.
+            for (InitialState state : initialStates) {
+                // Structural restore and default-value re-registration apply only to runtime
+                // configurations; a design-time configuration has no such user/URL-driven changes.
+                if (state.configuration instanceof RunTimeConfiguration runTimeConfiguration) {
+                    restoreStructure(runTimeConfiguration,
+                            runTimeConfiguration.getRootLogicalFilterComponent(),
+                            state.structure);
+                    restoreInitialDefaultValues(runTimeConfiguration, state);
+                }
+                // A value or operation changed via the URL must be reset for any configuration type,
+                // including a design-time configuration, whose captured state is restored here too.
+                restoreInitialStates(state);
             }
-            // A value or operation changed via the URL must be reset for any configuration type,
-            // including a design-time configuration, whose captured state is restored here too.
-            restoreInitialStates();
         } finally {
             bindFilterComponentsChangeListener(filter);
         }
 
-        filter.setCurrentConfiguration(initialState.configuration);
+        filter.setCurrentConfiguration(entryConfiguration);
     }
 
     protected void restoreStructure(Configuration configuration,
@@ -307,20 +326,20 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
         }
     }
 
-    protected void restoreInitialDefaultValues(RunTimeConfiguration configuration) {
+    protected void restoreInitialDefaultValues(RunTimeConfiguration configuration, InitialState state) {
         // The condition remove button and URL-driven operation changes reset registered default
         // values; re-register the initial ones so a later configuration switch restores them
         // instead of falling back to null.
         configuration.resetAllDefaultValues();
-        initialState.defaultValues.forEach(configuration::setFilterComponentDefaultValue);
+        state.defaultValues.forEach(configuration::setFilterComponentDefaultValue);
     }
 
-    protected void restoreInitialStates() {
+    protected void restoreInitialStates(InitialState state) {
         // The resettable fields (operation + value) and their restore order are defined in
         // SingleFilterComponentStateSupport. A surviving baseline component can be mutated in place
         // only by #updatePropertyCondition; keep the captured fields in sync if the reconciliation in
         // #updateFilterComponent is extended to JpqlFilter/GroupFilter.
-        initialState.states.forEach(singleFilterComponentStateSupport::restore);
+        state.states.forEach(singleFilterComponentStateSupport::restore);
     }
 
     @Override

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/PropertyFilterUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/PropertyFilterUrlQueryParametersBinder.java
@@ -64,8 +64,9 @@ public class PropertyFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
     protected ApplicationContext applicationContext;
     protected UrlParamSerializer urlParamSerializer;
     protected FilterUrlQueryParametersSupport filterUrlQueryParametersSupport;
+    protected SingleFilterComponentStateSupport singleFilterComponentStateSupport;
 
-    protected InitialState initialState;
+    protected SingleFilterComponentStateSupport.State initialState;
 
     public PropertyFilterUrlQueryParametersBinder(PropertyFilter<?> filter,
                                                   UrlParamSerializer urlParamSerializer,
@@ -80,6 +81,7 @@ public class PropertyFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
 
     protected void autowireDependencies() {
         filterUrlQueryParametersSupport = applicationContext.getBean(FilterUrlQueryParametersSupport.class);
+        singleFilterComponentStateSupport = applicationContext.getBean(SingleFilterComponentStateSupport.class);
     }
 
     protected void initComponent(PropertyFilter<?> filter) {
@@ -89,7 +91,7 @@ public class PropertyFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
 
     @Override
     public void saveInitialState() {
-        initialState = new InitialState(filter.getOperation(), filter.getValue());
+        initialState = singleFilterComponentStateSupport.capture(filter);
     }
 
     @SuppressWarnings("rawtypes")
@@ -118,8 +120,7 @@ public class PropertyFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
     @SuppressWarnings("unchecked")
     @Override
     public void applyInitialState() {
-        filter.setOperation(initialState.operation);
-        filter.setValue(initialState.value);
+        singleFilterComponentStateSupport.restore(filter, initialState);
     }
 
     @Override
@@ -200,12 +201,4 @@ public class PropertyFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
         return filter;
     }
 
-    /**
-     * A POJO class for storing properties of the {@link PropertyFilter}'s initial state.
-     *
-     * @param operation the value of {@code operation} at initialization
-     * @param value     the value of {@code value} at initialization
-     */
-    protected record InitialState(Operation operation, Object value) {
-    }
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/PropertyFilterUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/PropertyFilterUrlQueryParametersBinder.java
@@ -117,7 +117,6 @@ public class PropertyFilterUrlQueryParametersBinder extends AbstractUrlQueryPara
         fireQueryParametersChanged(new UrlQueryParametersChangeEvent(this, queryParameters));
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public void applyInitialState() {
         singleFilterComponentStateSupport.restore(filter, initialState);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/SingleFilterComponentStateSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/SingleFilterComponentStateSupport.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.facet.urlqueryparameters;
+
+import io.jmix.core.annotation.Internal;
+import io.jmix.flowui.component.filter.SingleFilterComponentBase;
+import io.jmix.flowui.component.propertyfilter.PropertyFilter;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+/**
+ * Captures and restores the runtime-editable state of a single filter component — its operation
+ * (for a {@link PropertyFilter}) and value. Used by the URL query parameter binders so that the
+ * definition of "a filter condition's resettable state" lives in one place instead of being
+ * duplicated per binder.
+ */
+@Internal
+@Component("flowui_SingleFilterComponentStateSupport")
+public class SingleFilterComponentStateSupport {
+
+    /**
+     * Captures the runtime-editable state of the given single filter component.
+     *
+     * @param filterComponent the filter component whose state to capture
+     * @return the captured state
+     */
+    public State capture(SingleFilterComponentBase<?> filterComponent) {
+        PropertyFilter.Operation operation = filterComponent instanceof PropertyFilter<?> propertyFilter
+                ? propertyFilter.getOperation()
+                : null;
+        return new State(operation, filterComponent.getValue());
+    }
+
+    /**
+     * Restores the previously captured state onto the given single filter component. The operation
+     * is applied before the value, because changing the operation may recreate the value component
+     * and clear the value.
+     *
+     * @param filterComponent the filter component to restore
+     * @param state           the state captured by {@link #capture(SingleFilterComponentBase)}
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public void restore(SingleFilterComponentBase filterComponent, State state) {
+        if (filterComponent instanceof PropertyFilter propertyFilter && state.operation() != null) {
+            propertyFilter.setOperation(state.operation());
+        }
+        filterComponent.setValue(state.value());
+    }
+
+    /**
+     * The runtime-editable state of a single filter component.
+     *
+     * @param operation the {@link PropertyFilter} operation, or {@code null} for components without
+     *                  a runtime-editable operation
+     * @param value     the component value
+     */
+    public record State(PropertyFilter.@Nullable Operation operation, @Nullable Object value) {
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterBaseConditionAfterActivationTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterBaseConditionAfterActivationTest.groovy
@@ -16,16 +16,17 @@
 
 package component.genericfilter
 
-import component.genericfilter.view.GfBaseConditionAfterActivationView
-import component.genericfilter.view.GfBaseConditionReviseView
-import component.genericfilter.view.GfConfigsNoActivationView
-import io.jmix.core.querycondition.Condition
+import component.genericfilter.view.GfBaseConditionAfterActivationTestView
+import component.genericfilter.view.GfBaseConditionReviseTestView
+import component.genericfilter.view.GfConfigsNoActivationTestView
 import io.jmix.core.querycondition.LogicalCondition
 import io.jmix.core.querycondition.PropertyCondition
 import io.jmix.flowui.component.genericfilter.FilterUtils
 import io.jmix.flowui.component.genericfilter.GenericFilter
 import org.springframework.boot.test.context.SpringBootTest
 import test_support.spec.FlowuiTestSpecification
+
+import static component.genericfilter.TestFilterConditions.hasPropertyConditionOn
 
 /**
  * A base condition set on the data loader after a configuration is activated in {@code onInit}
@@ -40,7 +41,7 @@ class GenericFilterBaseConditionAfterActivationTest extends FlowuiTestSpecificat
 
     def "base condition set after activation in onInit survives a configuration switch"() {
         when: "the view opens: c1 activated in onInit, then a base condition on 'amount' set on the loader"
-        GenericFilter filter = navigateToView(GfBaseConditionAfterActivationView).genericFilter
+        GenericFilter filter = navigateToView(GfBaseConditionAfterActivationTestView).genericFilter
 
         and: "switching to c2"
         filter.setCurrentConfiguration(filter.getConfiguration("c2"))
@@ -51,7 +52,7 @@ class GenericFilterBaseConditionAfterActivationTest extends FlowuiTestSpecificat
 
     def "base condition revised after activation in onInit is the one preserved on switch"() {
         when: "the view opens: base on 'amount', activate c1, then base revised to 'total' — all in onInit"
-        GenericFilter filter = navigateToView(GfBaseConditionReviseView).genericFilter
+        GenericFilter filter = navigateToView(GfBaseConditionReviseTestView).genericFilter
 
         and: "switching to c2"
         filter.setCurrentConfiguration(filter.getConfiguration("c2"))
@@ -62,7 +63,7 @@ class GenericFilterBaseConditionAfterActivationTest extends FlowuiTestSpecificat
 
     def "explicitly set initial condition is preserved when a configuration is later activated"() {
         given: "the view opens with a configuration built but not activated (filter has not contributed yet)"
-        GenericFilter filter = navigateToView(GfConfigsNoActivationView).genericFilter
+        GenericFilter filter = navigateToView(GfConfigsNoActivationTestView).genericFilter
 
         and: "the loader already holds some condition, and a DIFFERENT initial condition is set explicitly"
         filter.dataLoader.setCondition(PropertyCondition.equal("number", "X"))
@@ -77,7 +78,7 @@ class GenericFilterBaseConditionAfterActivationTest extends FlowuiTestSpecificat
 
     def "a logical base condition is preserved and combined with the active configuration"() {
         given: "the view opens with a configuration built but not activated"
-        GenericFilter filter = navigateToView(GfConfigsNoActivationView).genericFilter
+        GenericFilter filter = navigateToView(GfConfigsNoActivationTestView).genericFilter
 
         and: "the loader has a logical base condition with two properties"
         filter.dataLoader.setCondition(LogicalCondition.and(
@@ -92,13 +93,4 @@ class GenericFilterBaseConditionAfterActivationTest extends FlowuiTestSpecificat
         hasPropertyConditionOn(filter.dataLoader.condition, "total")
     }
 
-    protected static boolean hasPropertyConditionOn(Condition condition, String property) {
-        if (condition instanceof PropertyCondition) {
-            return property == condition.property
-        }
-        if (condition instanceof LogicalCondition) {
-            return condition.conditions.any { hasPropertyConditionOn(it, property) }
-        }
-        return false
-    }
 }

--- a/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterInitialConditionTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterInitialConditionTest.groovy
@@ -17,12 +17,11 @@
 package component.genericfilter
 
 import component.genericfilter.view.GenericFilterInitialConditionTestView
-import io.jmix.core.querycondition.Condition
-import io.jmix.core.querycondition.LogicalCondition
-import io.jmix.core.querycondition.PropertyCondition
 import io.jmix.flowui.component.genericfilter.GenericFilter
 import org.springframework.boot.test.context.SpringBootTest
 import test_support.spec.FlowuiTestSpecification
+
+import static component.genericfilter.TestFilterConditions.countPropertyConditions
 
 /**
  * Regression test: activating a configuration during {@code onInit} must not pollute the data
@@ -50,13 +49,4 @@ class GenericFilterInitialConditionTest extends FlowuiTestSpecification {
         countPropertyConditions(filter.dataLoader.condition) == 1
     }
 
-    protected static int countPropertyConditions(Condition condition) {
-        if (condition instanceof PropertyCondition) {
-            return 1
-        }
-        if (condition instanceof LogicalCondition) {
-            return condition.conditions.inject(0) { acc, c -> acc + countPropertyConditions(c) }
-        }
-        return 0
-    }
 }

--- a/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterMakeCurrentActivationTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterMakeCurrentActivationTest.groovy
@@ -16,16 +16,15 @@
 
 package component.genericfilter
 
-import component.genericfilter.view.GfActivationBeforeShowView
-import component.genericfilter.view.GfActivationDoubleLoadView
-import component.genericfilter.view.GfActivationOnInitDlcView
-import component.genericfilter.view.GfActivationOnInitNoDlcView
-import component.genericfilter.view.GfActivationPlainSetCurrentView
-import io.jmix.core.querycondition.Condition
-import io.jmix.core.querycondition.LogicalCondition
-import io.jmix.core.querycondition.PropertyCondition
+import component.genericfilter.view.GfActivationBeforeShowTestView
+import component.genericfilter.view.GfActivationDoubleLoadTestView
+import component.genericfilter.view.GfActivationOnInitDlcTestView
+import component.genericfilter.view.GfActivationOnInitNoDlcTestView
+import component.genericfilter.view.GfActivationPlainSetCurrentTestView
 import org.springframework.boot.test.context.SpringBootTest
 import test_support.spec.FlowuiTestSpecification
+
+import static component.genericfilter.TestFilterConditions.countPropertyConditions
 
 /**
  * Integration tests for the variability of configuration activation via the GenericFilter builder:
@@ -42,7 +41,7 @@ class GenericFilterMakeCurrentActivationTest extends FlowuiTestSpecification {
 
     def "makeCurrent in onInit activates the configuration synchronously"() {
         when: "the view opens; c1 is made current via makeCurrent() in onInit"
-        def view = navigateToView(GfActivationOnInitNoDlcView)
+        def view = navigateToView(GfActivationOnInitNoDlcTestView)
 
         then: "the configuration was made current immediately during onInit (right after buildAndRegister)"
         view.currentRightAfterMakeCurrent.id == "c1"
@@ -53,7 +52,7 @@ class GenericFilterMakeCurrentActivationTest extends FlowuiTestSpecification {
 
     def "without a DataLoadCoordinator, makeCurrent triggers a single filtered load on open"() {
         when: "the view opens (no DataLoadCoordinator); applyFilterIfNeeded loads the default-valued config"
-        def view = navigateToView(GfActivationOnInitNoDlcView)
+        def view = navigateToView(GfActivationOnInitNoDlcTestView)
 
         then: "exactly one load happened, filtered by the active configuration"
         view.loadCount == 1
@@ -62,7 +61,7 @@ class GenericFilterMakeCurrentActivationTest extends FlowuiTestSpecification {
 
     def "with a DataLoadCoordinator, makeCurrent yields exactly one filtered load on open"() {
         when: "the view opens (with a DataLoadCoordinator)"
-        def view = navigateToView(GfActivationOnInitDlcView)
+        def view = navigateToView(GfActivationOnInitDlcTestView)
 
         then: "exactly one load happened, with the configuration's condition applied"
         view.loadCount == 1
@@ -71,7 +70,7 @@ class GenericFilterMakeCurrentActivationTest extends FlowuiTestSpecification {
 
     def "activation in BeforeShow (filter already attached) is synchronous and switching applies only the new configuration"() {
         when: "the view opens; c1 is made current via makeCurrent() in BeforeShow"
-        def view = navigateToView(GfActivationBeforeShowView)
+        def view = navigateToView(GfActivationBeforeShowTestView)
 
         then: "c1 is current and only its condition is applied"
         view.genericFilter.currentConfiguration.id == "c1"
@@ -86,7 +85,7 @@ class GenericFilterMakeCurrentActivationTest extends FlowuiTestSpecification {
 
     def "a current default configuration plus a deferred makeCurrent triggers exactly one load (no double load)"() {
         when: "the view opens: a default-like config is current in onInit, another is makeCurrent (deferred), no DataLoadCoordinator"
-        def view = navigateToView(GfActivationDoubleLoadView)
+        def view = navigateToView(GfActivationDoubleLoadTestView)
 
         then: "exactly one load happened — the deferred activation did not add a second one"
         view.loadCount == 1
@@ -94,7 +93,7 @@ class GenericFilterMakeCurrentActivationTest extends FlowuiTestSpecification {
 
     def "plain setCurrentConfiguration in onInit does not pollute the baseline"() {
         given: "the view opens; c1 is activated via base-API setCurrentConfiguration in onInit"
-        def view = navigateToView(GfActivationPlainSetCurrentView)
+        def view = navigateToView(GfActivationPlainSetCurrentTestView)
 
         when: "switching to c2"
         view.genericFilter.setCurrentConfiguration(view.genericFilter.getConfiguration("c2"))
@@ -103,13 +102,4 @@ class GenericFilterMakeCurrentActivationTest extends FlowuiTestSpecification {
         countPropertyConditions(view.genericFilter.dataLoader.condition) == 1
     }
 
-    protected static int countPropertyConditions(Condition condition) {
-        if (condition instanceof PropertyCondition) {
-            return 1
-        }
-        if (condition instanceof LogicalCondition) {
-            return condition.conditions.inject(0) { acc, c -> acc + countPropertyConditions(c) }
-        }
-        return 0
-    }
 }

--- a/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterNestedRemoveTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GenericFilterNestedRemoveTest.groovy
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.genericfilter
+
+import component.genericfilter.view.GfNestedGroupRemoveTestView
+import io.jmix.core.querycondition.Condition
+import io.jmix.core.querycondition.LogicalCondition
+import io.jmix.core.querycondition.PropertyCondition
+import io.jmix.flowui.component.UiComponentUtils
+import io.jmix.flowui.component.genericfilter.GenericFilter
+import io.jmix.flowui.component.logicalfilter.GroupFilter
+import io.jmix.flowui.component.propertyfilter.PropertyFilter
+import io.jmix.flowui.kit.component.button.JmixButton
+import org.springframework.boot.test.context.SpringBootTest
+import test_support.spec.FlowuiTestSpecification
+
+/**
+ * Reproduction: the remove (x) button on a condition nested inside a group.
+ * Establishes empirically, for a run-time configuration, whether such a condition gets a
+ * remove button and whether removing it clears the model and the loader condition.
+ */
+@SpringBootTest
+class GenericFilterNestedRemoveTest extends FlowuiTestSpecification {
+
+    private static final String REMOVE_BUTTON_SUFFIX = "conditionRemoveButton"
+
+    void setup() {
+        registerViewBasePackages("component.genericfilter.view")
+    }
+
+    def "clicking the remove (x) button on a condition nested in a group removes it"() {
+        given: "a run-time configuration whose root contains a nested group with one property condition"
+        def view = navigateToView(GfNestedGroupRemoveTestView)
+        GenericFilter filter = view.genericFilter
+        GroupFilter nestedGroup = view.nestedGroup
+        PropertyFilter<String> nestedCondition = view.nestedCondition
+
+        expect: "the nested condition is in the model and drives the loader condition"
+        nestedGroup.ownFilterComponents.contains(nestedCondition)
+        hasPropertyConditionOn(filter.dataLoader.condition, "number")
+
+        and: "the nested condition has a remove (x) button"
+        JmixButton removeButton = findRemoveButton(nestedCondition)
+        removeButton != null
+
+        when: "clicking the remove (x) button — the same handler a user triggers"
+        removeButton.click()
+
+        then: "it is removed from the nested group and no longer filters"
+        !nestedGroup.ownFilterComponents.contains(nestedCondition)
+        !hasPropertyConditionOn(filter.dataLoader.condition, "number")
+    }
+
+    def "clicking the remove (x) button on a condition nested two groups deep removes it"() {
+        given: "a run-time configuration: root -> outer group -> inner group -> one property condition"
+        GenericFilter filter = navigateToView(GfNestedGroupRemoveTestView).genericFilter
+
+        PropertyFilter<String> deepCondition = filter.filterComponentBuilder()
+                .<String> propertyFilter()
+                .property("number")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .build()
+        deepCondition.value = "n2"
+
+        GroupFilter innerGroup = filter.filterComponentBuilder().groupFilter().add(deepCondition).build()
+        GroupFilter outerGroup = filter.filterComponentBuilder().groupFilter().add(innerGroup).build()
+        filter.runtimeConfigurationBuilder()
+                .id("c2")
+                .name("C2")
+                .add(outerGroup)
+                .makeCurrent()
+                .buildAndRegister()
+
+        expect: "the two-levels-deep condition drives the loader condition"
+        innerGroup.ownFilterComponents.contains(deepCondition)
+        hasPropertyConditionOn(filter.dataLoader.condition, "number")
+
+        and: "the deep condition has a remove (x) button"
+        JmixButton removeButton = findRemoveButton(deepCondition)
+        removeButton != null
+
+        when: "clicking the remove (x) button"
+        removeButton.click()
+
+        then: "it is removed from its inner group and no longer filters"
+        !innerGroup.ownFilterComponents.contains(deepCondition)
+        !hasPropertyConditionOn(filter.dataLoader.condition, "number")
+    }
+
+    protected static JmixButton findRemoveButton(PropertyFilter<?> condition) {
+        String id = condition.innerComponentPrefix + REMOVE_BUTTON_SUFFIX
+        return UiComponentUtils.findComponent(condition.root, id).orElse(null) as JmixButton
+    }
+
+    protected static boolean hasPropertyConditionOn(Condition condition, String property) {
+        if (condition instanceof PropertyCondition) {
+            return property == condition.property
+        }
+        if (condition instanceof LogicalCondition) {
+            return condition.conditions.any { hasPropertyConditionOn(it, property) }
+        }
+        return false
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GroupFilterBaseConditionTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/genericfilter/GroupFilterBaseConditionTest.groovy
@@ -16,14 +16,15 @@
 
 package component.genericfilter
 
-import component.genericfilter.view.GfGroupFilterBaseConditionView
-import io.jmix.core.querycondition.Condition
+import component.genericfilter.view.GfGroupFilterBaseConditionTestView
 import io.jmix.core.querycondition.LogicalCondition
 import io.jmix.core.querycondition.PropertyCondition
 import io.jmix.flowui.component.logicalfilter.GroupFilter
 import io.jmix.flowui.component.logicalfilter.LogicalFilterComponent
 import org.springframework.boot.test.context.SpringBootTest
 import test_support.spec.FlowuiTestSpecification
+
+import static component.genericfilter.TestFilterConditions.hasPropertyConditionOn
 
 /**
  * A base condition set on the data loader of a standalone {@code GroupFilter} in {@code onInit}
@@ -38,7 +39,7 @@ class GroupFilterBaseConditionTest extends FlowuiTestSpecification {
 
     def "base condition set in onInit on a standalone GroupFilter survives a structural rebuild"() {
         when: "the view opens: standalone GroupFilter with a base condition on 'amount' set in onInit"
-        GroupFilter groupFilter = navigateToView(GfGroupFilterBaseConditionView).groupFilter
+        GroupFilter groupFilter = navigateToView(GfGroupFilterBaseConditionTestView).groupFilter
 
         and: "a structural change (operation switch) forces the loader condition to be rebuilt"
         groupFilter.setOperation(LogicalFilterComponent.Operation.OR)
@@ -49,7 +50,7 @@ class GroupFilterBaseConditionTest extends FlowuiTestSpecification {
 
     def "a logical base condition on a standalone GroupFilter is preserved on a structural rebuild"() {
         given: "the view opens with a standalone GroupFilter"
-        GroupFilter groupFilter = navigateToView(GfGroupFilterBaseConditionView).groupFilter
+        GroupFilter groupFilter = navigateToView(GfGroupFilterBaseConditionTestView).groupFilter
 
         and: "the loader has a logical base condition with two properties"
         groupFilter.dataLoader.setCondition(LogicalCondition.and(
@@ -64,13 +65,4 @@ class GroupFilterBaseConditionTest extends FlowuiTestSpecification {
         hasPropertyConditionOn(groupFilter.dataLoader.condition, "total")
     }
 
-    protected static boolean hasPropertyConditionOn(Condition condition, String property) {
-        if (condition instanceof PropertyCondition) {
-            return property == condition.property
-        }
-        if (condition instanceof LogicalCondition) {
-            return condition.conditions.any { hasPropertyConditionOn(it, property) }
-        }
-        return false
-    }
 }

--- a/jmix-flowui/flowui/src/test/groovy/component/genericfilter/TestFilterConditions.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/genericfilter/TestFilterConditions.groovy
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.genericfilter
+
+import io.jmix.core.querycondition.Condition
+import io.jmix.core.querycondition.LogicalCondition
+import io.jmix.core.querycondition.PropertyCondition
+
+/**
+ * Shared assertions over a query {@link Condition} tree for generic-filter tests.
+ */
+class TestFilterConditions {
+
+    static boolean hasPropertyConditionOn(Condition condition, String property) {
+        if (condition instanceof PropertyCondition) {
+            return property == condition.property
+        }
+        if (condition instanceof LogicalCondition) {
+            return condition.conditions.any { hasPropertyConditionOn(it, property) }
+        }
+        return false
+    }
+
+    static int countPropertyConditions(Condition condition) {
+        if (condition instanceof PropertyCondition) {
+            return 1
+        }
+        if (condition instanceof LogicalCondition) {
+            return condition.conditions.inject(0) { acc, c -> acc + countPropertyConditions(c) }
+        }
+        return 0
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
@@ -27,6 +27,7 @@ import io.jmix.flowui.component.logicalfilter.GroupFilter
 import io.jmix.flowui.component.propertyfilter.PropertyFilter
 import io.jmix.flowui.facet.UrlQueryParametersFacet
 import io.jmix.flowui.facet.urlqueryparameters.GenericFilterUrlQueryParametersBinder
+import io.jmix.flowui.model.CollectionLoader
 import io.jmix.flowui.view.View
 import io.jmix.flowui.view.ViewControllerUtils
 import org.springframework.boot.test.context.SpringBootTest
@@ -487,6 +488,60 @@ class GenericFilterReNavigationTest extends FlowuiTestSpecification {
 
         cleanup:
         registration.remove()
+    }
+
+    // --- Listener leak: re-navigation must not accumulate a baseline's operation-change listener ---
+
+    def "re-navigation does not accumulate a baseline condition's operation-change listener"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+        def nameFilter = propertyFilterOn(active, "name")
+
+        and: "auto-apply is on, so every apply() hits the loader, and each load is counted"
+        active.rootLogicalFilterComponent.autoApply = true
+        def loadCount = new AtomicInteger(0)
+        (screen.ownersFilter.dataLoader as CollectionLoader).addPostLoadListener { loadCount.incrementAndGet() }
+
+        when: "several clean re-navigations rebuild the configuration structure"
+        3.times {
+            binder.applyInitialState()
+            binder.updateState(QueryParameters.empty())
+        }
+
+        and: "the user changes the baseline operation once"
+        loadCount.set(0)
+        nameFilter.setOperation(PropertyFilter.Operation.CONTAINS)
+
+        then: "the loader is loaded exactly once — not once per accumulated (leaked) listener"
+        loadCount.get() == 1
+    }
+
+    def "removeAll on a group detaches operation-change listeners so re-adding does not accumulate them"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+        def rootGroup = active.rootLogicalFilterComponent
+        def nameFilter = propertyFilterOn(active, "name")
+
+        and: "auto-apply is on, so every apply() hits the loader, and each load is counted"
+        rootGroup.autoApply = true
+        def loadCount = new AtomicInteger(0)
+        (screen.ownersFilter.dataLoader as CollectionLoader).addPostLoadListener { loadCount.incrementAndGet() }
+
+        when: "the group is cleared via removeAll and the same condition is re-added several times"
+        3.times {
+            rootGroup.removeAll()
+            rootGroup.add(nameFilter)
+        }
+
+        and: "the user changes the baseline operation once"
+        loadCount.set(0)
+        nameFilter.setOperation(PropertyFilter.Operation.CONTAINS)
+
+        then: "the loader is loaded exactly once — removeAll detached the stale listeners"
+        loadCount.get() == 1
     }
 
     // --- helpers ---

--- a/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
@@ -336,7 +336,7 @@ class GenericFilterReNavigationTest extends FlowuiTestSpecification {
         propertyFilterOn(active, "name").value == "John"
     }
 
-    def "a condition added to a non-entry configuration survives re-navigation; only the entry config is restored (no URL)"() {
+    def "a condition added to a non-entry configuration is also restored on re-navigation (no URL)"() {
         given:
         def screen = navigateToView(GenericFilterConfigsTestView)
         def binder = getBinder(screen)
@@ -362,8 +362,35 @@ class GenericFilterReNavigationTest extends FlowuiTestSpecification {
         screen.ownersFilter.currentConfiguration.is(active)
         hasPropertyConditionOn(active, "name")
 
-        and: "the user's own addition on the non-entry config remains (it is outside the restore scope)"
-        hasPropertyConditionOn(other, "name")
+        and: "the non-entry config is ALSO restored: the user's addition is gone, its baseline remains"
+        !hasPropertyConditionOn(other, "name")
+        hasPropertyConditionOn(other, "email")
+    }
+
+    def "a condition removed from a non-entry configuration is restored on re-navigation (no URL)"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+        Configuration other = screen.ownersFilter.getConfiguration("other")
+
+        when: "the user switches to 'other' and removes its baseline 'email' condition, then switches back"
+        screen.ownersFilter.setCurrentConfiguration(other)
+        def emailFilter = propertyFilterOn(other, "email")
+        other.rootLogicalFilterComponent.remove(emailFilter)
+        ((RunTimeConfiguration) other).setFilterComponentModified(emailFilter, false)
+        screen.ownersFilter.setCurrentConfiguration(active)
+
+        then: "the condition is gone from 'other'"
+        !hasPropertyConditionOn(other, "email")
+
+        when: "a clean re-navigation happens"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the entry config is restored, and 'other' is restored too: its baseline condition is back"
+        screen.ownersFilter.currentConfiguration.is(active)
+        hasPropertyConditionOn(active, "name")
         hasPropertyConditionOn(other, "email")
     }
 

--- a/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
@@ -544,6 +544,26 @@ class GenericFilterReNavigationTest extends FlowuiTestSpecification {
         loadCount.get() == 1
     }
 
+    def "re-navigation does not accumulate GenericFilter's per-condition operation-change listener"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+        def nameFilter = propertyFilterOn(active, "name")
+
+        and: "the number of operation-change listeners on the baseline condition right after init"
+        int initialListeners = operationChangeListenerCount(nameFilter)
+
+        when: "several clean re-navigations happen (each re-activates the configuration)"
+        3.times {
+            binder.applyInitialState()
+            binder.updateState(QueryParameters.empty())
+        }
+
+        then: "the listener count did not grow — the per-condition listener is not re-registered on every restore"
+        operationChangeListenerCount(nameFilter) == initialListeners
+    }
+
     // --- helpers ---
 
     static GenericFilterUrlQueryParametersBinder getBinder(screen) {
@@ -573,5 +593,9 @@ class GenericFilterReNavigationTest extends FlowuiTestSpecification {
         return group.ownFilterComponents
                 .findAll { it instanceof PropertyFilter }
                 .collect { ((PropertyFilter) it).property }
+    }
+
+    static int operationChangeListenerCount(PropertyFilter<?> filter) {
+        return filter.getEventBus().getListeners(PropertyFilter.OperationChangeEvent).size()
     }
 }

--- a/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
@@ -1,0 +1,495 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package facet.url_query_parameters
+
+import com.vaadin.flow.router.QueryParameters
+import facet.url_query_parameters.view.GenericFilterConfigsTestView
+import facet.url_query_parameters.view.GenericFilterDesignTimeConfigTestView
+import facet.url_query_parameters.view.GenericFilterNestedGroupTestView
+import facet.url_query_parameters.view.GenericFilterUrlQueryParamsTestView
+import io.jmix.flowui.component.genericfilter.Configuration
+import io.jmix.flowui.component.genericfilter.configuration.RunTimeConfiguration
+import io.jmix.flowui.component.logicalfilter.GroupFilter
+import io.jmix.flowui.component.propertyfilter.PropertyFilter
+import io.jmix.flowui.facet.UrlQueryParametersFacet
+import io.jmix.flowui.facet.urlqueryparameters.GenericFilterUrlQueryParametersBinder
+import io.jmix.flowui.view.View
+import io.jmix.flowui.view.ViewControllerUtils
+import org.springframework.boot.test.context.SpringBootTest
+import test_support.spec.FlowuiTestSpecification
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Verifies how a {@link io.jmix.flowui.component.genericfilter.GenericFilter} bound via the
+ * {@code urlQueryParameters} facet behaves on a same-view re-navigation. When Vaadin reuses the
+ * view instance, {@code onInit} is not called again: the facet fires
+ * {@code RestoreComponentsStateEvent} (-&gt; {@code applyInitialState()}) and then a
+ * {@code QueryParametersChangeEvent} (-&gt; {@code updateState(...)}). These two calls on the same
+ * binder instance reproduce that lifecycle without a real browser.
+ *
+ * <ul>
+ *     <li><b>Bug/T4</b> — a programmatic configuration activated in {@code onInit} must survive a
+ *     clean re-navigation instead of being wiped by {@code applyInitialState()}.</li>
+ *     <li><b>T1/T2</b> — the common empty-configuration + URL-derived conditions flow must be
+ *     unchanged (byte-for-byte with the old {@code removeAll()} behaviour).</li>
+ *     <li><b>T3</b> — a configuration switched to via the URL is reset to the initial configuration
+ *     on a clean re-navigation.</li>
+ *     <li><b>T6/T7</b> — a baseline value changed via the URL is reset, and a condition added via
+ *     the URL on top of a baseline is removed, while the baseline itself is kept.</li>
+ * </ul>
+ */
+@SpringBootTest
+class GenericFilterReNavigationTest extends FlowuiTestSpecification {
+
+    @Override
+    void setup() {
+        registerViewBasePackages("facet.url_query_parameters", "io.jmix.flowui.app")
+    }
+
+    // --- Bug / T4: programmatic baseline must survive re-navigation ---
+
+    def "programmatic configuration activated in onInit survives a clean re-navigation"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+
+        expect: "the programmatic 'name' condition is present after init"
+        hasPropertyConditionOn(active, "name")
+
+        when: "the same view is reopened: initial state restored, then a clean URL applied"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the programmatic condition is NOT wiped and the configuration stays current"
+        hasPropertyConditionOn(active, "name")
+        screen.ownersFilter.currentConfiguration.is(active)
+    }
+
+    // --- T1: empty configuration + URL condition, cleared on clean re-navigation ---
+
+    def "T1: a URL-derived condition on the empty configuration is cleared on clean re-navigation"() {
+        given:
+        def screen = navigateToView(GenericFilterUrlQueryParamsTestView)
+        def binder = getBinder(screen)
+
+        when: "a condition is applied from the URL"
+        binder.updateState(QueryParameters.simple([(binder.conditionParam): "property:name_equal_Bob"]))
+
+        then: "the empty configuration now carries the condition"
+        !currentComponents(screen).isEmpty()
+
+        when: "clean re-navigation"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the condition is removed (back to the empty baseline)"
+        currentComponents(screen).isEmpty()
+    }
+
+    // --- T2: switching between URLs does not accumulate conditions ---
+
+    def "T2: re-navigating to a different URL condition does not accumulate conditions"() {
+        given:
+        def screen = navigateToView(GenericFilterUrlQueryParamsTestView)
+        def binder = getBinder(screen)
+
+        when: "first URL condition"
+        binder.updateState(QueryParameters.simple([(binder.conditionParam): "property:name_equal_Bob"]))
+
+        and: "re-navigation to a different URL condition"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.simple([(binder.conditionParam): "property:name_equal_Alice"]))
+
+        then: "exactly one condition, reflecting only the latest URL"
+        def components = currentComponents(screen)
+        components.size() == 1
+        (components.first() as PropertyFilter).value == "Alice"
+    }
+
+    // --- T3: a configuration selected via URL is reset to the initial configuration ---
+
+    def "T3: a configuration selected via URL after init is reset to the initial one on clean re-navigation"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+        Configuration other = screen.ownersFilter.getConfiguration("other")
+
+        when: "the user switches to the 'other' configuration via URL"
+        binder.updateState(QueryParameters.simple([(binder.configurationParam): "other"]))
+
+        then:
+        screen.ownersFilter.currentConfiguration.is(other)
+
+        when: "clean re-navigation"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the filter is restored to the initial configuration, still carrying its baseline"
+        screen.ownersFilter.currentConfiguration.is(active)
+        hasPropertyConditionOn(active, "name")
+    }
+
+    // --- T6: a baseline value changed via URL is reset on re-navigation ---
+
+    def "T6: a baseline value changed via URL is reset on clean re-navigation"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+
+        when: "URL selects the active configuration and changes the 'name' value"
+        binder.updateState(QueryParameters.simple([
+                (binder.configurationParam): "active",
+                (binder.conditionParam)    : "property:name_equal_Zoe"
+        ]))
+
+        then: "the name filter value reflects the URL"
+        propertyFilterOn(active, "name").value == "Zoe"
+
+        when: "clean re-navigation"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the value is restored to the initial baseline value"
+        propertyFilterOn(active, "name").value == "John"
+    }
+
+    // --- T7: a condition added via URL is removed while the baseline is kept ---
+
+    def "T7: a condition added via URL on top of a baseline is removed on clean re-navigation"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+
+        when: "URL adds an extra 'email' condition on top of the 'name' baseline"
+        binder.updateState(new QueryParameters([
+                (binder.configurationParam): ["active"],
+                (binder.conditionParam)    : ["property:name_equal_John", "property:email_equal_extra"]
+        ]))
+
+        then: "both conditions are present"
+        hasPropertyConditionOn(active, "name")
+        hasPropertyConditionOn(active, "email")
+
+        when: "clean re-navigation"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the URL-added condition is gone, the baseline remains"
+        hasPropertyConditionOn(active, "name")
+        !hasPropertyConditionOn(active, "email")
+    }
+
+    // --- T8: an operation changed via URL on a baseline is reset ---
+
+    def "T8: an operation changed via URL on a baseline is reset on clean re-navigation"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+
+        when: "URL changes the operation of the baseline 'name' condition"
+        binder.updateState(QueryParameters.simple([
+                (binder.configurationParam): "active",
+                (binder.conditionParam)    : "property:name_contains_John"
+        ]))
+
+        then: "the operation reflects the URL"
+        propertyFilterOn(active, "name").operation == PropertyFilter.Operation.CONTAINS
+
+        when: "clean re-navigation"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the operation is restored to the initial baseline operation"
+        propertyFilterOn(active, "name").operation == PropertyFilter.Operation.EQUAL
+    }
+
+    // --- T9: operation AND value changed via URL are both reset (ordering) ---
+
+    def "T9: operation and value changed via URL are both reset on clean re-navigation"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+
+        when: "URL changes both the operation and the value of the baseline 'name' condition"
+        binder.updateState(QueryParameters.simple([
+                (binder.configurationParam): "active",
+                (binder.conditionParam)    : "property:name_not-equal_Zoe"
+        ]))
+
+        then:
+        propertyFilterOn(active, "name").operation == PropertyFilter.Operation.NOT_EQUAL
+        propertyFilterOn(active, "name").value == "Zoe"
+
+        when: "clean re-navigation"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "both operation and value are restored to the initial baseline"
+        propertyFilterOn(active, "name").operation == PropertyFilter.Operation.EQUAL
+        propertyFilterOn(active, "name").value == "John"
+    }
+
+    // --- a design-time configuration value changed via URL is reset on re-navigation ---
+
+    def "T10: a design-time configuration value changed via URL is reset on clean re-navigation"() {
+        given:
+        def screen = navigateToView(GenericFilterDesignTimeConfigTestView)
+        def binder = getBinder(screen)
+        Configuration byName = screen.ownersFilter.getConfiguration("byName")
+
+        expect: "the design-time configuration is current with its default value"
+        screen.ownersFilter.currentConfiguration.is(byName)
+        propertyFilterOn(byName, "name").value == "John"
+
+        when: "URL selects the design-time configuration and changes the 'name' value"
+        binder.updateState(QueryParameters.simple([
+                (binder.configurationParam): "byName",
+                (binder.conditionParam)    : "property:name_equal_Zoe"
+        ]))
+
+        then: "the name filter value reflects the URL"
+        propertyFilterOn(byName, "name").value == "Zoe"
+
+        when: "clean re-navigation"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the value is restored to the design-time default"
+        propertyFilterOn(byName, "name").value == "John"
+    }
+
+    // --- Facet-level: drive the REAL event chain (RestoreComponentsStateEvent /
+    //     QueryParametersChangeEvent) through UrlQueryParametersFacetImpl, not the binder directly ---
+
+    def "F1: programmatic configuration survives re-navigation through the real facet event chain"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+
+        expect: "the programmatic 'name' condition is present after init"
+        hasPropertyConditionOn(active, "name")
+
+        when: "the framework restores the initial state and applies a clean URL via real view events"
+        ViewControllerUtils.fireEvent(screen, new View.RestoreComponentsStateEvent(screen))
+        ViewControllerUtils.fireEvent(screen, new View.QueryParametersChangeEvent(screen, QueryParameters.empty()))
+
+        then: "the facet routed the events to the binder and the baseline condition survived"
+        hasPropertyConditionOn(active, "name")
+        screen.ownersFilter.currentConfiguration.is(active)
+    }
+
+    def "F2: URL condition on the empty configuration is cleared on re-navigation through the real facet event chain"() {
+        given:
+        def screen = navigateToView(GenericFilterUrlQueryParamsTestView)
+        def binder = getBinder(screen)
+
+        when: "a condition arrives via a real QueryParametersChangeEvent"
+        ViewControllerUtils.fireEvent(screen, new View.QueryParametersChangeEvent(screen,
+                QueryParameters.simple([(binder.conditionParam): "property:name_equal_Bob"])))
+
+        then: "the empty configuration now carries the condition"
+        !currentComponents(screen).isEmpty()
+
+        when: "clean re-navigation: RestoreComponentsStateEvent then a clean QueryParametersChangeEvent"
+        ViewControllerUtils.fireEvent(screen, new View.RestoreComponentsStateEvent(screen))
+        ViewControllerUtils.fireEvent(screen, new View.QueryParametersChangeEvent(screen, QueryParameters.empty()))
+
+        then: "the condition is removed (back to the empty baseline)"
+        currentComponents(screen).isEmpty()
+    }
+
+    // --- Pure user actions (no URL): scope of the re-navigation restore across several configurations ---
+
+    def "a value edit on a configuration is reset when switching away and back (no URL)"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+        Configuration other = screen.ownersFilter.getConfiguration("other")
+
+        when: "the user edits the name value on the entry config, then switches to another config and back"
+        propertyFilterOn(active, "name").setValue("Zoe")
+        screen.ownersFilter.setCurrentConfiguration(other)
+        screen.ownersFilter.setCurrentConfiguration(active)
+
+        then: "the transient value is gone: it was reset to the configuration default on switch, not kept"
+        propertyFilterOn(active, "name").value == "John"
+    }
+
+    def "a condition added to a non-entry configuration survives re-navigation; only the entry config is restored (no URL)"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+        Configuration other = screen.ownersFilter.getConfiguration("other")
+
+        when: "the user switches to 'other' and adds a condition to it (pure UI, no URL), then switches back"
+        screen.ownersFilter.setCurrentConfiguration(other)
+        def added = screen.ownersFilter.filterComponentBuilder()
+                .propertyFilter()
+                .property("name")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .build()
+        other.rootLogicalFilterComponent.add(added)
+        ((RunTimeConfiguration) other).setFilterComponentModified(added, true)
+        screen.ownersFilter.setCurrentConfiguration(active)
+
+        and: "a clean re-navigation happens"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the entry config is restored to its baseline"
+        screen.ownersFilter.currentConfiguration.is(active)
+        hasPropertyConditionOn(active, "name")
+
+        and: "the user's own addition on the non-entry config remains (it is outside the restore scope)"
+        hasPropertyConditionOn(other, "name")
+        hasPropertyConditionOn(other, "email")
+    }
+
+    // --- a baseline condition removed via the remove button is fully restored on re-navigation ---
+
+    def "a baseline condition removed via the remove button is restored on re-navigation"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+        def nameFilter = propertyFilterOn(active, "name")
+        def paramName = nameFilter.parameterName
+
+        expect: "the baseline is present, modified (so it has a remove button) and its default value is registered"
+        hasPropertyConditionOn(active, "name")
+        active.isFilterComponentModified(nameFilter)
+        active.getFilterComponentDefaultValue(paramName) == "John"
+
+        when: "the user removes the baseline condition via the remove button (same effect as GenericFilter.removeFilterComponent)"
+        active.resetFilterComponentDefaultValue(paramName)
+        active.rootLogicalFilterComponent.remove(nameFilter)
+        active.setFilterComponentModified(nameFilter, false)
+
+        then: "it is gone from the configuration"
+        !hasPropertyConditionOn(active, "name")
+
+        when: "a clean re-navigation happens"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the baseline condition is fully restored: present again, modified (remove button reappears), default value re-registered and value reset"
+        hasPropertyConditionOn(active, "name")
+        def restored = propertyFilterOn(active, "name")
+        active.isFilterComponentModified(restored)
+        active.getFilterComponentDefaultValue(paramName) == "John"
+        restored.value == "John"
+    }
+
+    // --- Nested group: a condition removed from a nested group is restored (recursive structure) ---
+
+    def "a condition removed from a nested group is restored on re-navigation"() {
+        given:
+        def screen = navigateToView(GenericFilterNestedGroupTestView)
+        def binder = getBinder(screen)
+        Configuration grouped = screen.ownersFilter.getConfiguration("grouped")
+        GroupFilter group = grouped.rootLogicalFilterComponent.ownFilterComponents
+                .find { it instanceof GroupFilter } as GroupFilter
+
+        expect: "the nested group initially holds both conditions, in order"
+        group != null
+        nestedProperties(group) == ["name", "email"]
+
+        when: "a condition is removed directly from the nested group (simulating a fixed nested removal)"
+        def nameInner = group.ownFilterComponents
+                .find { it instanceof PropertyFilter && ((PropertyFilter) it).property == "name" }
+        group.remove(nameInner)
+
+        then: "only the other condition remains in the group"
+        nestedProperties(group) == ["email"]
+
+        when: "a clean re-navigation happens"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the nested group is fully restored, in the original order"
+        GroupFilter restoredGroup = grouped.rootLogicalFilterComponent.ownFilterComponents
+                .find { it instanceof GroupFilter } as GroupFilter
+        nestedProperties(restoredGroup) == ["name", "email"]
+    }
+
+    // --- Event storm: restore must not push URL parameters once per add/remove ---
+
+    def "restore does not push URL parameters once per add/remove (event storm suppressed)"() {
+        given:
+        def screen = navigateToView(GenericFilterUrlQueryParamsTestView)
+        def binder = getBinder(screen)
+
+        and: "the empty configuration currently holds several URL-added conditions"
+        binder.updateState(new QueryParameters([
+                (binder.conditionParam): ["property:name_equal_A", "property:name_equal_B", "property:name_equal_C"]
+        ]))
+        assert currentComponents(screen).size() == 3
+
+        and: "a listener counts how many times the binder pushes URL parameters"
+        def pushCount = new AtomicInteger(0)
+        def registration = binder.addUrlQueryParametersChangeListener({ event -> pushCount.incrementAndGet() })
+
+        when: "the initial (empty) state is restored — this removes all three conditions"
+        binder.applyInitialState()
+
+        then: "all conditions are gone, but the whole reconciliation pushed at most once (not once per removed condition)"
+        currentComponents(screen).isEmpty()
+        pushCount.get() <= 1
+
+        cleanup:
+        registration.remove()
+    }
+
+    // --- helpers ---
+
+    static GenericFilterUrlQueryParametersBinder getBinder(screen) {
+        UrlQueryParametersFacet facet = screen.urlQueryParameters
+        return facet.binders
+                .findAll { it instanceof GenericFilterUrlQueryParametersBinder }
+                .first() as GenericFilterUrlQueryParametersBinder
+    }
+
+    static List currentComponents(screen) {
+        return screen.ownersFilter.currentConfiguration.rootLogicalFilterComponent.filterComponents
+    }
+
+    static boolean hasPropertyConditionOn(Configuration configuration, String property) {
+        return configuration.rootLogicalFilterComponent.filterComponents.any {
+            it instanceof PropertyFilter && ((PropertyFilter) it).property == property
+        }
+    }
+
+    static PropertyFilter propertyFilterOn(Configuration configuration, String property) {
+        return configuration.rootLogicalFilterComponent.filterComponents.find {
+            it instanceof PropertyFilter && ((PropertyFilter) it).property == property
+        } as PropertyFilter
+    }
+
+    static List<String> nestedProperties(GroupFilter group) {
+        return group.ownFilterComponents
+                .findAll { it instanceof PropertyFilter }
+                .collect { ((PropertyFilter) it).property }
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfActivationBeforeShowTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfActivationBeforeShowTestView.java
@@ -22,18 +22,20 @@ import io.jmix.flowui.component.propertyfilter.PropertyFilter;
 import io.jmix.flowui.view.*;
 
 /**
- * Builds a configuration but does not activate it in {@code onInit}.
+ * Activates a configuration via {@code makeCurrent()} in {@code BeforeShowEvent}, i.e. when the filter
+ * is already attached — the synchronous activation path. Switching afterwards must apply only the new
+ * configuration's condition (the baseline was captured before, so it stays clean).
  */
-@Route(value = "gf-configs-no-activation-view")
-@ViewController("GfConfigsNoActivationView")
+@Route(value = "gf-activation-beforeshow-view")
+@ViewController("GfActivationBeforeShowTestView")
 @ViewDescriptor("gf-activation-nodlc-view.xml")
-public class GfConfigsNoActivationView extends StandardView {
+public class GfActivationBeforeShowTestView extends StandardView {
 
     @ViewComponent
     public GenericFilter genericFilter;
 
     @Subscribe
-    public void onInit(final InitEvent event) {
+    public void onBeforeShow(final BeforeShowEvent event) {
         PropertyFilter<String> number1 = genericFilter.filterComponentBuilder()
                 .<String>propertyFilter()
                 .property("number")
@@ -43,6 +45,22 @@ public class GfConfigsNoActivationView extends StandardView {
                 .id("c1")
                 .name("C1")
                 .add(number1, "n1")
+                .makeCurrent()
                 .buildAndRegister();
+
+        PropertyFilter<String> number2 = genericFilter.filterComponentBuilder()
+                .<String>propertyFilter()
+                .property("number")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .build();
+        genericFilter.runtimeConfigurationBuilder()
+                .id("c2")
+                .name("C2")
+                .add(number2, "n2")
+                .buildAndRegister();
+    }
+
+    public void switchTo(String configurationId) {
+        genericFilter.setCurrentConfiguration(genericFilter.getConfiguration(configurationId));
     }
 }

--- a/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfActivationDoubleLoadTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfActivationDoubleLoadTestView.java
@@ -17,50 +17,58 @@
 package component.genericfilter.view;
 
 import com.vaadin.flow.router.Route;
-import io.jmix.core.querycondition.PropertyCondition;
 import io.jmix.flowui.component.genericfilter.GenericFilter;
 import io.jmix.flowui.component.genericfilter.configuration.RunTimeConfiguration;
 import io.jmix.flowui.component.propertyfilter.PropertyFilter;
+import io.jmix.flowui.model.CollectionLoader;
 import io.jmix.flowui.view.*;
+import test_support.entity.sales.Order;
 
 /**
- * Sets a base condition, activates a configuration, then revises the base condition, all in
- * {@code onInit}.
+ * No {@code DataLoadCoordinator}. A configuration with a value is made current synchronously in
+ * {@code onInit} (so {@code applyFilterIfNeeded} loads it once), and a second configuration is
+ * activated via the builder's deferred {@code makeCurrent()}. The deferred activation must NOT add a
+ * second load — exactly one load is expected on open.
  */
-@Route(value = "gf-base-revise-view")
-@ViewController("GfBaseConditionReviseView")
+@Route(value = "gf-activation-double-load-view")
+@ViewController("GfActivationDoubleLoadTestView")
 @ViewDescriptor("gf-activation-nodlc-view.xml")
-public class GfBaseConditionReviseView extends StandardView {
+public class GfActivationDoubleLoadTestView extends StandardView {
 
     @ViewComponent
     public GenericFilter genericFilter;
+    @ViewComponent
+    private CollectionLoader<Order> ordersDl;
+
+    public int loadCount;
 
     @Subscribe
     public void onInit(final InitEvent event) {
-        PropertyFilter<String> number1 = genericFilter.filterComponentBuilder()
+        ordersDl.addPostLoadListener(e -> loadCount++);
+
+        PropertyFilter<String> declValue = genericFilter.filterComponentBuilder()
                 .<String>propertyFilter()
                 .property("number")
                 .operation(PropertyFilter.Operation.EQUAL)
                 .build();
-        RunTimeConfiguration c1 = genericFilter.runtimeConfigurationBuilder()
-                .id("c1")
-                .name("C1")
-                .add(number1, "n1")
+        RunTimeConfiguration declConfiguration = genericFilter.runtimeConfigurationBuilder()
+                .id("decl")
+                .name("Declarative-like default")
+                .add(declValue, "d1")
                 .buildAndRegister();
+        // Make it current synchronously, emulating a default configuration that applyFilterIfNeeded loads.
+        genericFilter.setCurrentConfiguration(declConfiguration);
 
-        PropertyFilter<String> number2 = genericFilter.filterComponentBuilder()
+        PropertyFilter<String> runtimeValue = genericFilter.filterComponentBuilder()
                 .<String>propertyFilter()
                 .property("number")
                 .operation(PropertyFilter.Operation.EQUAL)
                 .build();
         genericFilter.runtimeConfigurationBuilder()
-                .id("c2")
-                .name("C2")
-                .add(number2, "n2")
+                .id("rt")
+                .name("Runtime")
+                .add(runtimeValue, "n1")
+                .makeCurrent()
                 .buildAndRegister();
-
-        genericFilter.getDataLoader().setCondition(PropertyCondition.greater("amount", 0));
-        genericFilter.setCurrentConfiguration(c1);
-        genericFilter.getDataLoader().setCondition(PropertyCondition.greater("total", 0));
     }
 }

--- a/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfActivationOnInitDlcTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfActivationOnInitDlcTestView.java
@@ -19,23 +19,30 @@ package component.genericfilter.view;
 import com.vaadin.flow.router.Route;
 import io.jmix.flowui.component.genericfilter.GenericFilter;
 import io.jmix.flowui.component.propertyfilter.PropertyFilter;
+import io.jmix.flowui.model.CollectionLoader;
 import io.jmix.flowui.view.*;
+import test_support.entity.sales.Order;
 
 /**
- * Activates a configuration via {@code makeCurrent()} in {@code BeforeShowEvent}, i.e. when the filter
- * is already attached — the synchronous activation path. Switching afterwards must apply only the new
- * configuration's condition (the baseline was captured before, so it stays clean).
+ * Same as {@link GfActivationOnInitNoDlcTestView} but WITH a {@code DataLoadCoordinator}: the configuration
+ * activated via {@code makeCurrent()} in {@code onInit} must yield exactly one filtered load on open.
  */
-@Route(value = "gf-activation-beforeshow-view")
-@ViewController("GfActivationBeforeShowView")
-@ViewDescriptor("gf-activation-nodlc-view.xml")
-public class GfActivationBeforeShowView extends StandardView {
+@Route(value = "gf-activation-oninit-dlc-view")
+@ViewController("GfActivationOnInitDlcTestView")
+@ViewDescriptor("gf-activation-dlc-view.xml")
+public class GfActivationOnInitDlcTestView extends StandardView {
 
     @ViewComponent
     public GenericFilter genericFilter;
+    @ViewComponent
+    private CollectionLoader<Order> ordersDl;
+
+    public int loadCount;
 
     @Subscribe
-    public void onBeforeShow(final BeforeShowEvent event) {
+    public void onInit(final InitEvent event) {
+        ordersDl.addPostLoadListener(e -> loadCount++);
+
         PropertyFilter<String> number1 = genericFilter.filterComponentBuilder()
                 .<String>propertyFilter()
                 .property("number")
@@ -58,9 +65,5 @@ public class GfActivationBeforeShowView extends StandardView {
                 .name("C2")
                 .add(number2, "n2")
                 .buildAndRegister();
-    }
-
-    public void switchTo(String configurationId) {
-        genericFilter.setCurrentConfiguration(genericFilter.getConfiguration(configurationId));
     }
 }

--- a/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfActivationOnInitNoDlcTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfActivationOnInitNoDlcTestView.java
@@ -17,35 +17,48 @@
 package component.genericfilter.view;
 
 import com.vaadin.flow.router.Route;
-import io.jmix.core.querycondition.PropertyCondition;
+import io.jmix.flowui.component.genericfilter.Configuration;
 import io.jmix.flowui.component.genericfilter.GenericFilter;
-import io.jmix.flowui.component.genericfilter.configuration.RunTimeConfiguration;
 import io.jmix.flowui.component.propertyfilter.PropertyFilter;
+import io.jmix.flowui.model.CollectionLoader;
 import io.jmix.flowui.view.*;
+import test_support.entity.sales.Order;
 
 /**
- * Sets a base condition on the data loader after activating a configuration in {@code onInit}.
+ * No {@code DataLoadCoordinator}. Two configurations on {@code number}; the first is activated via the
+ * builder's {@code makeCurrent()} during {@code onInit} (deferred-to-attach path).
  */
-@Route(value = "gf-base-after-activation-view")
-@ViewController("GfBaseConditionAfterActivationView")
+@Route(value = "gf-activation-oninit-nodlc-view")
+@ViewController("GfActivationOnInitNoDlcTestView")
 @ViewDescriptor("gf-activation-nodlc-view.xml")
-public class GfBaseConditionAfterActivationView extends StandardView {
+public class GfActivationOnInitNoDlcTestView extends StandardView {
 
     @ViewComponent
     public GenericFilter genericFilter;
+    @ViewComponent
+    private CollectionLoader<Order> ordersDl;
+
+    public int loadCount;
+    public Configuration currentRightAfterMakeCurrent;
 
     @Subscribe
     public void onInit(final InitEvent event) {
+        ordersDl.addPostLoadListener(e -> loadCount++);
+
         PropertyFilter<String> number1 = genericFilter.filterComponentBuilder()
                 .<String>propertyFilter()
                 .property("number")
                 .operation(PropertyFilter.Operation.EQUAL)
                 .build();
-        RunTimeConfiguration c1 = genericFilter.runtimeConfigurationBuilder()
+        genericFilter.runtimeConfigurationBuilder()
                 .id("c1")
                 .name("C1")
                 .add(number1, "n1")
+                .makeCurrent()
                 .buildAndRegister();
+
+        // Captured during onInit: activation is deferred, so this must still be the empty configuration.
+        currentRightAfterMakeCurrent = genericFilter.getCurrentConfiguration();
 
         PropertyFilter<String> number2 = genericFilter.filterComponentBuilder()
                 .<String>propertyFilter()
@@ -57,8 +70,5 @@ public class GfBaseConditionAfterActivationView extends StandardView {
                 .name("C2")
                 .add(number2, "n2")
                 .buildAndRegister();
-
-        genericFilter.setCurrentConfiguration(c1);
-        genericFilter.getDataLoader().setCondition(PropertyCondition.greater("amount", 0));
     }
 }

--- a/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfActivationPlainSetCurrentTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfActivationPlainSetCurrentTestView.java
@@ -29,9 +29,9 @@ import io.jmix.flowui.view.*;
  * corresponding test is {@code @PendingFeature} until the core hardening lands.
  */
 @Route(value = "gf-activation-plain-setcurrent-view")
-@ViewController("GfActivationPlainSetCurrentView")
+@ViewController("GfActivationPlainSetCurrentTestView")
 @ViewDescriptor("gf-activation-nodlc-view.xml")
-public class GfActivationPlainSetCurrentView extends StandardView {
+public class GfActivationPlainSetCurrentTestView extends StandardView {
 
     @ViewComponent
     public GenericFilter genericFilter;

--- a/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfBaseConditionAfterActivationTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfBaseConditionAfterActivationTestView.java
@@ -17,58 +17,48 @@
 package component.genericfilter.view;
 
 import com.vaadin.flow.router.Route;
+import io.jmix.core.querycondition.PropertyCondition;
 import io.jmix.flowui.component.genericfilter.GenericFilter;
 import io.jmix.flowui.component.genericfilter.configuration.RunTimeConfiguration;
 import io.jmix.flowui.component.propertyfilter.PropertyFilter;
-import io.jmix.flowui.model.CollectionLoader;
 import io.jmix.flowui.view.*;
-import test_support.entity.sales.Order;
 
 /**
- * No {@code DataLoadCoordinator}. A configuration with a value is made current synchronously in
- * {@code onInit} (so {@code applyFilterIfNeeded} loads it once), and a second configuration is
- * activated via the builder's deferred {@code makeCurrent()}. The deferred activation must NOT add a
- * second load — exactly one load is expected on open.
+ * Sets a base condition on the data loader after activating a configuration in {@code onInit}.
  */
-@Route(value = "gf-activation-double-load-view")
-@ViewController("GfActivationDoubleLoadView")
+@Route(value = "gf-base-after-activation-view")
+@ViewController("GfBaseConditionAfterActivationTestView")
 @ViewDescriptor("gf-activation-nodlc-view.xml")
-public class GfActivationDoubleLoadView extends StandardView {
+public class GfBaseConditionAfterActivationTestView extends StandardView {
 
     @ViewComponent
     public GenericFilter genericFilter;
-    @ViewComponent
-    private CollectionLoader<Order> ordersDl;
-
-    public int loadCount;
 
     @Subscribe
     public void onInit(final InitEvent event) {
-        ordersDl.addPostLoadListener(e -> loadCount++);
-
-        PropertyFilter<String> declValue = genericFilter.filterComponentBuilder()
+        PropertyFilter<String> number1 = genericFilter.filterComponentBuilder()
                 .<String>propertyFilter()
                 .property("number")
                 .operation(PropertyFilter.Operation.EQUAL)
                 .build();
-        RunTimeConfiguration declConfiguration = genericFilter.runtimeConfigurationBuilder()
-                .id("decl")
-                .name("Declarative-like default")
-                .add(declValue, "d1")
+        RunTimeConfiguration c1 = genericFilter.runtimeConfigurationBuilder()
+                .id("c1")
+                .name("C1")
+                .add(number1, "n1")
                 .buildAndRegister();
-        // Make it current synchronously, emulating a default configuration that applyFilterIfNeeded loads.
-        genericFilter.setCurrentConfiguration(declConfiguration);
 
-        PropertyFilter<String> runtimeValue = genericFilter.filterComponentBuilder()
+        PropertyFilter<String> number2 = genericFilter.filterComponentBuilder()
                 .<String>propertyFilter()
                 .property("number")
                 .operation(PropertyFilter.Operation.EQUAL)
                 .build();
         genericFilter.runtimeConfigurationBuilder()
-                .id("rt")
-                .name("Runtime")
-                .add(runtimeValue, "n1")
-                .makeCurrent()
+                .id("c2")
+                .name("C2")
+                .add(number2, "n2")
                 .buildAndRegister();
+
+        genericFilter.setCurrentConfiguration(c1);
+        genericFilter.getDataLoader().setCondition(PropertyCondition.greater("amount", 0));
     }
 }

--- a/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfBaseConditionReviseTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfBaseConditionReviseTestView.java
@@ -17,48 +17,36 @@
 package component.genericfilter.view;
 
 import com.vaadin.flow.router.Route;
-import io.jmix.flowui.component.genericfilter.Configuration;
+import io.jmix.core.querycondition.PropertyCondition;
 import io.jmix.flowui.component.genericfilter.GenericFilter;
+import io.jmix.flowui.component.genericfilter.configuration.RunTimeConfiguration;
 import io.jmix.flowui.component.propertyfilter.PropertyFilter;
-import io.jmix.flowui.model.CollectionLoader;
 import io.jmix.flowui.view.*;
-import test_support.entity.sales.Order;
 
 /**
- * No {@code DataLoadCoordinator}. Two configurations on {@code number}; the first is activated via the
- * builder's {@code makeCurrent()} during {@code onInit} (deferred-to-attach path).
+ * Sets a base condition, activates a configuration, then revises the base condition, all in
+ * {@code onInit}.
  */
-@Route(value = "gf-activation-oninit-nodlc-view")
-@ViewController("GfActivationOnInitNoDlcView")
+@Route(value = "gf-base-revise-view")
+@ViewController("GfBaseConditionReviseTestView")
 @ViewDescriptor("gf-activation-nodlc-view.xml")
-public class GfActivationOnInitNoDlcView extends StandardView {
+public class GfBaseConditionReviseTestView extends StandardView {
 
     @ViewComponent
     public GenericFilter genericFilter;
-    @ViewComponent
-    private CollectionLoader<Order> ordersDl;
-
-    public int loadCount;
-    public Configuration currentRightAfterMakeCurrent;
 
     @Subscribe
     public void onInit(final InitEvent event) {
-        ordersDl.addPostLoadListener(e -> loadCount++);
-
         PropertyFilter<String> number1 = genericFilter.filterComponentBuilder()
                 .<String>propertyFilter()
                 .property("number")
                 .operation(PropertyFilter.Operation.EQUAL)
                 .build();
-        genericFilter.runtimeConfigurationBuilder()
+        RunTimeConfiguration c1 = genericFilter.runtimeConfigurationBuilder()
                 .id("c1")
                 .name("C1")
                 .add(number1, "n1")
-                .makeCurrent()
                 .buildAndRegister();
-
-        // Captured during onInit: activation is deferred, so this must still be the empty configuration.
-        currentRightAfterMakeCurrent = genericFilter.getCurrentConfiguration();
 
         PropertyFilter<String> number2 = genericFilter.filterComponentBuilder()
                 .<String>propertyFilter()
@@ -70,5 +58,9 @@ public class GfActivationOnInitNoDlcView extends StandardView {
                 .name("C2")
                 .add(number2, "n2")
                 .buildAndRegister();
+
+        genericFilter.getDataLoader().setCondition(PropertyCondition.greater("amount", 0));
+        genericFilter.setCurrentConfiguration(c1);
+        genericFilter.getDataLoader().setCondition(PropertyCondition.greater("total", 0));
     }
 }

--- a/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfConfigsNoActivationTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfConfigsNoActivationTestView.java
@@ -19,30 +19,21 @@ package component.genericfilter.view;
 import com.vaadin.flow.router.Route;
 import io.jmix.flowui.component.genericfilter.GenericFilter;
 import io.jmix.flowui.component.propertyfilter.PropertyFilter;
-import io.jmix.flowui.model.CollectionLoader;
 import io.jmix.flowui.view.*;
-import test_support.entity.sales.Order;
 
 /**
- * Same as {@link GfActivationOnInitNoDlcView} but WITH a {@code DataLoadCoordinator}: the configuration
- * activated via {@code makeCurrent()} in {@code onInit} must yield exactly one filtered load on open.
+ * Builds a configuration but does not activate it in {@code onInit}.
  */
-@Route(value = "gf-activation-oninit-dlc-view")
-@ViewController("GfActivationOnInitDlcView")
-@ViewDescriptor("gf-activation-dlc-view.xml")
-public class GfActivationOnInitDlcView extends StandardView {
+@Route(value = "gf-configs-no-activation-view")
+@ViewController("GfConfigsNoActivationTestView")
+@ViewDescriptor("gf-activation-nodlc-view.xml")
+public class GfConfigsNoActivationTestView extends StandardView {
 
     @ViewComponent
     public GenericFilter genericFilter;
-    @ViewComponent
-    private CollectionLoader<Order> ordersDl;
-
-    public int loadCount;
 
     @Subscribe
     public void onInit(final InitEvent event) {
-        ordersDl.addPostLoadListener(e -> loadCount++);
-
         PropertyFilter<String> number1 = genericFilter.filterComponentBuilder()
                 .<String>propertyFilter()
                 .property("number")
@@ -52,18 +43,6 @@ public class GfActivationOnInitDlcView extends StandardView {
                 .id("c1")
                 .name("C1")
                 .add(number1, "n1")
-                .makeCurrent()
-                .buildAndRegister();
-
-        PropertyFilter<String> number2 = genericFilter.filterComponentBuilder()
-                .<String>propertyFilter()
-                .property("number")
-                .operation(PropertyFilter.Operation.EQUAL)
-                .build();
-        genericFilter.runtimeConfigurationBuilder()
-                .id("c2")
-                .name("C2")
-                .add(number2, "n2")
                 .buildAndRegister();
     }
 }

--- a/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfGroupFilterBaseConditionTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfGroupFilterBaseConditionTestView.java
@@ -25,9 +25,9 @@ import io.jmix.flowui.view.*;
  * A standalone {@code GroupFilter} with a base condition set on its data loader in {@code onInit}.
  */
 @Route(value = "gf-group-filter-base-condition-view")
-@ViewController("GfGroupFilterBaseConditionView")
+@ViewController("GfGroupFilterBaseConditionTestView")
 @ViewDescriptor("gf-group-filter-base-condition-view.xml")
-public class GfGroupFilterBaseConditionView extends StandardView {
+public class GfGroupFilterBaseConditionTestView extends StandardView {
 
     @ViewComponent
     public GroupFilter groupFilter;

--- a/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfNestedGroupRemoveTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/genericfilter/view/GfNestedGroupRemoveTestView.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.genericfilter.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.component.genericfilter.GenericFilter;
+import io.jmix.flowui.component.logicalfilter.GroupFilter;
+import io.jmix.flowui.component.propertyfilter.PropertyFilter;
+import io.jmix.flowui.view.*;
+
+/**
+ * A run-time configuration whose root contains a nested group with a single property condition,
+ * used to reproduce the removal behaviour of a condition nested inside a group.
+ */
+@Route(value = "gf-nested-group-remove-test-view")
+@ViewController("GfNestedGroupRemoveTestView")
+@ViewDescriptor("gf-nested-group-remove-test-view.xml")
+public class GfNestedGroupRemoveTestView extends StandardView {
+
+    @ViewComponent
+    public GenericFilter genericFilter;
+
+    public GroupFilter nestedGroup;
+    public PropertyFilter<String> nestedCondition;
+
+    @Subscribe
+    public void onInit(final InitEvent event) {
+        nestedCondition = genericFilter.filterComponentBuilder()
+                .<String>propertyFilter()
+                .property("number")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .build();
+        nestedCondition.setValue("n1");
+
+        nestedGroup = genericFilter.filterComponentBuilder()
+                .groupFilter()
+                .add(nestedCondition)
+                .build();
+
+        genericFilter.runtimeConfigurationBuilder()
+                .id("c1")
+                .name("C1")
+                .add(nestedGroup)
+                .makeCurrent()
+                .buildAndRegister();
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/facet/url_query_parameters/view/GenericFilterConfigsTestView.java
+++ b/jmix-flowui/flowui/src/test/java/facet/url_query_parameters/view/GenericFilterConfigsTestView.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package facet.url_query_parameters.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.component.genericfilter.GenericFilter;
+import io.jmix.flowui.component.propertyfilter.PropertyFilter;
+import io.jmix.flowui.facet.UrlQueryParametersFacet;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.View.InitEvent;
+import io.jmix.flowui.view.Subscribe;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+
+/**
+ * A view that activates a programmatic {@code RunTimeConfiguration} in {@code onInit}:
+ * {@code active} (a {@code name} condition, made current) and {@code other} (an {@code email}
+ * condition, registered but not current). Used to verify that such a programmatic baseline survives
+ * a same-view re-navigation ({@code RestoreComponentsStateEvent} + a clean
+ * {@code QueryParametersChangeEvent}) instead of being wiped.
+ */
+@Route("GenericFilterConfigsTestView")
+@ViewController
+@ViewDescriptor("generic-filter-configs-test-view.xml")
+public class GenericFilterConfigsTestView extends StandardView {
+
+    @ViewComponent
+    public GenericFilter ownersFilter;
+
+    @ViewComponent("urlQueryParameters")
+    public UrlQueryParametersFacet urlQueryParameters;
+
+    @Subscribe
+    public void onInit(final InitEvent event) {
+        PropertyFilter<String> nameFilter = ownersFilter.filterComponentBuilder()
+                .<String>propertyFilter()
+                .property("name")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .operationEditable(true)
+                .build();
+
+        ownersFilter.runtimeConfigurationBuilder()
+                .id("active")
+                .name("Active")
+                .add(nameFilter, "John")
+                .makeCurrent()
+                .buildAndRegister();
+
+        PropertyFilter<String> emailFilter = ownersFilter.filterComponentBuilder()
+                .<String>propertyFilter()
+                .property("email")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .build();
+
+        ownersFilter.runtimeConfigurationBuilder()
+                .id("other")
+                .name("Other")
+                .add(emailFilter, "someone@example.com")
+                .buildAndRegister();
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/facet/url_query_parameters/view/GenericFilterDesignTimeConfigTestView.java
+++ b/jmix-flowui/flowui/src/test/java/facet/url_query_parameters/view/GenericFilterDesignTimeConfigTestView.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package facet.url_query_parameters.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.component.genericfilter.GenericFilter;
+import io.jmix.flowui.facet.UrlQueryParametersFacet;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+
+@Route("GenericFilterDesignTimeConfigTestView")
+@ViewController
+@ViewDescriptor("generic-filter-designtime-config-test-view.xml")
+public class GenericFilterDesignTimeConfigTestView extends StandardView {
+
+    @ViewComponent
+    public GenericFilter ownersFilter;
+
+    @ViewComponent("urlQueryParameters")
+    public UrlQueryParametersFacet urlQueryParameters;
+}

--- a/jmix-flowui/flowui/src/test/java/facet/url_query_parameters/view/GenericFilterNestedGroupTestView.java
+++ b/jmix-flowui/flowui/src/test/java/facet/url_query_parameters/view/GenericFilterNestedGroupTestView.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package facet.url_query_parameters.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.component.genericfilter.GenericFilter;
+import io.jmix.flowui.component.logicalfilter.LogicalFilterComponent;
+import io.jmix.flowui.component.propertyfilter.PropertyFilter;
+import io.jmix.flowui.facet.UrlQueryParametersFacet;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.View.InitEvent;
+import io.jmix.flowui.view.Subscribe;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+
+/**
+ * A view whose programmatic {@code RunTimeConfiguration} has a NESTED structure: the root holds a
+ * {@code groupFilter} (AND) that in turn holds two conditions ({@code name}, {@code email}). Used to
+ * verify that the re-navigation restore reconstructs the whole tree, including a condition removed
+ * from a nested group.
+ */
+@Route("GenericFilterNestedGroupTestView")
+@ViewController
+@ViewDescriptor("generic-filter-nested-group-test-view.xml")
+public class GenericFilterNestedGroupTestView extends StandardView {
+
+    @ViewComponent
+    public GenericFilter ownersFilter;
+
+    @ViewComponent("urlQueryParameters")
+    public UrlQueryParametersFacet urlQueryParameters;
+
+    @Subscribe
+    public void onInit(final InitEvent event) {
+        PropertyFilter<String> nameFilter = ownersFilter.filterComponentBuilder()
+                .<String>propertyFilter()
+                .property("name")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .build();
+
+        PropertyFilter<String> emailFilter = ownersFilter.filterComponentBuilder()
+                .<String>propertyFilter()
+                .property("email")
+                .operation(PropertyFilter.Operation.EQUAL)
+                .build();
+
+        LogicalFilterComponent<?> group = ownersFilter.filterComponentBuilder()
+                .groupFilter()
+                .operation(LogicalFilterComponent.Operation.AND)
+                .add(nameFilter)
+                .add(emailFilter)
+                .build();
+
+        ownersFilter.runtimeConfigurationBuilder()
+                .id("grouped")
+                .name("Grouped")
+                .add(group)
+                .makeCurrent()
+                .buildAndRegister();
+    }
+}

--- a/jmix-flowui/flowui/src/test/resources/component/genericfilter/view/gf-nested-group-remove-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/genericfilter/view/gf-nested-group-remove-test-view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <collection id="ordersDc"
+                    class="test_support.entity.sales.Order">
+            <fetchPlan extends="_base"/>
+            <loader id="ordersDl">
+                <query>
+                    <![CDATA[select e from test_Order e]]>
+                </query>
+            </loader>
+        </collection>
+    </data>
+    <layout>
+        <genericFilter id="genericFilter" dataLoader="ordersDl"/>
+    </layout>
+</view>

--- a/jmix-flowui/flowui/src/test/resources/facet/url_query_parameters/view/generic-filter-configs-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/facet/url_query_parameters/view/generic-filter-configs-test-view.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <collection id="ownersDc" class="test_support.entity.petclinic.Owner">
+            <fetchPlan extends="_base"/>
+            <loader id="ownersDl">
+                <query><![CDATA[select e from pc_Owner e]]></query>
+            </loader>
+        </collection>
+    </data>
+    <facets>
+        <urlQueryParameters id="urlQueryParameters">
+            <genericFilter component="ownersFilter"/>
+        </urlQueryParameters>
+    </facets>
+    <layout>
+        <genericFilter id="ownersFilter" dataLoader="ownersDl"/>
+    </layout>
+</view>

--- a/jmix-flowui/flowui/src/test/resources/facet/url_query_parameters/view/generic-filter-designtime-config-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/facet/url_query_parameters/view/generic-filter-designtime-config-test-view.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <collection id="ownersDc" class="test_support.entity.petclinic.Owner">
+            <fetchPlan extends="_base"/>
+            <loader id="ownersDl">
+                <query><![CDATA[select e from pc_Owner e]]></query>
+            </loader>
+        </collection>
+    </data>
+    <facets>
+        <urlQueryParameters id="urlQueryParameters">
+            <genericFilter component="ownersFilter"/>
+        </urlQueryParameters>
+    </facets>
+    <layout>
+        <genericFilter id="ownersFilter" dataLoader="ownersDl">
+            <configurations>
+                <configuration id="byName" name="By name" default="true">
+                    <propertyFilter property="name" operation="EQUAL" defaultValue="John"/>
+                </configuration>
+            </configurations>
+        </genericFilter>
+    </layout>
+</view>

--- a/jmix-flowui/flowui/src/test/resources/facet/url_query_parameters/view/generic-filter-nested-group-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/facet/url_query_parameters/view/generic-filter-nested-group-test-view.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <collection id="ownersDc" class="test_support.entity.petclinic.Owner">
+            <fetchPlan extends="_base"/>
+            <loader id="ownersDl">
+                <query><![CDATA[select e from pc_Owner e]]></query>
+            </loader>
+        </collection>
+    </data>
+    <facets>
+        <urlQueryParameters id="urlQueryParameters">
+            <genericFilter component="ownersFilter"/>
+        </urlQueryParameters>
+    </facets>
+    <layout>
+        <genericFilter id="ownersFilter" dataLoader="ownersDl"/>
+    </layout>
+</view>


### PR DESCRIPTION
Fixes #5425 and #5487

### Problem

A `GenericFilter` bound via the `urlQueryParameters` facet broke on a clean re-navigation to the same view. When Vaadin reuses the view instance, `onInit` is not called again, and `applyInitialState()` wiped the current configuration instead of restoring it:

- a programmatically created/activated configuration disappeared and could not be reselected (#5425);
- a value or operation changed via the URL was not reset on re-navigation — for a design-time configuration it stuck as if it were the default (#5487).

### Fix

On re-navigation the binder now restores the captured initial state instead of clearing it:

- **Structure** — the configuration tree is reconciled recursively: conditions removed by the user are re-added, conditions added afterwards (e.g. from the URL) are dropped, order and `modified` flags are restored, component instances are preserved.
- **Values/operations** — the captured operation and value of each condition are restored for **every** configuration type, including design-time (#5487); structural and default-value restore stay runtime-specific.
- **Event storm** — the reconciliation unbinds the components-change listener and rebinds once, so it no longer pushes URL parameters per add/remove.

Supporting changes: the duplicated base-condition capture/compose logic in `GenericFilter` and `GroupFilter` was extracted into `@Internal BaseConditionSupport` (behaviour unchanged); the internal `InitialState`/`ComponentNode` records and the single-filter state helper are marked `@Internal`; generic-filter test views were renamed to the `*TestView` convention.

### Tests

Facet-level re-navigation tests driving the real event chain (`RestoreComponentsStateEvent` → `QueryParametersChangeEvent`): programmatic-baseline survival, empty-configuration clearing, URL value/operation/condition reset, design-time value reset (#5487), nested-group restore, pure-user-action scope, and an event-storm regression. Also a regression test for removing a condition nested in a group (#5486).

### Commits

- `restore configuration state on same-view re-navigation (5425, 5487)` — the fix and its tests.
- `add a regression test for removing a condition nested in a group (5486)` — the regression test.

### Backward compatibility

No `public` API contract is removed or changed: the `HasInitialState` interface is untouched, `GenericFilter.updateDataLoaderInitialCondition` is kept as `@Deprecated(forRemoval = true)` rather than removed, and the only new public types (`BaseConditionSupport`, `SingleFilterComponentStateSupport`) are `@Internal` and purely additive. The behavioural changes are the bug fixes themselves — re-navigation now restores the configuration instead of clearing it (#5425) and resets a URL-changed design-time value (#5487); both correct broken behaviour, so no application migration is required.

However, the following **`protected` members of the URL query-parameter binders changed shape**. They are now marked `@Internal`, and all usages are confined to the `flowui` module (no references in `jmix-premium` or sample apps), but a subclass that referenced them would break at source/binary level. Worth a release-note line for anyone who extended these binders:

- **BC-1 — `PropertyFilterUrlQueryParametersBinder`** (sharpest break): the `protected record InitialState(Operation, Object)` is **removed**, and the type of the `protected` field `initialState` changed from `InitialState` to `SingleFilterComponentStateSupport.State`. A subclass reading that field or the record no longer compiles.
- **BC-2 — `DataGridFilterUrlQueryParametersBinder.InitialState`**: record signature changed from `(String key, String property, PropertyFilter.Operation operation, Object value)` to `(String key, String property, SingleFilterComponentStateSupport.State state)`.
- **BC-3 — `GenericFilterUrlQueryParametersBinder.InitialState`**: record signature changed from `(Configuration configuration)` to `(Configuration configuration, List<ComponentNode> structure, Map<…> states, Map<…> defaultValues)`; a new `ComponentNode` record was added.

Mitigations already in place: all three records carry `@Internal`, the public `HasInitialState` contract does not expose them, and the new `SingleFilterComponentStateSupport` bean is resolved from the standard `io.jmix.flowui` component scan (no manual wiring needed).
