### PR TITLE
Eagerly fetched to-one reference is INNER-joined when the attribute is used in a filter condition (port to 2.8)

### DIFF
--- a/jmix-data/data/src/main/java/io/jmix/data/QueryParser.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/QueryParser.java
@@ -54,6 +54,15 @@ public interface QueryParser {
     boolean hasIsNotNullCondition(String attribute);
 
     /**
+     * Returns true if the query contains a condition on the given attribute of the main entity,
+     * e.g. {@code e.customer = :param} for the 'customer' attribute. Conditions on nested attributes
+     * (e.g. {@code e.customer.name = :param}) are not taken into account.
+     */
+    default boolean hasConditionOnAttribute(String attribute) {
+        return false;
+    }
+
+    /**
      * Returns true if SELECT query contains joins
      */
     boolean isQueryWithJoins();

--- a/jmix-data/data/src/main/java/io/jmix/data/impl/jpql/QueryParserAstBased.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/impl/jpql/QueryParserAstBased.java
@@ -156,6 +156,17 @@ public class QueryParserAstBased implements QueryParser {
     }
 
     @Override
+    public boolean hasConditionOnAttribute(String attribute) {
+        IdentificationVariableNode identificationVariable = getAnalyzer().getMainIdentificationVariableNode();
+        if (identificationVariable != null) {
+            String variableName = identificationVariable.getVariableName();
+            return queryTree.visit(NodesFinder.of(SimpleConditionNode.class)).getFoundNodes().stream()
+                    .anyMatch(condition -> getAnalyzer().isConditionForEntityProperty(condition, variableName, attribute));
+        }
+        return false;
+    }
+
+    @Override
     public boolean isQueryWithJoins() {
         return getAnalyzer().isQueryWithJoins();
     }

--- a/jmix-data/data/src/test/java/query_parser/QueryParserAstBasedTest.java
+++ b/jmix-data/data/src/test/java/query_parser/QueryParserAstBasedTest.java
@@ -279,6 +279,32 @@ public class QueryParserAstBasedTest {
     }
 
     @Test
+    public void testHasConditionOnAttribute() throws Exception {
+        DomainModel model = prepareDomainModel();
+        QueryParserAstBased parser = new QueryParserAstBased(model, "select h from sec_GroupHierarchy h");
+        assertFalse(parser.hasConditionOnAttribute("group"));
+
+        parser = new QueryParserAstBased(model, "select h from sec_GroupHierarchy h where h.group = ?1");
+        assertTrue(parser.hasConditionOnAttribute("group"));
+
+        parser = new QueryParserAstBased(model, "select h from sec_GroupHierarchy h where h.group = :group or h.createdBy = :createdBy");
+        assertTrue(parser.hasConditionOnAttribute("group"));
+
+        parser = new QueryParserAstBased(model, "select h from sec_GroupHierarchy h where h.group is null");
+        assertTrue(parser.hasConditionOnAttribute("group"));
+
+        parser = new QueryParserAstBased(model, "select h from sec_GroupHierarchy h where h.createdBy = :createdBy");
+        assertFalse(parser.hasConditionOnAttribute("group"));
+
+        parser = new QueryParserAstBased(model, "select h from sec_GroupHierarchy h where h.group.name = :name");
+        assertFalse(parser.hasConditionOnAttribute("group"));
+        assertTrue(parser.hasConditionOnAttribute("group.name"));
+
+        parser = new QueryParserAstBased(model, "select h from sec_GroupHierarchy h left join h.group g where g.name = :name");
+        assertFalse(parser.hasConditionOnAttribute("group"));
+    }
+
+    @Test
     public void testNewKeyword() {
         DomainModel model = prepareDomainModel();
         QueryParserAstBased parser = new QueryParserAstBased(model,

--- a/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/FetchGroupManager.java
+++ b/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/FetchGroupManager.java
@@ -249,6 +249,24 @@ public class FetchGroupManager {
                 }
             }
 
+            // If a to-one attribute is present in a query condition (e.g. 'e.customer = :param'), Eclipselink
+            // reuses the expression created for the condition when processing the left join fetch hint for the
+            // same attribute. Such expression implies an inner join, so entities with null reference would be
+            // filtered out of the result. Use batch fetching instead of join fetching for these attributes.
+            List<FetchGroupField> conditionFields = joinFields.stream()
+                    .filter(f -> f.fetchMode == FetchMode.AUTO && parser.hasConditionOnAttribute(f.path()))
+                    .collect(Collectors.toList());
+            if (!conditionFields.isEmpty()) {
+                for (Iterator<FetchGroupField> fieldIt = joinFields.iterator(); fieldIt.hasNext(); ) {
+                    FetchGroupField joinField = fieldIt.next();
+                    boolean conditionField = conditionFields.stream()
+                            .anyMatch(f -> joinField == f || joinField.metaPropertyPath.startsWith(f.metaPropertyPath));
+                    if (conditionField) {
+                        fieldIt.remove();
+                        batchFields.add(joinField);
+                    }
+                }
+            }
 
             long toManyCount = refFields.stream()
                     .filter(f -> f.metaProperty.getRange().getCardinality().isMany()).count();

--- a/jmix-data/eclipselink/src/test/groovy/fetch_groups/JoinFetchConditionOnReferenceTest.groovy
+++ b/jmix-data/eclipselink/src/test/groovy/fetch_groups/JoinFetchConditionOnReferenceTest.groovy
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package fetch_groups
+
+import io.jmix.core.DataManager
+import io.jmix.core.EntityStates
+import io.jmix.core.FetchPlan
+import io.jmix.core.FetchPlans
+import io.jmix.core.querycondition.LogicalCondition
+import io.jmix.core.querycondition.PropertyCondition
+import io.jmix.eclipselink.impl.FetchGroupManager
+import org.eclipse.persistence.config.QueryHints
+import org.springframework.beans.factory.annotation.Autowired
+import test_support.DataSpec
+import test_support.entity.sales.Customer
+import test_support.entity.sales.Order
+
+class JoinFetchConditionOnReferenceTest extends DataSpec {
+
+    @Autowired
+    DataManager dm
+    @Autowired
+    EntityStates entityStates
+    @Autowired
+    FetchPlans fetchPlans
+    @Autowired
+    FetchGroupManager fetchGroupManager
+
+    Customer customer
+    Order orderWithCustomer
+    Order orderWithoutCustomer
+
+    @Override
+    void setup() {
+        customer = dm.create(Customer)
+        customer.name = 'cust1'
+
+        orderWithCustomer = dm.create(Order)
+        orderWithCustomer.number = 'ord-with-customer'
+        orderWithCustomer.customer = customer
+
+        orderWithoutCustomer = dm.create(Order)
+        orderWithoutCustomer.number = 'ord-without-customer'
+
+        dm.save(customer, orderWithCustomer, orderWithoutCustomer)
+    }
+
+    def "order without customer matches OR condition when customer is join-fetched, JPQL condition"() {
+        def fetchPlan = fetchPlans.builder(Order)
+                .addFetchPlan(FetchPlan.BASE)
+                .add('customer', FetchPlan.BASE)
+                .build()
+
+        when:
+        def orders = dm.load(Order)
+                .query('select e from sales_Order e where e.customer = :customer or e.number = :number')
+                .parameter('customer', customer)
+                .parameter('number', 'ord-without-customer')
+                .fetchPlan(fetchPlan)
+                .list()
+
+        then:
+        orders.size() == 2
+        orders.find { it == orderWithCustomer } != null
+        orders.find { it == orderWithoutCustomer } != null
+        entityStates.isLoaded(orders.find { it == orderWithCustomer }, 'customer')
+    }
+
+    def "order without customer matches OR condition when customer is join-fetched, PropertyConditions"() {
+        def fetchPlan = fetchPlans.builder(Order)
+                .addFetchPlan(FetchPlan.BASE)
+                .add('customer', FetchPlan.BASE)
+                .build()
+
+        when:
+        def orders = dm.load(Order)
+                .condition(LogicalCondition.or(
+                        PropertyCondition.equal('customer', customer),
+                        PropertyCondition.contains('number', 'without')
+                ))
+                .fetchPlan(fetchPlan)
+                .list()
+
+        then:
+        orders.size() == 2
+    }
+
+    def "batch fetching is used instead of join fetching for reference used in query condition"() {
+        def fetchPlan = fetchPlans.builder(Order)
+                .addFetchPlan(FetchPlan.BASE)
+                .add('customer', FetchPlan.BASE)
+                .build()
+
+        when: "reference is used in a query condition"
+        def description = fetchGroupManager.calculateFetchGroup(
+                'select e from sales_Order e where e.customer = :customer or e.number = :number',
+                fetchPlan, false, true)
+
+        then:
+        description.hints['e.customer'] == QueryHints.BATCH
+
+        when: "reference is not used in query conditions"
+        description = fetchGroupManager.calculateFetchGroup(
+                'select e from sales_Order e where e.number = :number',
+                fetchPlan, false, true)
+
+        then:
+        description.hints['e.customer'] == QueryHints.LEFT_FETCH
+
+        when: "condition is on a nested attribute of the reference"
+        description = fetchGroupManager.calculateFetchGroup(
+                'select e from sales_Order e where e.customer.name = :name',
+                fetchPlan, false, true)
+
+        then:
+        description.hints['e.customer'] == QueryHints.LEFT_FETCH
+
+        when: "reference is used in an explicit left join, condition is on the join variable"
+        description = fetchGroupManager.calculateFetchGroup(
+                'select e from sales_Order e left join e.customer cje_0 where (lower(cje_0.name) like :name or e.number = :number)',
+                fetchPlan, false, true)
+
+        then:
+        description.hints['e.customer'] == QueryHints.LEFT_FETCH
+    }
+}


### PR DESCRIPTION
See #5393