### PR TITLE
Running app's app-info.json is deleted by other JVMs started from the same project directory

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/ApplicationInfoProvider.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/ApplicationInfoProvider.java
@@ -19,9 +19,10 @@ package io.jmix.core;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.jmix.core.annotation.Internal;
-import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -40,9 +41,19 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.UUID;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+/**
+ * Provides information about the running application (host, port, active profiles, etc.) and stores it
+ * to the {@code app-info.json} file in the conf directory for development tools.
+ * <p>
+ * The file is created on application startup and removed on shutdown. It is not created if the JVM is
+ * bootstrapped by a test framework, because tests may run from the same directory as a normally running
+ * application instance and must not affect its file. On shutdown, the file is removed only if it still
+ * belongs to this application instance.
+ */
 @Internal
 @Component("core_ApplicationInfoProvider")
 @ConditionalOnClass(WebServerApplicationContext.class)
@@ -52,11 +63,27 @@ public class ApplicationInfoProvider {
 
     protected static final String APP_INFO_DIR_NAME = "/app-info";
     protected static final String APP_INFO_FILE_NAME = "app-info.json";
+    protected static final String INSTANCE_ID_PROPERTY = "instanceId";
+
+    /**
+     * Stack trace prefixes of test framework launchers. Same approach as in Spring Boot DevTools
+     * ({@code DevToolsEnablementDeducer}): if the application is bootstrapped by a test framework,
+     * the application info file must not be created or removed, because such a JVM may share the
+     * conf directory with a normally running application instance.
+     */
+    protected static final List<String> TEST_LAUNCHER_STACK_PREFIXES = List.of(
+            "org.junit.runners.",
+            "org.junit.platform.",
+            "org.springframework.boot.test.",
+            "org.testng.",
+            "cucumber.runtime.");
 
     @Autowired
     protected Environment environment;
     @Autowired
     protected CoreProperties coreProperties;
+
+    protected String instanceId = UUID.randomUUID().toString();
 
     protected String host;
     protected int port;
@@ -70,7 +97,11 @@ public class ApplicationInfoProvider {
     public void onApplicationReady(ApplicationReadyEvent event) {
         initValues(event.getApplicationContext());
         if (coreProperties.isApplicationInfoFileEnabled()) {
-            createAppInfoFile();
+            if (isLaunchedFromTest()) {
+                log.debug("Application is launched from a test, application info file is not created");
+            } else {
+                createAppInfoFile();
+            }
         }
         log.debug("ApplicationInfoProvider initialization is completed");
     }
@@ -159,7 +190,9 @@ public class ApplicationInfoProvider {
         log.debug("Application info: {}", content);
 
         Path fileLocation = resolveAppInfoFileLocation();
-        writeFile(fileLocation, content);
+        if (writeFile(fileLocation, content)) {
+            registerShutdownHook();
+        }
     }
 
     protected JsonObject createJson() {
@@ -174,12 +207,13 @@ public class ApplicationInfoProvider {
         general.addProperty("startupTime", startupTime != null ? startupTime.toString() : null);
 
         JsonObject root = new JsonObject();
+        root.addProperty(INSTANCE_ID_PROPERTY, instanceId);
         root.add("general", general);
 
         return root;
     }
 
-    protected void writeFile(Path fileLocation, JsonObject json) {
+    protected boolean writeFile(Path fileLocation, JsonObject json) {
         try {
             Path parent = fileLocation.getParent();
             if (parent != null) {
@@ -199,8 +233,14 @@ public class ApplicationInfoProvider {
             );
 
             log.info("Application info stored to file: {}", fileLocation.toAbsolutePath());
+            return true;
         } catch (IOException e) {
-            log.warn("Failed to store application info to file: {}", fileLocation.toAbsolutePath(), e);
+            // The file is a development-time helper, its absence must not alarm production logs.
+            // Output is split into short and detailed forms.
+            // e.toString() is intentional: a trailing Throwable argument would be printed with the stack trace.
+            log.info("Application info file is not stored: {}", e.toString());
+            log.debug("Failed to store application info to file: {}", fileLocation.toAbsolutePath(), e);
+            return false;
         }
     }
 
@@ -225,17 +265,58 @@ public class ApplicationInfoProvider {
     protected void removeAppInfoFile() {
         Path fileLocation = resolveAppInfoFileLocation();
 
+        if (!isOwnAppInfoFile(fileLocation)) {
+            log.debug("Application info file is absent or created by another application instance, " +
+                    "skipping removal: {}", fileLocation.toAbsolutePath());
+            return;
+        }
+
         try {
             Files.deleteIfExists(fileLocation);
             log.debug("Application info file removed: {}", fileLocation.toAbsolutePath());
         } catch (IOException e) {
-            log.warn("Failed to remove application info file: {}", fileLocation.toAbsolutePath(), e);
+            log.info("Application info file is not removed: {}", e.toString());
+            log.debug("Failed to remove application info file: {}", fileLocation.toAbsolutePath(), e);
         }
     }
 
-    @PostConstruct
-    public void init() {
+    /**
+     * Checks that the file was created by this application instance. The file may have been overwritten
+     * by another instance launched from the same directory, then it must not be removed on shutdown.
+     */
+    protected boolean isOwnAppInfoFile(Path fileLocation) {
+        try {
+            if (!Files.exists(fileLocation)) {
+                return false;
+            }
+            String content = Files.readString(fileLocation, StandardCharsets.UTF_8);
+            JsonElement fileInstanceId = JsonParser.parseString(content)
+                    .getAsJsonObject()
+                    .get(INSTANCE_ID_PROPERTY);
+            return fileInstanceId != null && fileInstanceId.isJsonPrimitive()
+                    && instanceId.equals(fileInstanceId.getAsString());
+        } catch (IOException | RuntimeException e) {
+            log.debug("Unable to read application info file: {}", fileLocation.toAbsolutePath(), e);
+            return false;
+        }
+    }
+
+    protected void registerShutdownHook() {
         Runtime.getRuntime().addShutdownHook(new Thread(
                 () -> shutdownHookOperation(), "application-info-provider-shutdown-hook"));
+    }
+
+    /**
+     * Detects that the JVM was bootstrapped by a test framework by inspecting the current thread's stack trace.
+     */
+    protected boolean isLaunchedFromTest() {
+        for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
+            for (String prefix : TEST_LAUNCHER_STACK_PREFIXES) {
+                if (element.getClassName().startsWith(prefix)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/jmix-core/core/src/test/groovy/application_info/ApplicationInfoSpockDetectionTest.groovy
+++ b/jmix-core/core/src/test/groovy/application_info/ApplicationInfoSpockDetectionTest.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package application_info
+
+import io.jmix.core.ApplicationInfoProvider
+import spock.lang.Specification
+
+class ApplicationInfoSpockDetectionTest extends Specification {
+
+    def "test framework launch is detected when running from a Spock specification"() {
+        expect:
+        new TestableProvider().detectsTestLaunch()
+    }
+
+    private static class TestableProvider extends ApplicationInfoProvider {
+
+        boolean detectsTestLaunch() {
+            return isLaunchedFromTest()
+        }
+    }
+}

--- a/jmix-core/core/src/test/java/application_info/ApplicationInfoFileTest.java
+++ b/jmix-core/core/src/test/java/application_info/ApplicationInfoFileTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package application_info;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.jmix.core.ApplicationInfoProvider;
+import io.jmix.core.CoreProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.mock.env.MockEnvironment;
+import test_support.TestCoreProperties;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApplicationInfoFileTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testDetectsTestFrameworkLaunch() {
+        TestableApplicationInfoProvider provider = createProvider(true);
+
+        assertThat(provider.detectsTestLaunch()).isTrue();
+    }
+
+    @Test
+    void testFileNotCreatedWhenLaunchedFromTest() {
+        TestableApplicationInfoProvider provider = createProvider(true);
+
+        startApplication(provider);
+
+        assertThat(fileLocation()).doesNotExist();
+        assertThat(provider.hookRegistrations).isZero();
+    }
+
+    @Test
+    void testFileCreatedWithInstanceIdWhenAppLaunchedNormally() throws IOException {
+        TestableApplicationInfoProvider provider = createProvider(true);
+        provider.testLaunchOverride = false;
+
+        startApplication(provider);
+
+        assertThat(fileLocation()).exists();
+        assertThat(provider.hookRegistrations).isEqualTo(1);
+
+        JsonObject root = readFileJson();
+        assertThat(root.get("instanceId").getAsString()).isNotBlank();
+        JsonObject general = root.getAsJsonObject("general");
+        assertThat(general.get("host").getAsString()).isEqualTo("localhost");
+        assertThat(general.get("port").getAsInt()).isEqualTo(8080);
+    }
+
+    @Test
+    void testFileNotCreatedWhenDisabled() {
+        TestableApplicationInfoProvider provider = createProvider(false);
+        provider.testLaunchOverride = false;
+
+        startApplication(provider);
+
+        assertThat(fileLocation()).doesNotExist();
+        assertThat(provider.hookRegistrations).isZero();
+    }
+
+    @Test
+    void testShutdownRemovesOwnFile() {
+        TestableApplicationInfoProvider provider = createProvider(true);
+        provider.testLaunchOverride = false;
+        startApplication(provider);
+
+        provider.runShutdownHook();
+
+        assertThat(fileLocation()).doesNotExist();
+    }
+
+    @Test
+    void testShutdownKeepsFileOfAnotherInstance() throws IOException {
+        TestableApplicationInfoProvider provider = createProvider(true);
+        provider.testLaunchOverride = false;
+        startApplication(provider);
+
+        writeFileContent("{\"instanceId\": \"another-instance\", \"general\": {}}");
+
+        provider.runShutdownHook();
+
+        assertThat(fileLocation()).exists();
+    }
+
+    @Test
+    void testShutdownKeepsUnparsableFile() throws IOException {
+        TestableApplicationInfoProvider provider = createProvider(true);
+        provider.testLaunchOverride = false;
+        startApplication(provider);
+
+        writeFileContent("not a json");
+
+        provider.runShutdownHook();
+
+        assertThat(fileLocation()).exists();
+    }
+
+    @Test
+    void testWriteFailureRegistersNoHookAndDoesNotFail() throws IOException {
+        // A regular file in place of the parent directory makes the write fail with an IOException
+        // on any OS, standing in for real-world failures like missing permissions in a container.
+        Path blocker = tempDir.resolve("blocker");
+        Files.createFile(blocker);
+
+        CoreProperties properties = TestCoreProperties.builder().build();
+        TestableApplicationInfoProvider provider =
+                new TestableApplicationInfoProvider(blocker.resolve("app-info.json"), properties);
+        provider.testLaunchOverride = false;
+
+        startApplication(provider);
+
+        assertThat(provider.hookRegistrations).isZero();
+    }
+
+    @Test
+    void testShutdownWithoutCreatedFileKeepsExistingFile() throws IOException {
+        writeFileContent("{\"instanceId\": \"another-instance\", \"general\": {}}");
+
+        TestableApplicationInfoProvider provider = createProvider(false);
+        provider.testLaunchOverride = false;
+        startApplication(provider);
+
+        provider.runShutdownHook();
+
+        assertThat(fileLocation()).exists();
+    }
+
+    private TestableApplicationInfoProvider createProvider(boolean applicationInfoFileEnabled) {
+        CoreProperties properties = TestCoreProperties.builder()
+                .setApplicationInfoFileEnabled(applicationInfoFileEnabled)
+                .build();
+        return new TestableApplicationInfoProvider(fileLocation(), properties);
+    }
+
+    private void startApplication(TestableApplicationInfoProvider provider) {
+        provider.onApplicationReady(new ApplicationReadyEvent(
+                new SpringApplication(Object.class), new String[0], new StaticApplicationContext(), Duration.ZERO));
+    }
+
+    private Path fileLocation() {
+        return tempDir.resolve("app-info.json");
+    }
+
+    private JsonObject readFileJson() throws IOException {
+        String content = Files.readString(fileLocation(), StandardCharsets.UTF_8);
+        return JsonParser.parseString(content).getAsJsonObject();
+    }
+
+    private void writeFileContent(String content) throws IOException {
+        Files.writeString(fileLocation(), content, StandardCharsets.UTF_8);
+    }
+
+    private static class TestableApplicationInfoProvider extends ApplicationInfoProvider {
+
+        final Path fileLocation;
+        int hookRegistrations;
+        Boolean testLaunchOverride;
+
+        TestableApplicationInfoProvider(Path fileLocation, CoreProperties properties) {
+            this.fileLocation = fileLocation;
+            this.environment = new MockEnvironment();
+            this.coreProperties = properties;
+        }
+
+        @Override
+        protected Path resolveAppInfoFileLocation() {
+            return fileLocation;
+        }
+
+        @Override
+        protected void registerShutdownHook() {
+            hookRegistrations++;
+        }
+
+        @Override
+        protected boolean isLaunchedFromTest() {
+            return testLaunchOverride != null ? testLaunchOverride : super.isLaunchedFromTest();
+        }
+
+        boolean detectsTestLaunch() {
+            return super.isLaunchedFromTest();
+        }
+
+        void runShutdownHook() {
+            shutdownHookOperation();
+        }
+    }
+}

--- a/jmix-core/core/src/test/java/test_support/TestCoreProperties.java
+++ b/jmix-core/core/src/test/java/test_support/TestCoreProperties.java
@@ -211,6 +211,11 @@ public class TestCoreProperties extends CoreProperties {
             return this;
         }
 
+        public Builder setApplicationInfoFileEnabled(boolean applicationInfoFileEnabled) {
+            this.applicationInfoFileEnabled = applicationInfoFileEnabled;
+            return this;
+        }
+
         public TestCoreProperties build() {
             return new TestCoreProperties(
                     this.webHostName,


### PR DESCRIPTION
See #5573

Changes:

- Shutdown hook (which performs removal) is registrated only if write of file was successful.
- Launch of tests is ignored by `ApplicationInfoProvider` and doesn't cause file creation\removal.
- Extra protection: new field in app-info.json (on root level) - `instanceId`. Random UUID generated on application start. It links the file and the jvm created it.
   - Shutdown hook from some JVM can't remove the file linked to another JVM via `instanceId`.
   - 2+ concurrent real instances from the same directory still works as **last-writer-wins**. If the last started instance stops first - it will remove the file. So it's not fully independent - a single file path cannot represent two instances. Full multi-instance support is out of the patch scope.