### PR TITLE
@PostConstruct methods of entities are invoked when deserializing from JSON

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/CoreProperties.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/CoreProperties.java
@@ -81,6 +81,12 @@ public class CoreProperties {
     String entitySerializationTokenEncryptionKey;
 
     /**
+     * Whether the @PostConstruct methods of entities are invoked when an entity instance is created during
+     * deserialization from JSON. The entity is not new in this case, so the default value is false.
+     */
+    boolean invokePostConstructOnEntityDeserialization;
+
+    /**
      * Whether potentially dangerous runtime features are enabled.
      */
     boolean unsafeRuntimeFeaturesEnabled;
@@ -175,7 +181,8 @@ public class CoreProperties {
             @DefaultValue("true") boolean instanceNameFallbackEnabled,
             @DefaultValue("false") boolean dataObservationEnabled,
             @DefaultValue("true") boolean useUserInfoForObservation,
-            @DefaultValue("true") boolean applicationInfoFileEnabled) {
+            @DefaultValue("true") boolean applicationInfoFileEnabled,
+            @DefaultValue("false") boolean invokePostConstructOnEntityDeserialization) {
         this.webHostName = webHostName;
         this.webPort = webPort;
         this.confDir = confDir;
@@ -210,6 +217,7 @@ public class CoreProperties {
         this.dataObservationEnabled = dataObservationEnabled;
         this.useUserInfoForObservation = useUserInfoForObservation;
         this.applicationInfoFileEnabled = applicationInfoFileEnabled;
+        this.invokePostConstructOnEntityDeserialization = invokePostConstructOnEntityDeserialization;
     }
 
     public String getWebHostName() {
@@ -282,6 +290,13 @@ public class CoreProperties {
      */
     public boolean isEntitySerializationTokenRequired() {
         return entitySerializationTokenRequired;
+    }
+
+    /**
+     * @see #invokePostConstructOnEntityDeserialization
+     */
+    public boolean isInvokePostConstructOnEntityDeserialization() {
+        return invokePostConstructOnEntityDeserialization;
     }
 
     public String getEntitySerializationTokenEncryptionKey() {

--- a/jmix-core/core/src/main/java/io/jmix/core/EntityInitializer.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/EntityInitializer.java
@@ -25,4 +25,12 @@ import org.jspecify.annotations.NullMarked;
 public interface EntityInitializer {
 
     void initEntity(Object entity);
+
+    /**
+     * Returns true if this initializer should be invoked when an instance is created for an entity that already
+     * exists, for example when the entity is deserialized from JSON.
+     */
+    default boolean isApplicableToExistingEntity() {
+        return true;
+    }
 }

--- a/jmix-core/core/src/main/java/io/jmix/core/Metadata.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/Metadata.java
@@ -85,4 +85,17 @@ public interface Metadata extends Session {
      * @return              entity instance
      */
     Object create(String entityName, Object id);
+
+    /**
+     * Instantiate an entity that already exists, for example when the entity is deserialized from JSON.
+     * <p>
+     * Unlike {@link #create(MetaClass)}, invokes only the {@link EntityInitializer} beans that are
+     * {@link EntityInitializer#isApplicableToExistingEntity() applicable to existing entities}.
+     *
+     * @param metaClass     entity MetaClass
+     * @return              entity instance
+     */
+    default Object createForExistingEntity(MetaClass metaClass) {
+        return create(metaClass);
+    }
 }

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/EntityEmbeddedInitializer.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/EntityEmbeddedInitializer.java
@@ -33,6 +33,15 @@ public class EntityEmbeddedInitializer implements EntityInitializer, Ordered {
     @Autowired
     protected Metadata metadata;
 
+    /**
+     * Returns false because the created embedded instances are always discarded by the caller: the entity is
+     * populated from the existing data right after creation.
+     */
+    @Override
+    public boolean isApplicableToExistingEntity() {
+        return false;
+    }
+
     @Override
     public void initEntity(Object entity) {
         MetaClass metaClass = metadata.getClass(entity);

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/EntityPostConstructInitializer.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/EntityPostConstructInitializer.java
@@ -21,6 +21,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import io.jmix.core.CoreProperties;
 import io.jmix.core.EntityInitializer;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -42,6 +43,9 @@ public class EntityPostConstructInitializer implements EntityInitializer {
     @Autowired
     protected ApplicationContext applicationContext;
 
+    @Autowired
+    protected CoreProperties coreProperties;
+
     // stores methods in the execution order, all methods are accessible
     protected LoadingCache<Class<?>, List<Method>> postConstructMethodsCache =
             CacheBuilder.newBuilder()
@@ -51,6 +55,11 @@ public class EntityPostConstructInitializer implements EntityInitializer {
                             return getPostConstructMethodsNotCached(concreteClass);
                         }
                     });
+
+    @Override
+    public boolean isApplicableToExistingEntity() {
+        return coreProperties.isInvokePostConstructOnEntityDeserialization();
+    }
 
     @Override
     public void initEntity(Object entity) {

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/MetadataImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/MetadataImpl.java
@@ -32,6 +32,7 @@ import org.jspecify.annotations.Nullable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 
 @Component("core_Metadata")
 public class MetadataImpl implements Metadata {
@@ -94,6 +95,11 @@ public class MetadataImpl implements Metadata {
     }
 
     protected <T> T internalCreate(Class<T> entityClass, @Nullable Object id) {
+        return internalCreate(entityClass, id, initializer -> true);
+    }
+
+    protected <T> T internalCreate(Class<T> entityClass, @Nullable Object id,
+                                   Predicate<EntityInitializer> initializerFilter) {
         Class<T> extClass = getSession().getClass(entityClass).getJavaClass();
         try {
             T obj = extClass.getDeclaredConstructor().newInstance();
@@ -103,7 +109,9 @@ public class MetadataImpl implements Metadata {
 
             if (entityInitializers != null) {
                 for (EntityInitializer initializer : entityInitializers) {
-                    initializer.initEntity(obj);
+                    if (initializerFilter.test(initializer)) {
+                        initializer.initEntity(obj);
+                    }
                 }
             }
 
@@ -144,6 +152,16 @@ public class MetadataImpl implements Metadata {
     public Object create(String entityName, Object id) {
         MetaClass metaClass = getSession().getClass(entityName);
         return internalCreate(metaClass.getJavaClass(), id);
+    }
+
+    /**
+     * Creates an instance for an entity that already exists, for example when the entity is deserialized from JSON.
+     * <p>
+     * Unlike {@link #create(MetaClass)}, invokes only the {@link EntityInitializer} beans that are
+     * {@link EntityInitializer#isApplicableToExistingEntity() applicable to existing entities}.
+     */
+    public Object createForExistingEntity(MetaClass metaClass) {
+        return internalCreate(metaClass.getJavaClass(), null, EntityInitializer::isApplicableToExistingEntity);
     }
 
     @Nullable

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/MetadataImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/MetadataImpl.java
@@ -154,12 +154,7 @@ public class MetadataImpl implements Metadata {
         return internalCreate(metaClass.getJavaClass(), id);
     }
 
-    /**
-     * Creates an instance for an entity that already exists, for example when the entity is deserialized from JSON.
-     * <p>
-     * Unlike {@link #create(MetaClass)}, invokes only the {@link EntityInitializer} beans that are
-     * {@link EntityInitializer#isApplicableToExistingEntity() applicable to existing entities}.
-     */
+    @Override
     public Object createForExistingEntity(MetaClass metaClass) {
         return internalCreate(metaClass.getJavaClass(), null, EntityInitializer::isApplicableToExistingEntity);
     }

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/serialization/EntitySerializationImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/serialization/EntitySerializationImpl.java
@@ -26,6 +26,7 @@ import io.jmix.core.*;
 import io.jmix.core.accesscontext.ExportImportEntityContext;
 import io.jmix.core.annotation.Secret;
 import io.jmix.core.entity.EntityValues;
+import io.jmix.core.impl.MetadataImpl;
 import io.jmix.core.metamodel.datatype.Datatype;
 import io.jmix.core.metamodel.datatype.DatatypeRegistry;
 import io.jmix.core.metamodel.model.MetaClass;
@@ -185,6 +186,16 @@ public class EntitySerializationImpl implements EntitySerialization {
         if (field != null && !Modifier.isPublic(field.getModifiers())) {
             field.setAccessible(true);
         }
+    }
+
+    /**
+     * Creates an instance for a deserialized entity. The entity is not new, so {@code @PostConstruct} methods are not
+     * invoked unless {@link CoreProperties#isInvokePostConstructOnEntityDeserialization()} is true.
+     */
+    protected Object createEntityInstance(MetaClass metaClass) {
+        return metadata instanceof MetadataImpl metadataImpl ?
+                metadataImpl.createForExistingEntity(metaClass) :
+                metadata.create(metaClass);
     }
 
     protected class EntitySerializer implements JsonSerializer<Entity> {
@@ -453,7 +464,7 @@ public class EntitySerializationImpl implements EntitySerialization {
                 throw new EntitySerializationException("Cannot deserialize an entity. MetaClass is not defined");
             }
 
-            Object entity = metadata.create(resultMetaClass);
+            Object entity = createEntityInstance(resultMetaClass);
             clearFields(entity);
 
             MetaProperty primaryKeyProperty = metadataTools.getPrimaryKeyProperty(resultMetaClass);
@@ -641,7 +652,7 @@ public class EntitySerializationImpl implements EntitySerialization {
 
         protected Object readEmbeddedEntity(JsonObject jsonObject, MetaProperty metaProperty) {
             MetaClass metaClass = metaProperty.getRange().asClass();
-            Object entity = metadata.create(metaClass);
+            Object entity = createEntityInstance(metaClass);
             clearFields(entity);
             readFields(jsonObject, entity);
 

--- a/jmix-core/core/src/main/java/io/jmix/core/impl/serialization/EntitySerializationImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/serialization/EntitySerializationImpl.java
@@ -26,7 +26,6 @@ import io.jmix.core.*;
 import io.jmix.core.accesscontext.ExportImportEntityContext;
 import io.jmix.core.annotation.Secret;
 import io.jmix.core.entity.EntityValues;
-import io.jmix.core.impl.MetadataImpl;
 import io.jmix.core.metamodel.datatype.Datatype;
 import io.jmix.core.metamodel.datatype.DatatypeRegistry;
 import io.jmix.core.metamodel.model.MetaClass;
@@ -186,16 +185,6 @@ public class EntitySerializationImpl implements EntitySerialization {
         if (field != null && !Modifier.isPublic(field.getModifiers())) {
             field.setAccessible(true);
         }
-    }
-
-    /**
-     * Creates an instance for a deserialized entity. The entity is not new, so {@code @PostConstruct} methods are not
-     * invoked unless {@link CoreProperties#isInvokePostConstructOnEntityDeserialization()} is true.
-     */
-    protected Object createEntityInstance(MetaClass metaClass) {
-        return metadata instanceof MetadataImpl metadataImpl ?
-                metadataImpl.createForExistingEntity(metaClass) :
-                metadata.create(metaClass);
     }
 
     protected class EntitySerializer implements JsonSerializer<Entity> {
@@ -464,7 +453,7 @@ public class EntitySerializationImpl implements EntitySerialization {
                 throw new EntitySerializationException("Cannot deserialize an entity. MetaClass is not defined");
             }
 
-            Object entity = createEntityInstance(resultMetaClass);
+            Object entity = metadata.createForExistingEntity(resultMetaClass);
             clearFields(entity);
 
             MetaProperty primaryKeyProperty = metadataTools.getPrimaryKeyProperty(resultMetaClass);
@@ -652,7 +641,7 @@ public class EntitySerializationImpl implements EntitySerialization {
 
         protected Object readEmbeddedEntity(JsonObject jsonObject, MetaProperty metaProperty) {
             MetaClass metaClass = metaProperty.getRange().asClass();
-            Object entity = createEntityInstance(metaClass);
+            Object entity = metadata.createForExistingEntity(metaClass);
             clearFields(entity);
             readFields(jsonObject, entity);
 

--- a/jmix-core/core/src/test/groovy/entity_serialization/PostConstructOnDeserializationEnabledTest.groovy
+++ b/jmix-core/core/src/test/groovy/entity_serialization/PostConstructOnDeserializationEnabledTest.groovy
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entity_serialization
+
+import io.jmix.core.CoreConfiguration
+import io.jmix.core.EntitySerialization
+import io.jmix.core.Metadata
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.context.TestPropertySource
+import spock.lang.Specification
+import test_support.base.TestBaseConfiguration
+import test_support.base.entity.TestPostConstructEntity
+
+@ContextConfiguration(classes = [CoreConfiguration, TestBaseConfiguration])
+@TestPropertySource(properties = ['jmix.core.invoke-post-construct-on-entity-deserialization = true'])
+class PostConstructOnDeserializationEnabledTest extends Specification {
+
+    @Autowired
+    EntitySerialization entitySerialization
+
+    @Autowired
+    Metadata metadata
+
+    def "@PostConstruct is invoked when an entity is deserialized if the property is set"() {
+
+        def json = entitySerialization.toJson(metadata.create(TestPostConstructEntity))
+        TestPostConstructEntity.initCount.set(0)
+
+        when:
+        entitySerialization.entityFromJson(json, metadata.getClass(TestPostConstructEntity))
+
+        then:
+        TestPostConstructEntity.initCount.get() == 1
+    }
+}

--- a/jmix-core/core/src/test/groovy/entity_serialization/PostConstructOnDeserializationTest.groovy
+++ b/jmix-core/core/src/test/groovy/entity_serialization/PostConstructOnDeserializationTest.groovy
@@ -23,6 +23,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.ContextConfiguration
 import spock.lang.Specification
 import test_support.base.TestBaseConfiguration
+import test_support.base.entity.TestEmbeddedOwnerEntity
+import test_support.base.entity.TestPostConstructEmbeddable
 import test_support.base.entity.TestPostConstructEntity
 
 @ContextConfiguration(classes = [CoreConfiguration, TestBaseConfiguration])
@@ -56,6 +58,19 @@ class PostConstructOnDeserializationTest extends Specification {
 
         then:
         TestPostConstructEntity.initCount.get() == 0
+        // the value comes from JSON, not from the @PostConstruct method
         entity.name == 'default name'
+    }
+
+    def "@PostConstruct of an embedded entity is not invoked when the owning entity is deserialized"() {
+
+        def json = entitySerialization.toJson(metadata.create(TestEmbeddedOwnerEntity))
+        TestPostConstructEmbeddable.initCount.set(0)
+
+        when:
+        entitySerialization.entityFromJson(json, metadata.getClass(TestEmbeddedOwnerEntity))
+
+        then:
+        TestPostConstructEmbeddable.initCount.get() == 0
     }
 }

--- a/jmix-core/core/src/test/groovy/entity_serialization/PostConstructOnDeserializationTest.groovy
+++ b/jmix-core/core/src/test/groovy/entity_serialization/PostConstructOnDeserializationTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entity_serialization
+
+import io.jmix.core.CoreConfiguration
+import io.jmix.core.EntitySerialization
+import io.jmix.core.Metadata
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+import test_support.base.TestBaseConfiguration
+import test_support.base.entity.TestPostConstructEntity
+
+@ContextConfiguration(classes = [CoreConfiguration, TestBaseConfiguration])
+class PostConstructOnDeserializationTest extends Specification {
+
+    @Autowired
+    EntitySerialization entitySerialization
+
+    @Autowired
+    Metadata metadata
+
+    def "@PostConstruct is invoked when an entity is created"() {
+
+        TestPostConstructEntity.initCount.set(0)
+
+        when:
+        def entity = metadata.create(TestPostConstructEntity)
+
+        then:
+        TestPostConstructEntity.initCount.get() == 1
+        entity.name == 'default name'
+    }
+
+    def "@PostConstruct is not invoked when an entity is deserialized"() {
+
+        def json = entitySerialization.toJson(metadata.create(TestPostConstructEntity))
+        TestPostConstructEntity.initCount.set(0)
+
+        when:
+        def entity = entitySerialization.entityFromJson(json, metadata.getClass(TestPostConstructEntity))
+
+        then:
+        TestPostConstructEntity.initCount.get() == 0
+        entity.name == 'default name'
+    }
+}

--- a/jmix-core/core/src/test/java/test_support/TestCoreProperties.java
+++ b/jmix-core/core/src/test/java/test_support/TestCoreProperties.java
@@ -48,7 +48,8 @@ public class TestCoreProperties extends CoreProperties {
                               boolean instanceNameFallbackEnabled,
                               boolean dataObservationEnabled,
                               boolean useUserInfoForObservation,
-                              boolean applicationInfoFileEnabled) {
+                              boolean applicationInfoFileEnabled,
+                              boolean invokePostConstructOnEntityDeserialization) {
         super(webHostName, webPort, confDir, workDir, tempDir, dbDir, availableLocales,
                 crossDataStoreReferenceLoadingBatchSize, idGenerationForEntitiesInAdditionalDataStoresEnabled,
                 dom4jMaxPoolSize, dom4jMaxBorrowWaitMillis, anonymousAuthenticationTokenKey, defaultFileStorage,
@@ -56,7 +57,8 @@ public class TestCoreProperties extends CoreProperties {
                 unsafeRuntimeFeaturesEnabled, hotDeployEnabled, legacyFetchPlanSerializationAttributeName,
                 triggerFilesEnabled, triggerFilesProcessInterval,
                 roundDecimalValueByFormat, skipNullOrEmptyConditionsByDefault, instanceNameFallbackEnabled,
-                dataObservationEnabled, useUserInfoForObservation, applicationInfoFileEnabled);
+                dataObservationEnabled, useUserInfoForObservation, applicationInfoFileEnabled,
+                invokePostConstructOnEntityDeserialization);
     }
 
     public static Builder builder() {
@@ -90,6 +92,7 @@ public class TestCoreProperties extends CoreProperties {
         boolean dataObservationEnabled = false;
         boolean useUserInfoForObservation = false;
         boolean applicationInfoFileEnabled = true;
+        boolean invokePostConstructOnEntityDeserialization = false;
 
         public Builder setWebHostName(String webHostName) {
             this.webHostName = webHostName;
@@ -216,6 +219,11 @@ public class TestCoreProperties extends CoreProperties {
             return this;
         }
 
+        public Builder setInvokePostConstructOnEntityDeserialization(boolean invokePostConstructOnEntityDeserialization) {
+            this.invokePostConstructOnEntityDeserialization = invokePostConstructOnEntityDeserialization;
+            return this;
+        }
+
         public TestCoreProperties build() {
             return new TestCoreProperties(
                     this.webHostName,
@@ -243,7 +251,8 @@ public class TestCoreProperties extends CoreProperties {
                     this.instanceNameFallbackEnabled,
                     this.dataObservationEnabled,
                     this.useUserInfoForObservation,
-                    this.applicationInfoFileEnabled);
+                    this.applicationInfoFileEnabled,
+                    this.invokePostConstructOnEntityDeserialization);
         }
     }
 }

--- a/jmix-core/core/src/test/java/test_support/base/entity/TestEmbeddedOwnerEntity.java
+++ b/jmix-core/core/src/test/java/test_support/base/entity/TestEmbeddedOwnerEntity.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.base.entity;
+
+import io.jmix.core.entity.annotation.EmbeddedParameters;
+import io.jmix.core.entity.annotation.JmixEmbedded;
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+
+import jakarta.persistence.Id;
+import java.util.UUID;
+
+@JmixEntity
+public class TestEmbeddedOwnerEntity {
+
+    @Id
+    @JmixGeneratedValue
+    protected UUID id;
+
+    @JmixEmbedded
+    @EmbeddedParameters(nullAllowed = false)
+    private TestPostConstructEmbeddable embedded;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public TestPostConstructEmbeddable getEmbedded() {
+        return embedded;
+    }
+
+    public void setEmbedded(TestPostConstructEmbeddable embedded) {
+        this.embedded = embedded;
+    }
+}

--- a/jmix-core/core/src/test/java/test_support/base/entity/TestPostConstructEmbeddable.java
+++ b/jmix-core/core/src/test/java/test_support/base/entity/TestPostConstructEmbeddable.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.base.entity;
+
+import io.jmix.core.metamodel.annotation.JmixEntity;
+
+import jakarta.annotation.PostConstruct;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@JmixEntity
+public class TestPostConstructEmbeddable {
+
+    public static final AtomicInteger initCount = new AtomicInteger();
+
+    private String value;
+
+    @PostConstruct
+    public void init() {
+        initCount.incrementAndGet();
+        value = "default value";
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/jmix-core/core/src/test/java/test_support/base/entity/TestPostConstructEntity.java
+++ b/jmix-core/core/src/test/java/test_support/base/entity/TestPostConstructEntity.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.base.entity;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.persistence.Id;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@JmixEntity
+public class TestPostConstructEntity {
+
+    public static final AtomicInteger initCount = new AtomicInteger();
+
+    @Id
+    @JmixGeneratedValue
+    protected UUID id;
+
+    private String name;
+
+    @PostConstruct
+    public void init() {
+        initCount.incrementAndGet();
+        name = "default name";
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
Fixes #5583.

`EntitySerializationImpl` created every deserialized instance through `Metadata.create()`, which invokes all `EntityInitializer` beans, including `EntityPostConstructInitializer`. As a result, `@PostConstruct` methods of entities were executed on every deserialization from JSON, for example on every load through the REST DataStore, even though such entities are not new.

Now the deserialization path invokes only the initializers that are applicable to existing entities, so `@PostConstruct` methods are not called. Genuine creates are not affected: the REST create endpoint calls `Metadata.create()` itself in `EntityImportExportImpl`, and id generation, embedded id and dynamic attributes state initializers still run during deserialization.

## Changes

- `CoreProperties`: new property `jmix.core.invoke-post-construct-on-entity-deserialization`, default `false`. Set it to `true` to restore the previous behavior.
- `EntityInitializer`: new default method `isApplicableToExistingEntity()` returning `true`. `EntityPostConstructInitializer` overrides it and returns the value of the new property.
- `MetadataImpl`: `internalCreate()` accepts a filter of initializers; new `createForExistingEntity(MetaClass)` method (not part of the `Metadata` interface).
- `EntitySerializationImpl`: `readEntity()` and `readEmbeddedEntity()` use the new creation method.

## Testing

- New tests in `jmix-core`: `@PostConstruct` is invoked on `Metadata.create()`, is not invoked on deserialization, and is invoked on deserialization again when the property is set.