### PR TITLE
@RemoteService methods returning replaced entities fail with MetaClass not found on the client #5574

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/impl/serialization/EntitySerializationImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/serialization/EntitySerializationImpl.java
@@ -420,7 +420,20 @@ public class EntitySerializationImpl implements EntitySerialization {
 
         @Override
         public Entity deserialize(JsonElement jsonElement, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-            return (Entity) readEntity(jsonElement.getAsJsonObject(), metaClass);
+            return (Entity) readEntity(jsonElement.getAsJsonObject(), resolveMetaClass(typeOfT));
+        }
+
+        /**
+         * Returns the MetaClass to deserialize into: the one passed to this deserializer if any, otherwise the one
+         * corresponding to the declared Java type. The latter is relevant for entities nested in POJOs and records,
+         * where the declared type of the field is the only information about the entity type available locally.
+         */
+        @Nullable
+        protected MetaClass resolveMetaClass(@Nullable Type typeOfT) {
+            if (metaClass != null) {
+                return metaClass;
+            }
+            return typeOfT instanceof Class<?> javaClass ? metadata.findClass(javaClass) : null;
         }
 
         protected Object readEntity(JsonObject jsonObject, @Nullable MetaClass metaClass) {

--- a/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceInvoker.java
+++ b/jmix-restds/restds/src/main/java/io/jmix/restds/impl/service/RemoteServiceInvoker.java
@@ -17,6 +17,7 @@
 package io.jmix.restds.impl.service;
 
 import io.jmix.core.EntitySerialization;
+import io.jmix.core.EntitySerializationOption;
 import io.jmix.core.Metadata;
 import io.jmix.core.entity.EntityValues;
 import io.jmix.core.metamodel.datatype.Datatype;
@@ -88,7 +89,7 @@ public class RemoteServiceInvoker {
             if (paramValue == null) {
                 paramJson = "null";
             } else if (EntityValues.isEntity(paramValue)) {
-                paramJson = entitySerialization.toJson(paramValue);
+                paramJson = entitySerialization.toJson(paramValue, null, EntitySerializationOption.IGNORE_ENTITY_NAME);
             } else {
                 Datatype<?> datatype = datatypeRegistry.find(paramValue.getClass());
                 if (datatype != null) {
@@ -99,7 +100,7 @@ public class RemoteServiceInvoker {
                         paramJson = "\"" + formatted + "\"";
                     }
                 } else {
-                    paramJson = entitySerialization.objectToJson(paramValue);
+                    paramJson = entitySerialization.objectToJson(paramValue, EntitySerializationOption.IGNORE_ENTITY_NAME);
                 }
             }
             paramsJson.append("\"").append(paramName).append("\":").append(paramJson);
@@ -122,11 +123,15 @@ public class RemoteServiceInvoker {
         Type returnType = method.getGenericReturnType();
         Class<?> rawReturnType = method.getReturnType();
 
+        Class<?> entityElementType = getEntityElementType(returnType);
+
         try {
             if (isEntity(rawReturnType)) {
-                result = entitySerialization.entityFromJson(resultJson, null);
-            } else if (isCollectionOfEntities(returnType)) {
-                result = entitySerialization.entitiesCollectionFromJson(resultJson, null);
+                result = entitySerialization.entityFromJson(resultJson, metadata.getClass(rawReturnType),
+                        EntitySerializationOption.IGNORE_ENTITY_NAME);
+            } else if (entityElementType != null) {
+                result = entitySerialization.entitiesCollectionFromJson(resultJson, metadata.getClass(entityElementType),
+                        EntitySerializationOption.IGNORE_ENTITY_NAME);
             } else {
                 Datatype<?> datatype = datatypeRegistry.find(rawReturnType);
                 if (datatype != null) {
@@ -135,7 +140,8 @@ public class RemoteServiceInvoker {
                     if (rawReturnType.isPrimitive())
                         result = deserializePrimitive(resultJson, rawReturnType);
                     else
-                        result = entitySerialization.objectFromJson(resultJson, returnType);
+                        result = entitySerialization.objectFromJson(resultJson, returnType,
+                                EntitySerializationOption.IGNORE_ENTITY_NAME);
                 }
             }
         } catch (ParseException e) {
@@ -149,21 +155,25 @@ public class RemoteServiceInvoker {
         return metadata.findClass(aClass) != null;
     }
 
-    protected boolean isCollectionOfEntities(Type type) {
+    /**
+     * Returns the entity type of a collection type, or null if the given type is not a collection of entities.
+     */
+    @Nullable
+    protected Class<?> getEntityElementType(Type type) {
         if (!(type instanceof ParameterizedType parameterizedType)) {
-            return false;
+            return null;
         }
         // Check if raw type is a collection
         Class<?> rawType = (Class<?>) parameterizedType.getRawType();
         if (!Collection.class.isAssignableFrom(rawType)) {
-            return false;
+            return null;
         }
         // Check if type argument is an entity
         Type[] typeArgs = parameterizedType.getActualTypeArguments();
-        if (typeArgs.length != 1 || !(typeArgs[0] instanceof Class<?>)) {
-            return false;
+        if (typeArgs.length != 1 || !(typeArgs[0] instanceof Class<?> elementType)) {
+            return null;
         }
-        return isEntity((Class<?>) typeArgs[0]);
+        return isEntity(elementType) ? elementType : null;
     }
 
     @Nullable

--- a/jmix-restds/restds/src/test/java/remote_service/RemoteServiceTest.java
+++ b/jmix-restds/restds/src/test/java/remote_service/RemoteServiceTest.java
@@ -27,6 +27,7 @@ import test_support.BaseRestDsIntegrationTest;
 import test_support.entity.ContactType;
 import test_support.entity.Customer;
 import test_support.entity.CustomerContact;
+import test_support.entity.Employee;
 import test_support.service.CustomerService;
 import test_support.service.SampleService;
 
@@ -93,6 +94,61 @@ public class RemoteServiceTest extends BaseRestDsIntegrationTest {
     @AfterEach
     void tearDown() {
         dataManager.remove(contact1, contact2, customer);
+    }
+
+    @Test
+    void testReplacedEntityResult() {
+        Employee employee = sampleService.replacedEntityMethod();
+
+        assertThat(employee).isNotNull();
+        assertThat(employee.getName()).isEqualTo("John Doe");
+        assertThat(employee.getExtInfo()).isEqualTo("Ext info");
+    }
+
+    @Test
+    void testReplacedEntityListResult() {
+        List<Employee> employees = sampleService.replacedEntityListMethod();
+
+        assertThat(employees).isNotEmpty();
+        assertThat(employees.get(0).getName()).isEqualTo("John Doe");
+    }
+
+    @Test
+    void testReplacedEntityParam() {
+        Employee employee = dataManager.load(Employee.class).all().maxResults(1).one();
+
+        String name = sampleService.replacedEntityParamMethod(employee);
+
+        assertThat(name).isEqualTo(employee.getName());
+    }
+
+    @Test
+    void testReplacedEntityInPojoResult() {
+        SampleService.SamplePojoWithReplacedEntity pojo = sampleService.pojoWithReplacedEntityMethod();
+
+        assertThat(pojo).isNotNull();
+        assertThat(pojo.getName()).isEqualTo("pojo");
+        assertThat(pojo.getEmployee()).isNotNull();
+        assertThat(pojo.getEmployee().getName()).isEqualTo("John Doe");
+        assertThat(pojo.getEmployee().getExtInfo()).isEqualTo("Ext info");
+    }
+
+    @Test
+    void testReplacedEntityInPojoListResult() {
+        List<SampleService.SamplePojoWithReplacedEntity> pojos = sampleService.pojoWithReplacedEntityListMethod();
+
+        assertThat(pojos).hasSize(1);
+        assertThat(pojos.get(0).getEmployee().getName()).isEqualTo("John Doe");
+    }
+
+    @Test
+    void testReplacedEntityInPojoParam() {
+        Employee employee = dataManager.load(Employee.class).all().maxResults(1).one();
+
+        String name = sampleService.pojoWithReplacedEntityParamMethod(
+                new SampleService.SamplePojoWithReplacedEntity("pojo", employee));
+
+        assertThat(name).isEqualTo(employee.getName());
     }
 
     @Test

--- a/jmix-restds/restds/src/test/java/test_support/service/SampleService.java
+++ b/jmix-restds/restds/src/test/java/test_support/service/SampleService.java
@@ -22,6 +22,7 @@ import org.jspecify.annotations.NullMarked;
 import test_support.entity.ContactType;
 import test_support.entity.Customer;
 import test_support.entity.CustomerContact;
+import test_support.entity.Employee;
 
 import java.net.URI;
 import java.time.LocalDateTime;
@@ -67,6 +68,18 @@ public interface SampleService {
     Set<Customer> entitySetMethod(Set<Customer> param);
 
     Map<String, CustomerContact> entityMapMethod(Map<String, CustomerContact> param);
+
+    Employee replacedEntityMethod();
+
+    List<Employee> replacedEntityListMethod();
+
+    String replacedEntityParamMethod(Employee param);
+
+    SamplePojoWithReplacedEntity pojoWithReplacedEntityMethod();
+
+    List<SamplePojoWithReplacedEntity> pojoWithReplacedEntityListMethod();
+
+    String pojoWithReplacedEntityParamMethod(SamplePojoWithReplacedEntity param);
 
     ContactType enumMethod(ContactType param);
 
@@ -160,4 +173,33 @@ public interface SampleService {
     record SampleRecord(String name, int age) {}
 
     record SampleRecordWithEntity(String name, Customer customer) {}
+
+    class SamplePojoWithReplacedEntity {
+        private String name;
+        private Employee employee;
+
+        public SamplePojoWithReplacedEntity() {
+        }
+
+        public SamplePojoWithReplacedEntity(String name, Employee employee) {
+            this.name = name;
+            this.employee = employee;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Employee getEmployee() {
+            return employee;
+        }
+
+        public void setEmployee(Employee employee) {
+            this.employee = employee;
+        }
+    }
 }

--- a/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/SampleService.java
+++ b/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/SampleService.java
@@ -23,6 +23,7 @@ import io.jmix.rest.annotation.RestService;
 import io.jmix.samples.restservice.entity.ContactType;
 import io.jmix.samples.restservice.entity.Customer;
 import io.jmix.samples.restservice.entity.CustomerContact;
+import io.jmix.samples.restservice.entity.Employee;
 
 import java.net.URI;
 import java.time.LocalDateTime;
@@ -135,6 +136,40 @@ public class SampleService {
             assert id != null;
         }
         return param;
+    }
+
+    @RestMethod
+    public Employee replacedEntityMethod() {
+        return dataManager.load(Employee.class).all().maxResults(1).one();
+    }
+
+    @RestMethod
+    public List<Employee> replacedEntityListMethod() {
+        return dataManager.load(Employee.class).all().maxResults(3).list();
+    }
+
+    @RestMethod
+    public String replacedEntityParamMethod(Employee param) {
+        return param.getName();
+    }
+
+    @RestMethod
+    public SamplePojoWithReplacedEntity pojoWithReplacedEntityMethod() {
+        return new SamplePojoWithReplacedEntity("pojo", loadEmployee());
+    }
+
+    @RestMethod
+    public List<SamplePojoWithReplacedEntity> pojoWithReplacedEntityListMethod() {
+        return List.of(new SamplePojoWithReplacedEntity("pojo", loadEmployee()));
+    }
+
+    @RestMethod
+    public String pojoWithReplacedEntityParamMethod(SamplePojoWithReplacedEntity param) {
+        return param.getEmployee().getName();
+    }
+
+    private Employee loadEmployee() {
+        return dataManager.load(Employee.class).all().maxResults(1).one();
     }
 
     @RestMethod
@@ -276,4 +311,33 @@ public class SampleService {
     public record SampleRecord(String name, int age) {}
 
     public record SampleRecordWithEntity(String name, Customer customer) {}
+
+    public static class SamplePojoWithReplacedEntity {
+        private String name;
+        private Employee employee;
+
+        public SamplePojoWithReplacedEntity() {
+        }
+
+        public SamplePojoWithReplacedEntity(String name, Employee employee) {
+            this.name = name;
+            this.employee = employee;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Employee getEmployee() {
+            return employee;
+        }
+
+        public void setEmployee(Employee employee) {
+            this.employee = employee;
+        }
+    }
 }


### PR DESCRIPTION
Fixes #5574

## Problem

A `@RemoteService` method that returns an entity failed on the client when the backend entity had been replaced via `@ReplaceEntity`, because the response carries the replacing entity's name, which the client does not know:

```
java.lang.IllegalArgumentException: MetaClass not found for EmployeeExt
```

The remote service call was the only place in `restds` that let `_entityName` from the wire decide the local metaclass. `RestDataStore` already ignores it and deserializes into the declared local type.

The same defect affected entities passed as method **arguments**, in the opposite direction: the client sent its own local entity name, which the service could not resolve.

```
400 Bad Request {"error":"Invalid parameter value","details":"Invalid parameter value for param"}
service log: java.lang.IllegalArgumentException: MetaClass not found for Employee
```

Both halves also affect plain `@RestDataStoreEntity(remoteName = ...)` renames, not only `@ReplaceEntity`.

## Changes

`RemoteServiceInvoker` now deserializes results into the declared return type and serializes arguments without the entity name, both using `EntitySerializationOption.IGNORE_ENTITY_NAME`, the same way `RestSerialization` already does it for `RestDataStore`. `isCollectionOfEntities(Type)` became `getEntityElementType(Type)`, since the collection branch now needs the element class to look up its metaclass.

`EntitySerializationImpl.EntityDeserializer` was discarding the `typeOfT` that Gson passes it. It now falls back to that declared Java type when no `MetaClass` was given, which is what makes entities nested in POJOs and records work. The precedence in `readEntity` is unchanged — an explicit metaclass still wins, and `_entityName` still overrides it unless ignored — so the fallback only fires where the code used to throw. It uses `findClass` rather than `getClass`, which keeps it inert for `entityFromJson` and `entitiesCollectionFromJson`, whose `typeOfT` is `Entity.class` or `Collection<Entity>`.

`Set` and `Map` of entities remain unsupported, as before.

## Tests

`RemoteServiceTest` covers a replaced entity as a result, in a list, as an argument, and nested in a POJO in all three positions. The sample service and the client `@RemoteService` interface gained the corresponding methods and a `SamplePojoWithReplacedEntity` type. All six tests fail without the fix, with the two errors quoted above.

Verified green: `:restds:test` (95 tests), `:core:test` (213), `:sample-rest:test` (415), and `:flowui:test --tests "data_context.*"` (11) — the last three because the change touches shared serialization.

Note for reviewers: the argument half of the fix needs both ends rebuilt together, since the service side of a POJO argument also goes through `objectFromJson` with no metaclass. Testing against a sample service running an older `jmix-core` will show failures in `testPojos` and `testCollections`.
