### PR TITLE
GenericFilter: on re-navigation only the entry configuration is restored; changes in other configurations persist  #5488

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
@@ -93,7 +93,9 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
 
     protected Registration filterComponentsChangeRegistration;
 
-    protected InitialState initialState;
+    protected final List<InitialState> initialStates = new ArrayList<>();
+
+    protected Configuration entryConfiguration;
 
     public GenericFilterUrlQueryParametersBinder(GenericFilter filter,
                                                  UrlParamSerializer urlParamSerializer,
@@ -121,12 +123,25 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
 
     @Override
     public void saveInitialState() {
-        Configuration configuration = filter.getCurrentConfiguration();
-        LogicalFilterComponent<?> rootLogicalFilterComponent = configuration.getRootLogicalFilterComponent();
-        initialState = new InitialState(configuration,
-                captureStructure(configuration, rootLogicalFilterComponent),
-                captureInitialStates(rootLogicalFilterComponent),
-                captureInitialDefaultValues(configuration, rootLogicalFilterComponent));
+        // Snapshot every configuration, not only the entry one, so a clean re-navigation can restore
+        // each configuration the user or the URL touched during the session (not just the current one).
+        initialStates.clear();
+        entryConfiguration = filter.getCurrentConfiguration();
+        for (Configuration configuration : collectConfigurations()) {
+            LogicalFilterComponent<?> rootLogicalFilterComponent = configuration.getRootLogicalFilterComponent();
+            initialStates.add(new InitialState(configuration,
+                    captureStructure(configuration, rootLogicalFilterComponent),
+                    captureInitialStates(rootLogicalFilterComponent),
+                    captureInitialDefaultValues(configuration, rootLogicalFilterComponent)));
+        }
+    }
+
+    protected List<Configuration> collectConfigurations() {
+        List<Configuration> configurations = new ArrayList<>(filter.getConfigurations());
+        if (!configurations.contains(filter.getEmptyConfiguration())) {
+            configurations.add(filter.getEmptyConfiguration());
+        }
+        return configurations;
     }
 
     protected List<ComponentNode> captureStructure(Configuration configuration,
@@ -268,22 +283,26 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
         // storm by unbinding the listener for the duration and rebinding once afterwards.
         unbindFilterComponentsChange();
         try {
-            // Structural restore and default-value re-registration apply only to runtime
-            // configurations; a design-time configuration has no such user/URL-driven changes.
-            if (initialState.configuration instanceof RunTimeConfiguration runTimeConfiguration) {
-                restoreStructure(runTimeConfiguration,
-                        runTimeConfiguration.getRootLogicalFilterComponent(),
-                        initialState.structure);
-                restoreInitialDefaultValues(runTimeConfiguration);
+            // Restore every snapshotted configuration, not only the entry one, so changes made to
+            // other configurations during the session are reverted as well.
+            for (InitialState state : initialStates) {
+                // Structural restore and default-value re-registration apply only to runtime
+                // configurations; a design-time configuration has no such user/URL-driven changes.
+                if (state.configuration instanceof RunTimeConfiguration runTimeConfiguration) {
+                    restoreStructure(runTimeConfiguration,
+                            runTimeConfiguration.getRootLogicalFilterComponent(),
+                            state.structure);
+                    restoreInitialDefaultValues(runTimeConfiguration, state);
+                }
+                // A value or operation changed via the URL must be reset for any configuration type,
+                // including a design-time configuration, whose captured state is restored here too.
+                restoreInitialStates(state);
             }
-            // A value or operation changed via the URL must be reset for any configuration type,
-            // including a design-time configuration, whose captured state is restored here too.
-            restoreInitialStates();
         } finally {
             bindFilterComponentsChangeListener(filter);
         }
 
-        filter.setCurrentConfiguration(initialState.configuration);
+        filter.setCurrentConfiguration(entryConfiguration);
     }
 
     protected void restoreStructure(Configuration configuration,
@@ -307,20 +326,20 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
         }
     }
 
-    protected void restoreInitialDefaultValues(RunTimeConfiguration configuration) {
+    protected void restoreInitialDefaultValues(RunTimeConfiguration configuration, InitialState state) {
         // The condition remove button and URL-driven operation changes reset registered default
         // values; re-register the initial ones so a later configuration switch restores them
         // instead of falling back to null.
         configuration.resetAllDefaultValues();
-        initialState.defaultValues.forEach(configuration::setFilterComponentDefaultValue);
+        state.defaultValues.forEach(configuration::setFilterComponentDefaultValue);
     }
 
-    protected void restoreInitialStates() {
+    protected void restoreInitialStates(InitialState state) {
         // The resettable fields (operation + value) and their restore order are defined in
         // SingleFilterComponentStateSupport. A surviving baseline component can be mutated in place
         // only by #updatePropertyCondition; keep the captured fields in sync if the reconciliation in
         // #updateFilterComponent is extended to JpqlFilter/GroupFilter.
-        initialState.states.forEach(singleFilterComponentStateSupport::restore);
+        state.states.forEach(singleFilterComponentStateSupport::restore);
     }
 
     @Override

--- a/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
@@ -336,7 +336,7 @@ class GenericFilterReNavigationTest extends FlowuiTestSpecification {
         propertyFilterOn(active, "name").value == "John"
     }
 
-    def "a condition added to a non-entry configuration survives re-navigation; only the entry config is restored (no URL)"() {
+    def "a condition added to a non-entry configuration is also restored on re-navigation (no URL)"() {
         given:
         def screen = navigateToView(GenericFilterConfigsTestView)
         def binder = getBinder(screen)
@@ -362,8 +362,35 @@ class GenericFilterReNavigationTest extends FlowuiTestSpecification {
         screen.ownersFilter.currentConfiguration.is(active)
         hasPropertyConditionOn(active, "name")
 
-        and: "the user's own addition on the non-entry config remains (it is outside the restore scope)"
-        hasPropertyConditionOn(other, "name")
+        and: "the non-entry config is ALSO restored: the user's addition is gone, its baseline remains"
+        !hasPropertyConditionOn(other, "name")
+        hasPropertyConditionOn(other, "email")
+    }
+
+    def "a condition removed from a non-entry configuration is restored on re-navigation (no URL)"() {
+        given:
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+        Configuration other = screen.ownersFilter.getConfiguration("other")
+
+        when: "the user switches to 'other' and removes its baseline 'email' condition, then switches back"
+        screen.ownersFilter.setCurrentConfiguration(other)
+        def emailFilter = propertyFilterOn(other, "email")
+        other.rootLogicalFilterComponent.remove(emailFilter)
+        ((RunTimeConfiguration) other).setFilterComponentModified(emailFilter, false)
+        screen.ownersFilter.setCurrentConfiguration(active)
+
+        then: "the condition is gone from 'other'"
+        !hasPropertyConditionOn(other, "email")
+
+        when: "a clean re-navigation happens"
+        binder.applyInitialState()
+        binder.updateState(QueryParameters.empty())
+
+        then: "the entry config is restored, and 'other' is restored too: its baseline condition is back"
+        screen.ownersFilter.currentConfiguration.is(active)
+        hasPropertyConditionOn(active, "name")
         hasPropertyConditionOn(other, "email")
     }
 


### PR DESCRIPTION
Fixes #5488 

Depends on #5425 fix

### Problem

On a clean same-view re-navigation the filter restored only the configuration that was current at initialization (the entry configuration). Changes made to any other configuration — a condition added or removed, via the URL or by user actions — were not restored and persisted for the session (until a full view reload).

### Fix

`GenericFilterUrlQueryParametersBinder` now snapshots **every** configuration at `saveInitialState` (all registered configurations plus the empty one), and `applyInitialState` restores each of them, then makes the entry configuration current again. The per-configuration restore reuses the existing structure/default-value/state reconciliation; the restore of non-current configurations happens on their models, so switching to them later shows the restored state.

### Behaviour change (relative to the re-navigation PR)

This extends #5425. The re-navigation PR intentionally restored only the entry configuration; #5488 broadens that to all configurations. The corresponding test in #5425 (which asserted the entry-only scope) is updated to the new expectation. Both PRs are unreleased, so no released behaviour changes; the shipped behaviour is the combined result.

### Tests

Two tests in `GenericFilterReNavigationTest` — a condition **added** to a non-entry configuration is removed on re-navigation, and a condition **removed** from a non-entry configuration is restored — both while the entry configuration is restored as before. Verified they fail on the entry-only snapshot and pass with the per-configuration snapshot; the rest of the re-navigation suite stays green.

### Backward compatibility

No public API change: `saveInitialState`/`applyInitialState`/`restore*` are `protected` on an `@Internal` binder; the internal field changed from a single `InitialState` to a `List<InitialState>` plus an `entryConfiguration` reference. The behavioural change is the bug fix itself; no application migration is required.