### PR TITLE
DataManager.save() erases the @DependsOnProperties column of a field-based transient cross-datastore reference when the reference is not resolved

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/impl/UnconstrainedDataManagerImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/UnconstrainedDataManagerImpl.java
@@ -80,6 +80,9 @@ public class UnconstrainedDataManagerImpl implements UnconstrainedDataManager {
     protected ObjectProvider<CrossDataStoreReferenceLoader> crossDataStoreReferenceLoaderProvider;
 
     @Autowired
+    protected FetchPlanRepository fetchPlanRepository;
+
+    @Autowired
     protected ExtendedEntities extendedEntities;
 
     @Autowired
@@ -399,7 +402,11 @@ public class UnconstrainedDataManagerImpl implements UnconstrainedDataManager {
                     if (entityStates.isLoaded(entity, relatedPropertyName)) {
                         Object refEntity = EntityValues.getValue(entity, property.getName());
                         if (refEntity == null) {
-                            EntityValues.setValue(entity, relatedPropertyName, null);
+                            // A new entity has no stale reference to clear: its null reference means
+                            // "never resolved", and the related property value may have been set directly.
+                            if (!entityStates.isNew(entity)) {
+                                EntityValues.setValue(entity, relatedPropertyName, null);
+                            }
                         } else {
                             Object refEntityId = EntityValues.getId(refEntity);
                             MetaClass refEntityMetaClass = metadata.getClass(refEntity);
@@ -428,10 +435,16 @@ public class UnconstrainedDataManagerImpl implements UnconstrainedDataManager {
         return repeatRequired;
     }
 
-    protected void readCrossDataStoreReferences(Collection<?> entities, FetchPlan fetchPlan, MetaClass metaClass,
+    protected void readCrossDataStoreReferences(Collection<?> entities, @Nullable FetchPlan fetchPlan, MetaClass metaClass,
                                                 boolean joinTransaction) {
-        if (stores.getAdditional().isEmpty() || entities.isEmpty() || fetchPlan == null)
+        if (stores.getAdditional().isEmpty() || entities.isEmpty())
             return;
+
+        if (fetchPlan == null) {
+            // Data stores load with the base fetch plan when it is not specified explicitly,
+            // so process cross-datastore references against the same plan.
+            fetchPlan = fetchPlanRepository.getFetchPlan(metaClass, FetchPlan.BASE);
+        }
 
         CrossDataStoreReferenceLoader crossDataStoreReferenceLoader = crossDataStoreReferenceLoaderProvider.getObject(
                 metaClass, fetchPlan, joinTransaction);

--- a/jmix-data/eclipselink/src/test/groovy/data_stores/MultiDbDataManagerTest.groovy
+++ b/jmix-data/eclipselink/src/test/groovy/data_stores/MultiDbDataManagerTest.groovy
@@ -294,6 +294,73 @@ class MultiDbDataManagerTest extends DataSpec {
         report2.db1Order != null
     }
 
+    void testCrossDatastoreReferenceIdNotClearedOnNewEntity() {
+        Db1Order order = metadata.create(Db1Order)
+        order.setOrderDate(new Date())
+        order = dataManager.save(order)
+
+        when: "saving a new entity with the reference id column set directly"
+        MainReport report = metadata.create(MainReport)
+        report.setName("test")
+        report.setDb1OrderId(order.id)
+        report = dataManager.save(report)
+
+        then: "the reference id column is not cleared"
+        def report1 = dataManager.load(MainReport)
+                .id(report.id)
+                .fetchPlan(FetchPlan.BASE)
+                .one()
+
+        report1.db1OrderId == order.id
+    }
+
+    void testCrossDatastoreReferenceIdNotClearedOnNewEntityForCustomStore() {
+        Mem1Customer customer = metadata.create(Mem1Customer)
+        customer.setName("John Doe")
+        customer = dataManager.save(customer)
+
+        when: "saving a new entity with the reference id column set directly"
+        Db1Order order = metadata.create(Db1Order)
+        order.setOrderDate(new Date())
+        order.setMem1CustomerId(customer.id)
+        order = dataManager.save(order)
+
+        then: "the reference id column is not cleared"
+        def order1 = dataManager.load(Db1Order)
+                .id(order.id)
+                .fetchPlan(FetchPlan.BASE)
+                .one()
+
+        order1.mem1CustomerId == customer.id
+    }
+
+    void testCrossDatastoreReferenceIdNotClearedWhenLoadedWithoutFetchPlan() {
+        Db1Order order = metadata.create(Db1Order)
+        order.setOrderDate(new Date())
+        dataManager.save(order)
+
+        MainReport report = metadata.create(MainReport)
+        report.setDb1Order(order)
+        report.setName("test")
+        report = dataManager.save(report)
+
+        when: "loading entity without explicit fetch plan and then saving changes"
+        def report1 = dataManager.load(MainReport)
+                .id(report.id)
+                .one()
+
+        report1.setName('changed')
+        dataManager.save(report1)
+
+        then: "the reference is not cleared"
+        def report2 = dataManager.load(MainReport)
+                .id(report.id)
+                .fetchPlan({ builder -> builder.addFetchPlan(FetchPlan.BASE).add('db1Order') })
+                .one()
+
+        report2.db1Order != null
+    }
+
     @SpringBean
     NoopDataStore noopDataStore = Stub() {
         save(_) >> { throw new RuntimeException("Invoked NoopDataStore save()") }


### PR DESCRIPTION
See #5599.

Requires backport to 3.0