### PR TITLE
Support for Firebird database

### DIFF
--- a/jmix-aitools/aitools-flowui-data/src/main/resources/io/jmix/aitoolsflowuidata/liquibase/changelog.xml
+++ b/jmix-aitools/aitools-flowui-data/src/main/resources/io/jmix/aitoolsflowuidata/liquibase/changelog.xml
@@ -24,6 +24,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <property name="offsetDateTime.type" dbms="postgresql" value="timestamp with time zone"/>
     <property name="offsetDateTime.type" dbms="oracle" value="timestamp with time zone"/>
@@ -32,6 +33,7 @@
     <property name="offsetDateTime.type" dbms="mariadb" value="DATETIME"/>
     <property name="offsetDateTime.type" dbms="hsqldb" value="timestamp with time zone"/>
     <property name="offsetDateTime.type" dbms="h2" value="timestamp with time zone"/>
+    <property name="offsetDateTime.type" dbms="firebird" value="timestamp with time zone"/>
 
     <include file="/io/jmix/aitoolsflowuidata/liquibase/changelog/001-aitls.xml"/>
     <include file="/io/jmix/aitoolsflowuidata/liquibase/changelog/002-aitls.xml"/>

--- a/jmix-audit/audit/src/main/resources/io/jmix/audit/liquibase/changelog.xml
+++ b/jmix-audit/audit/src/main/resources/io/jmix/audit/liquibase/changelog.xml
@@ -24,6 +24,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <include file="/io/jmix/audit/liquibase/changelog/001-audit.xml"/>
     <include file="/io/jmix/audit/liquibase/changelog/002-audit.xml"/>

--- a/jmix-authserver/authserver/src/main/resources/io/jmix/authserver/liquibase/changelog.xml
+++ b/jmix-authserver/authserver/src/main/resources/io/jmix/authserver/liquibase/changelog.xml
@@ -42,6 +42,9 @@
     <property name="authserver.data.type"
               value="BLOB"
               dbms="h2"/>
+    <property name="authserver.data.type"
+              value="BLOB SUB_TYPE TEXT"
+              dbms="firebird"/>
     <include file="/io/jmix/authserver/liquibase/changelog/001-authserver.xml"/>
 
 </databaseChangeLog>

--- a/jmix-data/data/src/main/java/io/jmix/data/impl/dbms/FirebirdDbTypeConverter.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/impl/dbms/FirebirdDbTypeConverter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.data.impl.dbms;
+
+import io.jmix.data.persistence.DbTypeConverter;
+import org.jspecify.annotations.Nullable;
+import org.springframework.stereotype.Component;
+
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.sql.Types;
+import java.util.Date;
+import java.util.UUID;
+
+@Component("firebirdDbTypeConverter")
+public class FirebirdDbTypeConverter implements DbTypeConverter {
+
+    @Nullable
+    @Override
+    public Object getJavaObject(ResultSet resultSet, int columnIndex) {
+        Object value;
+
+        try {
+            ResultSetMetaData metaData = resultSet.getMetaData();
+
+            if ((columnIndex > metaData.getColumnCount()) || (columnIndex <= 0))
+                throw new IndexOutOfBoundsException("Column index out of bound");
+
+            value = resultSet.getObject(columnIndex);
+
+            return value;
+        } catch (SQLException e) {
+            throw new RuntimeException("Error converting database value", e);
+        }
+    }
+
+    @Override
+    public Object getSqlObject(Object value) {
+        if (value instanceof Date)
+            return new Timestamp(((Date) value).getTime());
+        if (value instanceof UUID)
+            return value.toString();
+        if (value instanceof Boolean)
+            return ((Boolean) value) ? 1 : 0;
+        return value;
+    }
+
+    @Override
+    public int getSqlType(Class<?> javaClass) {
+        if (javaClass == Date.class)
+            return Types.TIMESTAMP;
+        else if (javaClass == UUID.class)
+            return Types.VARCHAR;
+        else if (javaClass == Boolean.class)
+            return Types.SMALLINT;
+        else if (javaClass == String.class)
+            return Types.VARCHAR;
+        else if (javaClass == Integer.class)
+            return Types.INTEGER;
+        else if (javaClass == Long.class)
+            return Types.BIGINT;
+        return Types.OTHER;
+    }
+
+    @Override
+    public String getTypeAndVersion() {
+        return "firebird";
+    }
+}

--- a/jmix-data/data/src/main/java/io/jmix/data/impl/dbms/FirebirdSequenceSupport.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/impl/dbms/FirebirdSequenceSupport.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.data.impl.dbms;
+
+import io.jmix.core.common.util.Preconditions;
+import io.jmix.data.persistence.SequenceSupport;
+import org.springframework.stereotype.Component;
+
+@Component("firebirdSequenceSupport")
+public class FirebirdSequenceSupport implements SequenceSupport {
+
+    @Override
+    public String sequenceExistsSql(String sequenceName) {
+        return "select rdb$generator_name from rdb$generators where rdb$generator_name = '"
+                + sequenceName.toUpperCase() + "'";
+    }
+
+    @Override
+    public String createSequenceSql(String sequenceName, long startValue, long increment) {
+        Preconditions.checkNotNullArgument(sequenceName, "sequenceName is null");
+        return "create sequence " + sequenceName
+                + " start with " + startValue + " increment by " + increment;
+    }
+
+    @Override
+    public String modifySequenceSql(String sequenceName, long startWith) {
+        Preconditions.checkNotNullArgument(sequenceName, "sequenceName is null");
+        // 'alter sequence ... restart with N' means "next value is exactly N" since Firebird 4,
+        // while this method must set the current value so that the next value is N + increment.
+        return "set generator " + sequenceName + " to " + startWith;
+    }
+
+    @Override
+    public String deleteSequenceSql(String sequenceName) {
+        Preconditions.checkNotNullArgument(sequenceName, "sequenceName is null");
+        return "drop sequence " + sequenceName;
+    }
+
+    @Override
+    public String getNextValueSql(String sequenceName) {
+        Preconditions.checkNotNullArgument(sequenceName, "sequenceName is null");
+        return "select next value for " + sequenceName + " from rdb$database";
+    }
+
+    @Override
+    public String getCurrentValueSql(String sequenceName) {
+        Preconditions.checkNotNullArgument(sequenceName, "sequenceName is null");
+        return "select gen_id(" + sequenceName + ", 0) from rdb$database";
+    }
+}

--- a/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/dbms/FirebirdDbmsFeatures.java
+++ b/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/dbms/FirebirdDbmsFeatures.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.eclipselink.impl.dbms;
+
+import io.jmix.data.persistence.DbmsFeatures;
+import org.springframework.stereotype.Component;
+
+import org.jspecify.annotations.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component("firebirdDbmsFeatures")
+public class FirebirdDbmsFeatures implements DbmsFeatures {
+
+    @Override
+    public Map<String, String> getJpaParameters() {
+        HashMap<String, String> params = new HashMap<>();
+        params.put("eclipselink.target-database", "io.jmix.eclipselink.impl.dbms.JmixFirebirdPlatform");
+        return params;
+    }
+
+    @Override
+    public String getTimeStampType() {
+        return "timestamp";
+    }
+
+    @Nullable
+    @Override
+    public String getUuidTypeClassName() {
+        return null;
+    }
+
+    @Nullable
+    @Override
+    public String getTransactionTimeoutStatement() {
+        return null;
+    }
+
+    @Override
+    public String getUniqueConstraintViolationPattern() {
+        return "violation of PRIMARY or UNIQUE KEY constraint \"(.+?)\"";
+    }
+
+    @Override
+    public boolean isNullsLastSorting() {
+        return false;
+    }
+
+    @Override
+    public boolean supportsLobSortingAndFiltering() {
+        return false;
+    }
+
+    @Override
+    public String getTypeAndVersion() {
+        return "firebird";
+    }
+}

--- a/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/dbms/JmixFirebirdPlatform.java
+++ b/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/dbms/JmixFirebirdPlatform.java
@@ -1,0 +1,85 @@
+
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.eclipselink.impl.dbms;
+
+import org.eclipse.persistence.exceptions.ConversionException;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.mappings.converters.Converter;
+import org.eclipse.persistence.platform.database.FirebirdPlatform;
+import org.eclipse.persistence.queries.Call;
+
+import java.io.Writer;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.UUID;
+
+public class JmixFirebirdPlatform extends FirebirdPlatform implements UuidMappingInfo {
+
+    @Override
+    public int appendParameterInternal(Call call, Writer writer, Object parameter) {
+        return super.appendParameterInternal(call, writer, convertToDataValueIfUUID(parameter));
+    }
+
+    @Override
+    public void setParameterValueInDatabaseCall(Object parameter,
+                                                PreparedStatement statement,
+                                                int index,
+                                                AbstractSession session)
+            throws SQLException {
+        super.setParameterValueInDatabaseCall(convertToDataValueIfUUID(parameter), statement, index, session);
+    }
+
+    @Override
+    public void setParameterValueInDatabaseCall(Object parameter,
+                                                CallableStatement statement,
+                                                String name,
+                                                AbstractSession session)
+            throws SQLException {
+        super.setParameterValueInDatabaseCall(convertToDataValueIfUUID(parameter), statement, name, session);
+    }
+
+    @Override
+    public Object convertObject(Object sourceObject, Class javaClass) throws ConversionException {
+        if (sourceObject instanceof UUID && javaClass == String.class) {
+            return String36UuidConverter.getInstance().convertObjectValueToDataValue(sourceObject, null);
+        }
+        return super.convertObject(sourceObject, javaClass);
+    }
+
+    @Override
+    public int getUuidSqlType() {
+        return Types.VARCHAR;
+    }
+
+    @Override
+    public Class<?> getUuidType() {
+        return String.class;
+    }
+
+    @Override
+    public String getUuidColumnDefinition() {
+        return "varchar(36)";
+    }
+
+    @Override
+    public Converter getUuidConverter() {
+        return String36UuidConverter.getInstance();
+    }
+}

--- a/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/dbms/JmixFirebirdPlatform.java
+++ b/jmix-data/eclipselink/src/main/java/io/jmix/eclipselink/impl/dbms/JmixFirebirdPlatform.java
@@ -22,15 +22,32 @@ import org.eclipse.persistence.internal.sessions.AbstractSession;
 import org.eclipse.persistence.mappings.converters.Converter;
 import org.eclipse.persistence.platform.database.FirebirdPlatform;
 import org.eclipse.persistence.queries.Call;
+import org.eclipse.persistence.tools.schemaframework.FieldDefinition;
 
 import java.io.Writer;
 import java.sql.CallableStatement;
+import java.sql.Clob;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.util.Map;
 import java.util.UUID;
 
 public class JmixFirebirdPlatform extends FirebirdPlatform implements UuidMappingInfo {
+
+    // TODO: remove when fixed in EclipseLink https://github.com/eclipse-ee4j/eclipselink/issues/2788
+    @Override
+    protected Map<Class<?>, FieldDefinition.DatabaseType> buildDatabaseTypes() {
+        Map<Class<?>, FieldDefinition.DatabaseType> types = super.buildDatabaseTypes();
+        types.put(Clob.class, new FieldDefinition.DatabaseType("BLOB SUB_TYPE TEXT", false));
+        types.put(Character[].class, new FieldDefinition.DatabaseType("BLOB SUB_TYPE TEXT", false));
+        types.put(char[].class, new FieldDefinition.DatabaseType("BLOB SUB_TYPE TEXT", false));
+        types.put(OffsetDateTime.class, new FieldDefinition.DatabaseType("TIMESTAMP WITH TIME ZONE", false));
+        types.put(OffsetTime.class, new FieldDefinition.DatabaseType("TIME WITH TIME ZONE", false));
+        return types;
+    }
 
     @Override
     public int appendParameterInternal(Call call, Writer writer, Object parameter) {

--- a/jmix-dynattr/dynattr/src/main/resources/io/jmix/dynattr/liquibase/changelog.xml
+++ b/jmix-dynattr/dynattr/src/main/resources/io/jmix/dynattr/liquibase/changelog.xml
@@ -24,6 +24,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <include file="/io/jmix/dynattr/liquibase/changelog/001-dynattr.xml"/>
 

--- a/jmix-email/email/src/main/resources/io/jmix/email/liquibase/changelog.xml
+++ b/jmix-email/email/src/main/resources/io/jmix/email/liquibase/changelog.xml
@@ -23,6 +23,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <property name="byte_array.type" dbms="mysql" value="LONGBLOB"/>
     <property name="byte_array.type" dbms="mariadb" value="LONGBLOB"/>
@@ -31,6 +32,7 @@
     <property name="byte_array.type" dbms="oracle" value="BLOB"/>
     <property name="byte_array.type" dbms="hsqldb" value="BLOB"/>
     <property name="byte_array.type" dbms="h2" value="BLOB"/>
+    <property name="byte_array.type" dbms="firebird" value="BLOB"/>
 
     <property name="offsetDateTime.type" dbms="postgresql" value="timestamp with time zone"/>
     <property name="offsetDateTime.type" dbms="oracle" value="timestamp with time zone"/>
@@ -39,6 +41,7 @@
     <property name="offsetDateTime.type" dbms="mariadb" value="DATETIME"/>
     <property name="offsetDateTime.type" dbms="hsqldb" value="timestamp with time zone"/>
     <property name="offsetDateTime.type" dbms="h2" value="timestamp with time zone"/>
+    <property name="offsetDateTime.type" dbms="firebird" value="timestamp with time zone"/>
 
     <include file="io/jmix/email/liquibase/changelog/001-email.xml"/>
     <include file="io/jmix/email/liquibase/changelog/002-email.xml"/>

--- a/jmix-flowui/flowui-data/src/main/resources/io/jmix/flowuidata/liquibase/changelog.xml
+++ b/jmix-flowui/flowui-data/src/main/resources/io/jmix/flowuidata/liquibase/changelog.xml
@@ -24,6 +24,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <include file="/io/jmix/flowuidata/liquibase/changelog/001-flowui-data.xml"/>
     <include file="/io/jmix/flowuidata/liquibase/changelog/002-flowui-data.xml"/>

--- a/jmix-messagetemplates/messagetemplates/src/main/resources/io/jmix/messagetemplates/liquibase/changelog.xml
+++ b/jmix-messagetemplates/messagetemplates/src/main/resources/io/jmix/messagetemplates/liquibase/changelog.xml
@@ -24,6 +24,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <include file="/io/jmix/messagetemplates/liquibase/changelog/001-message-templates.xml"/>
     <include file="/io/jmix/messagetemplates/liquibase/changelog/002-message-templates.xml"/>

--- a/jmix-messagetemplates/messagetemplates/src/main/resources/io/jmix/messagetemplates/liquibase/changelog/001-message-templates.xml
+++ b/jmix-messagetemplates/messagetemplates/src/main/resources/io/jmix/messagetemplates/liquibase/changelog/001-message-templates.xml
@@ -153,7 +153,7 @@
                                  referencedColumnNames="ID"/>
     </changeSet>
 
-    <changeSet id="2" author="message-templates" dbms="mssql, hsqldb, h2, oracle">
+    <changeSet id="2" author="message-templates" dbms="mssql, hsqldb, h2, oracle, firebird">
         <createIndex indexName="IDX_MSGTMP_MESSAGE_TEMPLATE_GROUP_UNQ_NAME"
                      tableName="MSGTMP_MESSAGE_TEMPLATE_GROUP"
                      unique="true">

--- a/jmix-multitenancy/multitenancy/src/main/resources/io/jmix/multitenancy/liquibase/changelog.xml
+++ b/jmix-multitenancy/multitenancy/src/main/resources/io/jmix/multitenancy/liquibase/changelog.xml
@@ -24,6 +24,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <include file="/io/jmix/multitenancy/liquibase/changelog/001-multitenancy.xml"/>
 

--- a/jmix-multitenancy/multitenancy/src/main/resources/io/jmix/multitenancy/liquibase/changelog/001-multitenancy.xml
+++ b/jmix-multitenancy/multitenancy/src/main/resources/io/jmix/multitenancy/liquibase/changelog/001-multitenancy.xml
@@ -84,7 +84,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet author="multitenancy" id="2-another-db" context="!cuba" dbms="mssql, hsqldb, h2, oracle">
+    <changeSet author="multitenancy" id="2-another-db" context="!cuba" dbms="mssql, hsqldb, h2, oracle, firebird">
         <createIndex tableName="MTEN_TENANT" indexName="IDX_MTEN_TENANT_UNIQ_TENANT_ID" unique="true">
             <column name="TENANT_ID"/>
             <column name="DELETE_TS"/>
@@ -107,7 +107,7 @@
         </createIndex>
     </changeSet>
 
-    <changeSet author="multitenancy" id="4-another-db" context="!cuba" dbms="mssql, hsqldb, h2, oracle">
+    <changeSet author="multitenancy" id="4-another-db" context="!cuba" dbms="mssql, hsqldb, h2, oracle, firebird">
         <createIndex tableName="MTEN_TENANT" indexName="IDX_MTEN_TENANT_UNIQ_NAME" unique="true">
             <column name="NAME"/>
             <column name="DELETE_TS"/>

--- a/jmix-quartz/quartz/src/main/resources/io/jmix/quartz/liquibase/changelog.xml
+++ b/jmix-quartz/quartz/src/main/resources/io/jmix/quartz/liquibase/changelog.xml
@@ -24,6 +24,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <property name="byte_array.type" dbms="postgresql" value="bytea"/>
     <property name="byte_array.type" dbms="mysql" value="BLOB"/>
@@ -32,6 +33,7 @@
     <property name="byte_array.type" dbms="oracle" value="BLOB"/>
     <property name="byte_array.type" dbms="hsqldb" value="BLOB"/>
     <property name="byte_array.type" dbms="h2" value="BLOB"/>
+    <property name="byte_array.type" dbms="firebird" value="BLOB"/>
 
     <property name="table_prefix" value="QRTZ_"/>
 

--- a/jmix-reports/reports/src/main/resources/io/jmix/reports/liquibase/changelog.xml
+++ b/jmix-reports/reports/src/main/resources/io/jmix/reports/liquibase/changelog.xml
@@ -24,6 +24,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <property name="byte_array.type" dbms="mysql" value="LONGBLOB"/>
     <property name="byte_array.type" dbms="mariadb" value="LONGBLOB"/>
@@ -32,6 +33,7 @@
     <property name="byte_array.type" dbms="oracle" value="BLOB"/>
     <property name="byte_array.type" dbms="hsqldb" value="BLOB"/>
     <property name="byte_array.type" dbms="h2" value="BLOB"/>
+    <property name="byte_array.type" dbms="firebird" value="BLOB"/>
 
     <include file="io/jmix/reports/liquibase/changelog/001-reports.xml"/>
     <include file="io/jmix/reports/liquibase/changelog/002-reports.xml"/>

--- a/jmix-reports/reports/src/main/resources/io/jmix/reports/liquibase/changelog/001-reports.xml
+++ b/jmix-reports/reports/src/main/resources/io/jmix/reports/liquibase/changelog/001-reports.xml
@@ -162,7 +162,7 @@
             <column name="START_TIME"/>
         </createIndex>
 
-        <insert tableName="REPORT_GROUP" dbms="postgresql, mssql, hsqldb, h2">
+        <insert tableName="REPORT_GROUP" dbms="postgresql, mssql, hsqldb, h2, firebird">
             <column name="ID" value="4e083530-0b9c-11e1-9b41-6bdaa41bff94"/>
             <column name="CREATE_TS" valueDate="current_timestamp"/>
             <column name="CREATED_BY" value="admin"/>
@@ -264,7 +264,7 @@
         </modifySql>
     </changeSet>
 
-    <changeSet id="4-another-db" author="reports" context="!cuba" dbms="mssql, hsqldb, h2, oracle">
+    <changeSet id="4-another-db" author="reports" context="!cuba" dbms="mssql, hsqldb, h2, oracle, firebird">
         <createIndex tableName="REPORT_GROUP" indexName="IDX_REPORT_GROUP_UNIQ_TITLE" unique="true">
             <column name="TITLE"/>
             <column name="DELETE_TS"/>
@@ -336,7 +336,7 @@
         </modifySql>
     </changeSet>
 
-    <changeSet id="5-another-db" author="reports" context="!cuba" dbms="mssql, hsqldb, h2, oracle">
+    <changeSet id="5-another-db" author="reports" context="!cuba" dbms="mssql, hsqldb, h2, oracle, firebird">
         <createIndex tableName="REPORT_REPORT" indexName="IDX_REPORT_REPORT_UNIQ_NAME" unique="true">
             <column name="NAME"/>
             <column name="DELETE_TS"/>

--- a/jmix-reports/reports/src/main/resources/io/jmix/reports/liquibase/changelog/003-reports.xml
+++ b/jmix-reports/reports/src/main/resources/io/jmix/reports/liquibase/changelog/003-reports.xml
@@ -25,6 +25,18 @@
         <modifyDataType tableName="REPORT_GROUP" columnName="LOCALE_NAMES" newDataType="varchar(4000)"/>
     </changeSet>
 
+    <changeSet author="reports" id="1-firebird" context="!cuba" dbms="firebird">
+        <addColumn tableName="REPORT_GROUP">
+            <column name="LOCALE_NAMES_TMP" type="varchar(4000)"/>
+        </addColumn>
+        <update tableName="REPORT_GROUP">
+            <column name="LOCALE_NAMES_TMP" valueComputed="cast(LOCALE_NAMES as varchar(4000))"/>
+        </update>
+        <dropColumn tableName="REPORT_GROUP" columnName="LOCALE_NAMES"/>
+        <renameColumn tableName="REPORT_GROUP" oldColumnName="LOCALE_NAMES_TMP" newColumnName="LOCALE_NAMES"
+                      columnDataType="varchar(4000)"/>
+    </changeSet>
+
     <changeSet author="reports" id="1-oracle" context="!cuba" dbms="oracle">
         <addColumn tableName="REPORT_GROUP">
             <column name="LOCALE_NAMES_TMP" type="varchar(4000)"/>

--- a/jmix-reports/reports/src/main/resources/io/jmix/reports/liquibase/changelog/004-reports.xml
+++ b/jmix-reports/reports/src/main/resources/io/jmix/reports/liquibase/changelog/004-reports.xml
@@ -21,7 +21,7 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
-    <changeSet id="1-other" author="reports" dbms="postgresql,hsqldb,h2,oracle">
+    <changeSet id="1-other" author="reports" dbms="postgresql,hsqldb,h2,oracle,firebird">
         <dropNotNullConstraint tableName="REPORT_REPORT" columnName="GROUP_ID"/>
     </changeSet>
 

--- a/jmix-restds/sample-common/src/main/resources/io/jmix/samples/restds/common/liquibase/changelog.xml
+++ b/jmix-restds/sample-common/src/main/resources/io/jmix/samples/restds/common/liquibase/changelog.xml
@@ -26,6 +26,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <include file="/io/jmix/data/liquibase/changelog.xml" contextFilter="@jmix-addon"/>
 

--- a/jmix-search/search/src/main/resources/io/jmix/search/liquibase/changelog.xml
+++ b/jmix-search/search/src/main/resources/io/jmix/search/liquibase/changelog.xml
@@ -23,6 +23,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <include file="/io/jmix/search/liquibase/changelog/001-search.xml"/>
 

--- a/jmix-security/security-data/src/main/resources/io/jmix/securitydata/liquibase/changelog.xml
+++ b/jmix-security/security-data/src/main/resources/io/jmix/securitydata/liquibase/changelog.xml
@@ -24,6 +24,7 @@
     <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
     <property name="uuid.type" dbms="mariadb" value="char(36)"/>
     <property name="uuid.type" dbms="postgresql, mysql, mssql, hsqldb, h2" value="uuid"/>
+    <property name="uuid.type" dbms="firebird" value="varchar(36)"/>
 
     <include file="/io/jmix/securitydata/liquibase/changelog/001-security-data.xml"/>
     <include file="/io/jmix/securitydata/liquibase/changelog/002-security-data.xml"/>

--- a/jmix-security/security-data/src/main/resources/io/jmix/securitydata/liquibase/changelog/001-security-data.xml
+++ b/jmix-security/security-data/src/main/resources/io/jmix/securitydata/liquibase/changelog/001-security-data.xml
@@ -206,7 +206,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="2-another-db" author="security-data" dbms="mssql, hsqldb, h2">
+    <changeSet id="2-another-db" author="security-data" dbms="mssql, hsqldb, h2, firebird">
         <createIndex tableName="SEC_RESOURCE_ROLE" indexName="IDX_RESOURCE_ROLE_UN_C">
             <column name="CODE"/>
             <column name="DELETE_TS"/>
@@ -252,7 +252,7 @@
         </rollback>
     </changeSet>
 
-    <changeSet id="3-another-db" author="security-data" dbms="mssql, hsqldb, h2">
+    <changeSet id="3-another-db" author="security-data" dbms="mssql, hsqldb, h2, firebird">
         <createIndex tableName="SEC_ROW_LEVEL_ROLE" indexName="IDX_ROW_LEVEL_ROLE_UN_C">
             <column name="CODE"/>
             <column name="DELETE_TS"/>


### PR DESCRIPTION
Firebird keeps coming up as an additional/secondary database around the CUBA and Jmix ecosystem. For example, it's already used as an additional data store in jmix-db-tests. There seems to be some interest in it, so I decided to try adding it as a supported main database type.

I don't have access to add Firebird support to Studio, but this should be a reasonable starting point for the open-source part of the framework.