### PR TITLE
Report unsupported DBMS instead of throwing NPE

### DIFF
--- a/jmix-data/data/src/main/java/io/jmix/data/persistence/DbmsSpecifics.java
+++ b/jmix-data/data/src/main/java/io/jmix/data/persistence/DbmsSpecifics.java
@@ -107,6 +107,10 @@ public class DbmsSpecifics {
                 bean = (T) applicationContext.getBean(name);
             }
         }
+        if (bean == null) {
+            throw new IllegalStateException(String.format("Unsupported DBMS '%s': no %s implementation found",
+                    dbmsType, intf.getSimpleName()));
+        }
         return bean;
     }
 


### PR DESCRIPTION
When `jmix.data.dbms-type` is set to a value that has no DbmsFeatures implementation on the classpath, the application fails with a bare NPE:

```Java
org.springframework.beans.factory.BeanCreationException: Error creating bean with name
'entityManagerFactory' ... Cannot invoke "io.jmix.data.persistence.DbmsFeatures.getJpaParameters()"
because the return value of "io.jmix.data.persistence.DbmsSpecifics.getDbmsFeatures(String)" is nu
      at io.jmix.data.impl.JmixBaseEntityManagerFactoryBean.setupJpaProperties(JmixBaseEntityManag
```

The message mentions neither the DBMS type nor the property that produced it, so the
actual cause is not discoverable from the log. This is easy to hit with a typo in a supported DBMS name -postgres instead of
postgresql, mssqlserver instead of mssql.

**Cause and fix**

DbmsSpecifics.get(Class, String, String) behaves differently depending on the requested interface: for DbmsFeatures and DbTypeConverter it silently returns null, while for the rest it delegates to applicationContext.getBean(name) and gets a NoSuchBeanDefinitionException with a meaningful message. On top of that, the internal findDbmsFeatures is annotated @Nullable, but the public getDbmsFeatures() wrapping it is not, and JmixBaseEntityManagerFactoryBean dereferences the result without a check.

Now all three lookups throw an IllegalStateException naming the DBMS type and the missing interface:

> Unsupported DBMS 'firebird': no DbmsFeatures implementation found

This matches the neighbouring DbmsType.getType(), which already throws the same exception when the DBMS cannot be determined.