### PR TITLE
Store nested meta-annotation members as maps

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/impl/MetaModelLoader.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/MetaModelLoader.java
@@ -780,7 +780,8 @@ public class MetaModelLoader {
         for (Annotation annotation : annotatedElement.getAnnotations()) {
             MetaAnnotation metaAnnotation = AnnotationUtils.findAnnotation(annotation.getClass(), MetaAnnotation.class);
             if (metaAnnotation != null) {
-                Map<String, Object> attributes = new LinkedHashMap<>(AnnotationUtils.getAnnotationAttributes(annotatedElement, annotation));
+                Map<String, Object> attributes = new LinkedHashMap<>(AnnotationUtils.getAnnotationAttributes(
+                        annotatedElement, annotation, /*classValuesAsString*/ false, /*nestedAnnotationsAsMap*/ true));
                 metaProperty.getAnnotations().put(annotation.annotationType().getName(), attributes);
             }
         }

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/MetadataLoader.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/MetadataLoader.java
@@ -146,7 +146,8 @@ public class MetadataLoader {
                 String name = annotation.annotationType().getName();
 
                 Map<String, Object> attributes = new LinkedHashMap<>(
-                        AnnotationUtils.getAnnotationAttributes(metaClass.getJavaClass(), annotation));
+                        AnnotationUtils.getAnnotationAttributes(metaClass.getJavaClass(), annotation,
+                                /*classValuesAsString*/ false, /*nestedAnnotationsAsMap*/ true));
                 metaClass.getAnnotations().put(name, attributes);
 
                 Object propagateToSubclasses = attributes.get("propagateToSubclasses");

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/LookupFieldSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/component/factory/LookupFieldSupport.java
@@ -18,7 +18,6 @@ package io.jmix.flowui.component.factory;
 import com.google.common.base.Strings;
 import io.jmix.core.MetadataTools;
 import io.jmix.core.entity.annotation.LookupField;
-import io.jmix.core.entity.annotation.LookupItemsQuery;
 import io.jmix.core.entity.annotation.LookupType;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
@@ -85,7 +84,7 @@ public class LookupFieldSupport {
         return resolveDropdown(componentSettings.itemsQuery, referencedEntityClass, fieldLevel, actions);
     }
 
-    protected EffectiveLookupConfig resolveDropdown(@Nullable LookupItemsQuery itemsQuery,
+    protected EffectiveLookupConfig resolveDropdown(@Nullable ItemsQuerySettings itemsQuery,
                                                     MetaClass metaClass, boolean fieldLevel,
                                                     List<String> actions) {
         if (itemsQuery == null || !isItemsQueryConfigured(itemsQuery)) {
@@ -145,7 +144,7 @@ public class LookupFieldSupport {
         return List.of();
     }
 
-    protected boolean isItemsQueryConfigured(@Nullable LookupItemsQuery itemsQuery) {
+    protected boolean isItemsQueryConfigured(@Nullable ItemsQuerySettings itemsQuery) {
         return itemsQuery != null && (itemsQuery.byInstanceName() || !itemsQuery.query().isEmpty());
     }
 
@@ -157,8 +156,25 @@ public class LookupFieldSupport {
         }
         LookupType type = (LookupType) attributes.get("type");
         String[] actions = (String[]) attributes.get("actions");
-        LookupItemsQuery itemsQuery = (LookupItemsQuery) attributes.get("itemsQuery");
+        ItemsQuerySettings itemsQuery = readItemsQuery(attributes.get("itemsQuery"));
         return new LookupFieldSettings(type, actions != null ? List.of(actions) : List.of(), itemsQuery);
+    }
+
+    @Nullable
+    protected ItemsQuerySettings readItemsQuery(@Nullable Object raw) {
+        if (!(raw instanceof Map<?, ?> map)) {
+            return null;
+        }
+        return new ItemsQuerySettings(
+                Boolean.TRUE.equals(map.get("byInstanceName")),
+                asString(map.get("query")),
+                asString(map.get("searchStringFormat")),
+                Boolean.TRUE.equals(map.get("escapeValueForLike")),
+                asString(map.get("fetchPlan")));
+    }
+
+    private static String asString(@Nullable Object value) {
+        return value instanceof String s ? s : "";
     }
 
     protected static class LookupFieldSettings {
@@ -166,12 +182,16 @@ public class LookupFieldSupport {
         protected final LookupType type;
         protected final List<String> actions;
         @Nullable
-        protected final LookupItemsQuery itemsQuery;
+        protected final ItemsQuerySettings itemsQuery;
 
-        public LookupFieldSettings(LookupType type, List<String> actions, @Nullable LookupItemsQuery itemsQuery) {
+        public LookupFieldSettings(LookupType type, List<String> actions, @Nullable ItemsQuerySettings itemsQuery) {
             this.type = type;
             this.actions = actions;
             this.itemsQuery = itemsQuery;
         }
+    }
+
+    protected record ItemsQuerySettings(boolean byInstanceName, String query, String searchStringFormat,
+                                        boolean escapeValueForLike, String fetchPlan) {
     }
 }


### PR DESCRIPTION
Nested meta-annotation members are now stored as maps, and `LookupFieldSupport` reads the `itemsQuery` member from that map form.

## Changes

- **`MetaModelLoader` / `MetadataLoader`** — load nested meta-annotation members as maps
  (`AnnotationUtils.getAnnotationAttributes(..., classValuesAsString=false, nestedAnnotationsAsMap=true)`).
  `@LookupField.itemsQuery` is the only nested-annotation member in the framework, so this is the
  only observable change; enum, `String[]`, and `Class` members are unaffected.
- **`LookupFieldSupport`** — reads the `itemsQuery` member as a `Map` instead of casting to a
  `LookupItemsQuery` instance (internal `ItemsQuerySettings` value object). This lets metadata built
  at runtime (without a real annotation instance) drive the resolver. `resolve(...)` returns the same
  `EffectiveLookupConfig` as before.

## Why

The Dynamic Model builds attribute metadata programmatically and cannot fabricate a nested
`@LookupItemsQuery` annotation instance. Storing nested annotations as maps gives both the static
annotation path and the runtime-built path a single representation.

## Compatibility

No behavior change for existing `@LookupField` usages — the annotation-driven resolution path is
covered by the existing `LookupFieldSupport` / template-generation test suites, which pass unchanged.
