### PR TITLE
Maximize/Minimize Dialog functionality jmix-framework/jmix#4926

### DIFF
--- a/jmix-flowui/flowui-themes/src/main/java/io/jmix/flowui/theme/StyleUtility.java
+++ b/jmix-flowui/flowui-themes/src/main/java/io/jmix/flowui/theme/StyleUtility.java
@@ -28,6 +28,7 @@ public final class StyleUtility {
     public static final class Button {
 
         public static final String DIALOG_CLOSE_BUTTON = "dialog-close-button";
+        public static final String DIALOG_HEADER_BUTTON = "dialog-header-button";
         public static final String LINK_BUTTON = "link-button";
 
         private Button() {

--- a/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-aura/src/components/jmix-dialog-window.css
+++ b/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-aura/src/components/jmix-dialog-window.css
@@ -22,3 +22,22 @@
 .jmix-dialog-window-header-wrapper > .jmix-dialog-window-close-button {
     margin-inline-start: auto;
 }
+
+.jmix-dialog-window-header-wrapper > .jmix-dialog-window-maximize-button:not([hidden]) {
+    margin-inline-start: auto;
+}
+
+.jmix-dialog-window-header-wrapper > .jmix-dialog-window-maximize-button:not([hidden]) ~ .jmix-dialog-window-close-button {
+    margin-inline-start: 0;
+}
+
+vaadin-dialog[jmix-maximized]::part(overlay) {
+    position: var(--jmix-dialog-maximized-position, fixed) !important;
+    inset: var(--jmix-dialog-maximized-inset, 0) !important;
+    width: var(--jmix-dialog-maximized-width, auto) !important;
+    height: var(--jmix-dialog-maximized-height, auto) !important;
+
+    max-width: none;
+    max-height: none;
+    border-radius: 0;
+}

--- a/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-aura/src/utilities/misc.css
+++ b/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-aura/src/utilities/misc.css
@@ -25,14 +25,16 @@
 }
 
 vaadin-button.link-button,
-vaadin-button.dialog-close-button {
+vaadin-button.dialog-close-button,
+vaadin-button.dialog-header-button {
   padding: 0;
 
   font-size: inherit;
   line-height: inherit;
 }
 
-vaadin-button.dialog-close-button {
+vaadin-button.dialog-close-button,
+vaadin-button.dialog-header-button {
   color: var(--vaadin-text-color);
 }
 

--- a/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-lumo/components/vaadin-dialog.css
+++ b/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-lumo/components/vaadin-dialog.css
@@ -22,3 +22,22 @@
 .jmix-dialog-window-header-wrapper > .jmix-dialog-window-close-button {
     margin-inline-start: auto;
 }
+
+.jmix-dialog-window-header-wrapper > .jmix-dialog-window-maximize-button:not([hidden]) {
+    margin-inline-start: auto;
+}
+
+.jmix-dialog-window-header-wrapper > .jmix-dialog-window-maximize-button:not([hidden]) ~ .jmix-dialog-window-close-button {
+    margin-inline-start: 0;
+}
+
+vaadin-dialog[jmix-maximized]::part(overlay) {
+    position: var(--jmix-dialog-maximized-position, fixed) !important;
+    inset: var(--jmix-dialog-maximized-inset, 0) !important;
+    width: var(--jmix-dialog-maximized-width, auto) !important;
+    height: var(--jmix-dialog-maximized-height, auto) !important;
+
+    max-width: none;
+    max-height: none;
+    border-radius: 0;
+}

--- a/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-lumo/src/utilities/misc.css
+++ b/jmix-flowui/flowui-themes/src/main/resources/META-INF/resources/themes/jmix-lumo/src/utilities/misc.css
@@ -26,7 +26,8 @@
 }
 
 vaadin-button.link-button,
-vaadin-button.dialog-close-button {
+vaadin-button.dialog-close-button,
+vaadin-button.dialog-header-button {
     font-size: inherit;
     line-height: inherit;
 
@@ -40,7 +41,8 @@ vaadin-button.dialog-close-button {
 }
 
 vaadin-button.link-button::part(label),
-vaadin-button.dialog-close-button::part(label) {
+vaadin-button.dialog-close-button::part(label),
+vaadin-button.dialog-header-button::part(label) {
     line-height: inherit;
     overflow: visible;
     padding: 0px;
@@ -50,6 +52,7 @@ vaadin-button.link-button {
     border: none;
 }
 
-vaadin-button.dialog-close-button {
+vaadin-button.dialog-close-button,
+vaadin-button.dialog-header-button {
     color: var(--lumo-contrast);
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/AbstractDialogWindow.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/AbstractDialogWindow.java
@@ -31,6 +31,7 @@ import com.vaadin.flow.dom.ThemeList;
 import com.vaadin.flow.shared.Registration;
 import io.jmix.core.Messages;
 import io.jmix.core.common.event.EventHub;
+import io.jmix.core.common.event.Subscription;
 import io.jmix.flowui.UiComponents;
 import io.jmix.flowui.component.WrapperUtils;
 import io.jmix.flowui.icon.Icons;
@@ -43,6 +44,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
+import java.util.EventObject;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -55,12 +57,22 @@ public class AbstractDialogWindow<V extends View<?>> implements HasSize, HasThem
         ApplicationContextAware, InitializingBean {
 
     protected static final String BASE_CLASS_NAME = "jmix-dialog-window";
+    protected static final String MAXIMIZED_ATTRIBUTE_NAME = "jmix-maximized";
 
     protected Dialog dialog;
     protected V view;
 
     protected ApplicationContext applicationContext;
     protected HorizontalLayout headerContent;
+
+    @Nullable
+    protected JmixButton maximizeButton;
+
+    protected boolean maximizable = false;
+    protected boolean maximized = false;
+
+    protected boolean resizableBeforeMaximize = false;
+    protected boolean draggableBeforeMaximize = false;
 
     // private, lazily initialized
     private EventHub eventHub = null;
@@ -144,6 +156,7 @@ public class AbstractDialogWindow<V extends View<?>> implements HasSize, HasThem
             }
             setDraggable(dialogMode.draggable());
             setResizable(dialogMode.resizable());
+            setMaximizable(dialogMode.maximizable());
             setCloseOnOutsideClick(dialogMode.closeOnOutsideClick());
             setCloseOnEsc(dialogMode.closeOnEsc());
             setKeepInViewport(dialogMode.keepInViewport());
@@ -188,6 +201,29 @@ public class AbstractDialogWindow<V extends View<?>> implements HasSize, HasThem
         view.closeWithDefaultAction();
     }
 
+    protected JmixButton createHeaderMaximizeButton() {
+        JmixButton maximizeButton = uiComponents().create(JmixButton.class);
+        maximizeButton.addClassNames(BASE_CLASS_NAME + "-maximize-button",
+                StyleUtility.Button.DIALOG_HEADER_BUTTON);
+        maximizeButton.setVisible(maximizable);
+        maximizeButton.addClickListener(this::onMaximizeButtonClicked);
+
+        updateMaximizeButtonState(maximizeButton);
+
+        return maximizeButton;
+    }
+
+    protected void onMaximizeButtonClicked(ClickEvent<Button> event) {
+        setMaximizedInternal(!maximized, true);
+    }
+
+    protected void updateMaximizeButtonState(JmixButton button) {
+        button.setIcon(icons().get(maximized ? JmixFontIcon.COMPRESS : JmixFontIcon.EXPAND));
+        button.setTitle(messages().getMessage(maximized
+                ? "dialogWindow.restoreButton.description"
+                : "dialogWindow.maximizeButton.description"));
+    }
+
     protected Div createHeaderWrapper() {
         Div headerWrapper = uiComponents().create(Div.class);
         headerWrapper.setClassName(BASE_CLASS_NAME + "-header-wrapper");
@@ -198,6 +234,9 @@ public class AbstractDialogWindow<V extends View<?>> implements HasSize, HasThem
         headerContent.setPadding(false);
 
         headerWrapper.add(headerContent);
+
+        maximizeButton = createHeaderMaximizeButton();
+        headerWrapper.add(maximizeButton);
 
         Button closeButton = createHeaderCloseButton();
         if (closeButton != null) {
@@ -278,6 +317,19 @@ public class AbstractDialogWindow<V extends View<?>> implements HasSize, HasThem
      */
     public Registration addDraggedListener(ComponentEventListener<Dialog.DialogDraggedEvent> listener) {
         return dialog.addDraggedListener(listener);
+    }
+
+    /**
+     * Adds a listener that is notified when the dialog window is maximized or restored.
+     *
+     * @param listener the listener to add
+     * @return a Registration for removing the event listener
+     * @see #setMaximized(boolean)
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public Registration addMaximizedChangeListener(Consumer<MaximizedChangeEvent<V>> listener) {
+        Subscription subscription = getEventHub().subscribe(MaximizedChangeEvent.class, ((Consumer) listener));
+        return Registration.once(subscription::remove);
     }
 
     /**
@@ -411,30 +463,117 @@ public class AbstractDialogWindow<V extends View<?>> implements HasSize, HasThem
      * @return whether dialog is enabled to be dragged or not.
      */
     public boolean isDraggable() {
-        return dialog.isDraggable();
+        return maximized ? draggableBeforeMaximize : dialog.isDraggable();
     }
 
     /**
+     * Sets whether dialog is enabled to be dragged by the user or not. While the dialog is
+     * maximized, dragging is suppressed and the passed value is applied when the dialog
+     * is restored.
+     *
      * @param draggable {@code true} to enable dragging of the dialog, {@code false} otherwise
      */
     public void setDraggable(boolean draggable) {
-        dialog.setDraggable(draggable);
+        if (maximized) {
+            draggableBeforeMaximize = draggable;
+        } else {
+            dialog.setDraggable(draggable);
+        }
     }
 
     /**
      * @return whether dialog is enabled to be resized or not.
      */
     public boolean isResizable() {
-        return dialog.isResizable();
+        return maximized ? resizableBeforeMaximize : dialog.isResizable();
     }
 
     /**
-     * Sets whether dialog can be resized by user or not.
+     * Sets whether dialog can be resized by user or not. While the dialog is maximized, resizing
+     * is suppressed and the passed value is applied when the dialog is restored.
      *
      * @param resizable {@code true} to enabled resizing of the dialog, {@code false} otherwise.
      */
     public void setResizable(boolean resizable) {
-        dialog.setResizable(resizable);
+        if (maximized) {
+            resizableBeforeMaximize = resizable;
+        } else {
+            dialog.setResizable(resizable);
+        }
+    }
+
+    /**
+     * @return {@code true} if the dialog window shows the maximize button, {@code false} otherwise
+     */
+    public boolean isMaximizable() {
+        return maximizable;
+    }
+
+    /**
+     * Sets whether the dialog window can be maximized by the user. When enabled, a toggle button
+     * is shown in the dialog header next to the close button.
+     *
+     * @param maximizable {@code true} to show the maximize button, {@code false} to hide it
+     */
+    public void setMaximizable(boolean maximizable) {
+        this.maximizable = maximizable;
+
+        if (maximizeButton != null) {
+            maximizeButton.setVisible(maximizable);
+        }
+    }
+
+    /**
+     * @return {@code true} if the dialog window is maximized, {@code false} otherwise
+     */
+    public boolean isMaximized() {
+        return maximized;
+    }
+
+    /**
+     * Maximizes the dialog window to the whole viewport or restores it to the previous size
+     * and position.
+     * <p>
+     * The size and position of the dialog are not changed on the server: the maximized layout is
+     * applied by the theme, so restoring returns the dialog exactly where the user left it. While
+     * the dialog is maximized, dragging and resizing are suppressed; values passed to
+     * {@link #setDraggable(boolean)} and {@link #setResizable(boolean)} in this state are applied
+     * when the dialog is restored.
+     *
+     * @param maximized {@code true} to maximize the dialog, {@code false} to restore it
+     */
+    public void setMaximized(boolean maximized) {
+        setMaximizedInternal(maximized, false);
+    }
+
+    protected void setMaximizedInternal(boolean maximized, boolean fromClient) {
+        if (this.maximized == maximized) {
+            return;
+        }
+
+        this.maximized = maximized;
+
+        if (maximized) {
+            resizableBeforeMaximize = dialog.isResizable();
+            draggableBeforeMaximize = dialog.isDraggable();
+
+            dialog.setResizable(false);
+            dialog.setDraggable(false);
+
+            dialog.getElement().setAttribute(MAXIMIZED_ATTRIBUTE_NAME, true);
+        } else {
+            dialog.getElement().removeAttribute(MAXIMIZED_ATTRIBUTE_NAME);
+
+            dialog.setResizable(resizableBeforeMaximize);
+            dialog.setDraggable(draggableBeforeMaximize);
+        }
+
+        if (maximizeButton != null) {
+            updateMaximizeButtonState(maximizeButton);
+        }
+
+        MaximizedChangeEvent<V> event = new MaximizedChangeEvent<>(this, maximized, fromClient);
+        publish(MaximizedChangeEvent.class, event);
     }
 
     /**
@@ -716,5 +855,53 @@ public class AbstractDialogWindow<V extends View<?>> implements HasSize, HasThem
 
     protected Icons icons() {
         return applicationContext.getBean(Icons.class);
+    }
+
+    /**
+     * An event that is fired when the dialog window is maximized or restored.
+     *
+     * @param <V> the type of the view associated with the dialog window
+     */
+    public static class MaximizedChangeEvent<V extends View<?>> extends EventObject {
+
+        protected final boolean maximized;
+        protected final boolean fromClient;
+
+        public MaximizedChangeEvent(AbstractDialogWindow<V> source, boolean maximized, boolean fromClient) {
+            super(source);
+
+            this.maximized = maximized;
+            this.fromClient = fromClient;
+        }
+
+        @SuppressWarnings("unchecked")
+        @Override
+        public AbstractDialogWindow<V> getSource() {
+            return (AbstractDialogWindow<V>) super.getSource();
+        }
+
+        /**
+         * Returns the view associated with the dialog window.
+         *
+         * @return the view associated with the dialog window
+         */
+        public V getView() {
+            return getSource().getView();
+        }
+
+        /**
+         * @return {@code true} if the dialog window is maximized, {@code false} if it is restored
+         */
+        public boolean isMaximized() {
+            return maximized;
+        }
+
+        /**
+         * @return {@code true} if the state was changed by the user using the maximize button,
+         * {@code false} if it was changed programmatically
+         */
+        public boolean isFromClient() {
+            return fromClient;
+        }
     }
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/DialogMode.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/DialogMode.java
@@ -130,6 +130,14 @@ public @interface DialogMode {
     boolean resizable() default false;
 
     /**
+     * Specifies whether the dialog window can be maximized to the whole viewport by the user.
+     * When enabled, a toggle button is shown in the dialog header next to the close button.
+     *
+     * @return {@code true} if the dialog is maximizable, otherwise {@code false}
+     */
+    boolean maximizable() default false;
+
+    /**
      * Specifies whether the dialog should close when a click is detected outside of it.
      *
      * @return {@code true} if the dialog should close on outside click, otherwise {@code false}

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/messages.properties
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/messages.properties
@@ -89,6 +89,8 @@ info.EntitySaved=%s %s saved successfully
 info.EntitySaved.short=%s saved successfully
 
 dialogWindow.closeButton.description = Close this dialog window
+dialogWindow.maximizeButton.description = Maximize this dialog window
+dialogWindow.restoreButton.description = Restore this dialog window
 
 validationFail.title = Alert
 validationFail.defaultRequiredMessage=The field is required

--- a/jmix-flowui/flowui/src/test/groovy/dialog_window/DialogWindowMaximizeTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/dialog_window/DialogWindowMaximizeTest.groovy
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dialog_window
+
+import com.vaadin.flow.component.button.Button
+import com.vaadin.flow.dom.Element
+import dialog_window.view.CustomHeaderDialogTestView
+import dialog_window.view.DialogHostTestView
+import dialog_window.view.MaximizableDialogTestView
+import dialog_window.view.PlainDialogTestView
+import io.jmix.core.Messages
+import io.jmix.flowui.DialogWindows
+import io.jmix.flowui.component.UiComponentUtils
+import io.jmix.flowui.view.DialogWindow
+import io.jmix.flowui.view.View
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import test_support.spec.FlowuiTestSpecification
+
+@SpringBootTest
+class DialogWindowMaximizeTest extends FlowuiTestSpecification {
+
+    protected static final String MAXIMIZE_BUTTON_CLASS_NAME = "jmix-dialog-window-maximize-button"
+
+    @Autowired
+    DialogWindows dialogWindows
+    @Autowired
+    Messages messages
+
+    @Override
+    void setup() {
+        registerViewBasePackages("dialog_window.view")
+    }
+
+    def "maximize button is hidden until the dialog is made maximizable"() {
+        given: "A dialog window of a non-maximizable view"
+        def dialogWindow = openDialog(PlainDialogTestView)
+
+        expect: "Its maximize button is present but hidden"
+        !dialogWindow.isMaximizable()
+        !findMaximizeButton(dialogWindow).visible
+    }
+
+    def "maximize button becomes visible when maximizable is set"() {
+        given: "An open dialog window of a non-maximizable view"
+        def dialogWindow = openDialog(PlainDialogTestView)
+
+        when: "It is made maximizable"
+        dialogWindow.setMaximizable(true)
+
+        then: "The maximize button is visible"
+        dialogWindow.isMaximizable()
+        findMaximizeButton(dialogWindow).visible
+    }
+
+    def "maximizing marks the dialog and suppresses dragging and resizing"() {
+        given: "An open maximizable dialog window"
+        def dialogWindow = openDialog(MaximizableDialogTestView)
+
+        when: "It is maximized"
+        dialogWindow.setMaximized(true)
+
+        then: "The dialog element is marked and can neither be dragged nor resized"
+        dialogWindow.isMaximized()
+
+        def dialog = UiComponentUtils.findDialog(dialogWindow.view)
+        dialog.element.hasAttribute("jmix-maximized")
+        !dialog.isResizable()
+        !dialog.isDraggable()
+    }
+
+    def "restoring removes the mark and brings dragging and resizing back"() {
+        given: "A maximized dialog window"
+        def dialogWindow = openDialog(MaximizableDialogTestView)
+        dialogWindow.setMaximized(true)
+
+        when: "It is restored"
+        dialogWindow.setMaximized(false)
+
+        then: "The mark is gone and the previous behaviour is back"
+        !dialogWindow.isMaximized()
+
+        def dialog = UiComponentUtils.findDialog(dialogWindow.view)
+        !dialog.element.hasAttribute("jmix-maximized")
+        dialog.isResizable()
+        dialog.isDraggable()
+    }
+
+    def "resizable changed while maximized is applied on restore"() {
+        given: "A maximized dialog window"
+        def dialogWindow = openDialog(MaximizableDialogTestView)
+        dialogWindow.setMaximized(true)
+
+        when: "Resizing is turned off while the dialog is maximized"
+        dialogWindow.setResizable(false)
+
+        then: "The configured value is reported and the dialog stays non-resizable"
+        !dialogWindow.isResizable()
+        !UiComponentUtils.findDialog(dialogWindow.view).isResizable()
+
+        when: "The dialog is restored"
+        dialogWindow.setMaximized(false)
+
+        then: "The value configured while maximized wins"
+        !dialogWindow.isResizable()
+        !UiComponentUtils.findDialog(dialogWindow.view).isResizable()
+    }
+
+    def "maximizing does not touch the dialog geometry"() {
+        given: "An open maximizable dialog window that was resized by the user"
+        def dialogWindow = openDialog(MaximizableDialogTestView)
+
+        def dialog = UiComponentUtils.findDialog(dialogWindow.view)
+        dialog.setWidth("42em")
+        dialog.setHeight("13em")
+        dialog.setTop("11px")
+        dialog.setLeft("17px")
+
+        when: "It is maximized and restored"
+        dialogWindow.setMaximized(true)
+        dialogWindow.setMaximized(false)
+
+        then: "Size and position are untouched"
+        dialog.width == "42em"
+        dialog.height == "13em"
+        dialog.top == "11px"
+        dialog.left == "17px"
+    }
+
+    def "clicking the maximize button toggles the state and notifies the listener"() {
+        given: "An open maximizable dialog window with a listener"
+        def dialogWindow = openDialog(MaximizableDialogTestView)
+
+        def events = []
+        dialogWindow.addMaximizedChangeListener { event -> events.add(event) }
+
+        when: "The maximize button is clicked"
+        findMaximizeButton(dialogWindow).click()
+
+        then: "The dialog is maximized and the event reports a client-side change"
+        dialogWindow.isMaximized()
+        events.size() == 1
+        events[0].isMaximized()
+        events[0].isFromClient()
+        events[0].source.is(dialogWindow)
+
+        when: "The button is clicked again"
+        findMaximizeButton(dialogWindow).click()
+
+        then: "The dialog is restored and the second event is fired"
+        !dialogWindow.isMaximized()
+        events.size() == 2
+        !events[1].isMaximized()
+    }
+
+    def "programmatic change reports fromClient false"() {
+        given: "An open maximizable dialog window with a listener"
+        def dialogWindow = openDialog(MaximizableDialogTestView)
+
+        def events = []
+        dialogWindow.addMaximizedChangeListener { event -> events.add(event) }
+
+        when: "It is maximized programmatically"
+        dialogWindow.setMaximized(true)
+
+        then: "The event is not marked as client-side"
+        events.size() == 1
+        !events[0].isFromClient()
+    }
+
+    def "maximized change event exposes the dialog window and its view"() {
+        given: "An open maximizable dialog window with a listener"
+        def dialogWindow = openDialog(MaximizableDialogTestView)
+
+        def events = []
+        dialogWindow.addMaximizedChangeListener { event -> events.add(event) }
+
+        when: "It is maximized"
+        dialogWindow.setMaximized(true)
+
+        then: "The event points to the dialog window and to the view shown in it"
+        events.size() == 1
+        events[0].getSource().is(dialogWindow)
+        events[0].getView().is(dialogWindow.view)
+        events[0].getView() instanceof MaximizableDialogTestView
+    }
+
+    def "listener is not notified when the state does not change"() {
+        given: "An open maximizable dialog window with a listener"
+        def dialogWindow = openDialog(MaximizableDialogTestView)
+
+        def events = []
+        dialogWindow.addMaximizedChangeListener { event -> events.add(event) }
+
+        when: "The current state is set again"
+        dialogWindow.setMaximized(false)
+
+        then: "No event is fired"
+        events.isEmpty()
+    }
+
+    def "maximizable is taken from the DialogMode annotation"() {
+        when: "A view annotated as maximizable is opened in a dialog"
+        def dialogWindow = openDialog(MaximizableDialogTestView)
+
+        then: "The maximize button is visible without any extra call"
+        dialogWindow.isMaximizable()
+        findMaximizeButton(dialogWindow).visible
+    }
+
+    def "maximize button icon and description reflect the state"() {
+        given: "An open maximizable dialog window"
+        def dialogWindow = openDialog(MaximizableDialogTestView)
+        def button = findMaximizeButton(dialogWindow)
+
+        expect: "The button offers to maximize the dialog"
+        button.element.getProperty("title") == messages.getMessage("dialogWindow.maximizeButton.description")
+        button.icon.iconClassNames.any { it == "jmix-font-icon-expand" }
+
+        when: "The dialog is maximized"
+        dialogWindow.setMaximized(true)
+
+        then: "The button offers to restore the dialog"
+        button.element.getProperty("title") == messages.getMessage("dialogWindow.restoreButton.description")
+        button.icon.iconClassNames.any { it == "jmix-font-icon-compress" }
+    }
+
+    def "components added via configureDialogWindowHeader stay in the header before the buttons"() {
+        when: "A view that contributes a header component is opened as a dialog"
+        def dialogWindow = openDialog(CustomHeaderDialogTestView)
+
+        then: "The contributed component is in the header content"
+        def dialog = UiComponentUtils.findDialog(dialogWindow.view)
+        def headerWrapper = findByClassName(dialog.header.element, "jmix-dialog-window-header-wrapper").get()
+        def headerContent = findByClassName(headerWrapper, "jmix-dialog-window-header-content").get()
+
+        headerContent.children
+                .anyMatch { Element child -> child.getAttribute("id") == CustomHeaderDialogTestView.CUSTOM_HEADER_BUTTON_ID }
+
+        and: "The header keeps the order: contributed content, maximize button, close button"
+        def wrapperClasses = headerWrapper.children
+                .map { Element child -> child.classList.toList() }
+                .toList()
+
+        wrapperClasses.size() == 3
+        wrapperClasses[0].contains("jmix-dialog-window-header-content")
+        wrapperClasses[1].contains("jmix-dialog-window-maximize-button")
+        wrapperClasses[2].contains("jmix-dialog-window-close-button")
+
+        and: "Both header buttons are visible"
+        findMaximizeButton(dialogWindow).visible
+    }
+
+    protected <V extends View<?>> DialogWindow<V> openDialog(Class<V> viewClass) {
+        def origin = navigateToView(DialogHostTestView)
+        def dialogWindow = dialogWindows.view(origin, viewClass).build()
+        dialogWindow.open()
+        return dialogWindow
+    }
+
+    protected Button findMaximizeButton(DialogWindow<?> dialogWindow) {
+        def dialog = UiComponentUtils.findDialog(dialogWindow.view)
+        def button = findByClassName(dialog.header.element, MAXIMIZE_BUTTON_CLASS_NAME)
+                .flatMap { Element element -> element.component }
+                .orElse(null)
+
+        assert button instanceof Button
+        return (Button) button
+    }
+
+    protected Optional<Element> findByClassName(Element root, String className) {
+        if (root.classList.contains(className)) {
+            return Optional.of(root)
+        }
+
+        return root.children
+                .map { Element child -> findByClassName(child, className) }
+                .filter { Optional<Element> found -> found.isPresent() }
+                .findFirst()
+                .orElse(Optional.empty())
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/dialog_window/view/CustomHeaderDialogTestView.java
+++ b/jmix-flowui/flowui/src/test/groovy/dialog_window/view/CustomHeaderDialogTestView.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dialog_window.view;
+
+import io.jmix.flowui.kit.component.button.JmixButton;
+import io.jmix.flowui.view.DialogMode;
+import io.jmix.flowui.view.DialogWindowHeader;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewController;
+
+@ViewController("CustomHeaderDialogTestView")
+@DialogMode(width = "30em", height = "20em", resizable = true, draggable = true, maximizable = true)
+public class CustomHeaderDialogTestView extends StandardView {
+
+    public static final String CUSTOM_HEADER_BUTTON_ID = "customHeaderButton";
+
+    @Override
+    protected void configureDialogWindowHeader(DialogWindowHeader header) {
+        JmixButton button = new JmixButton();
+        button.setText("Custom");
+        button.setId(CUSTOM_HEADER_BUTTON_ID);
+
+        header.add(button);
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/dialog_window/view/DialogHostTestView.java
+++ b/jmix-flowui/flowui/src/test/groovy/dialog_window/view/DialogHostTestView.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dialog_window.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewController;
+
+@Route("DialogHostTestView")
+@ViewController("DialogHostTestView")
+public class DialogHostTestView extends StandardView {
+}

--- a/jmix-flowui/flowui/src/test/groovy/dialog_window/view/MaximizableDialogTestView.java
+++ b/jmix-flowui/flowui/src/test/groovy/dialog_window/view/MaximizableDialogTestView.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dialog_window.view;
+
+import io.jmix.flowui.view.DialogMode;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewController;
+
+@ViewController("MaximizableDialogTestView")
+@DialogMode(width = "30em", height = "20em", resizable = true, maximizable = true)
+public class MaximizableDialogTestView extends StandardView {
+}

--- a/jmix-flowui/flowui/src/test/groovy/dialog_window/view/PlainDialogTestView.java
+++ b/jmix-flowui/flowui/src/test/groovy/dialog_window/view/PlainDialogTestView.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dialog_window.view;
+
+import io.jmix.flowui.view.DialogMode;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewController;
+
+@ViewController("PlainDialogTestView")
+@DialogMode(width = "30em", height = "20em", resizable = true)
+public class PlainDialogTestView extends StandardView {
+}

--- a/jmix-translations/content/io/jmix/flowui/messages.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages.properties
@@ -89,6 +89,8 @@ info.EntitySaved=%s %s saved successfully
 info.EntitySaved.short=%s saved successfully
 
 dialogWindow.closeButton.description = Close this dialog window
+dialogWindow.maximizeButton.description = Maximize this dialog window
+dialogWindow.restoreButton.description = Restore this dialog window
 
 validationFail.title = Alert
 validationFail.defaultRequiredMessage=The field is required

--- a/jmix-translations/content/io/jmix/flowui/messages_ru.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages_ru.properties
@@ -89,6 +89,8 @@ info.EntitySaved=Запись '%s %s' успешно сохранена
 info.EntitySaved.short=Запись '%s' успешно сохранена
 
 dialogWindow.closeButton.description = Закрыть диалог
+dialogWindow.maximizeButton.description = Развернуть диалог
+dialogWindow.restoreButton.description = Восстановить размер диалога
 
 validationFail.title = Внимание
 validationFail.defaultRequiredMessage=Поле является обязательным


### PR DESCRIPTION
### Summary

A View opened in a `DialogWindow` can now be maximized to the whole viewport and restored back, via a toggle button in the dialog header or from code. The feature is opt-in and inert for dialogs that don't enable it.

### What was done

- Added the `maximizable` attribute to `@DialogMode` (module `flowui`), `false` by default. When enabled, a toggle button appears in the dialog header next to the close button.
- Added the maximize API to `AbstractDialogWindow`: `isMaximizable()` / `setMaximizable(boolean)`, `isMaximized()` / `setMaximized(boolean)`, and `addMaximizedChangeListener(Consumer<MaximizedChangeEvent<V>>)`. The event reports `isMaximized()`, `isFromClient()`, the dialog window and the view shown in it.
- While a dialog is maximized, dragging and resizing are suppressed. Values passed to `setDraggable(...)` / `setResizable(...)` in this state are stored and applied when the dialog is restored, and the getters report the configured value.
- Maximizing no longer touches the dialog geometry on the server: the maximized layout is applied by the theme, driven by the `jmix-maximized` attribute set on the dialog element.

### How it works

`setMaximized(true)` marks the dialog element with `jmix-maximized` and turns off dragging and resizing, remembering their previous values. The themes (`jmix-aura`, `jmix-lumo`) stretch the dialog overlay over the viewport for that attribute, overriding the inline geometry Vaadin keeps on the overlay when a dialog is dragged or resized. Because width, height and position are never read or rewritten on the server, restoring removes the attribute and the dialog returns exactly to the size and position the user left it in — including a dialog that was dragged and resized first. Clicking the header button toggles the same state and fires `MaximizedChangeEvent` with `fromClient = true`; the button icon and description switch between "maximize" and "restore".

Components contributed through `View#configureDialogWindowHeader` keep their place: they stay in the header content, before the maximize and close buttons.

### How to use

Declaratively:

```java
@DialogMode(width = "50em", height = "40em", resizable = true, maximizable = true)
public class OrderDetailView extends StandardDetailView<Order> {
}
```

Programmatically, including opening a dialog already maximized:
```java
DialogWindow<OrderDetailView> dialogWindow = dialogWindows.view(this, OrderDetailView.class).build();
dialogWindow.setMaximizable(true);
dialogWindow.setMaximized(true);
dialogWindow.addMaximizedChangeListener(event -> log.debug("maximized: {}", event.isMaximized()));
dialogWindow.open();
```

A theme can adjust the maximized layout through the:
- `--jmix-dialog-maximized-position`
- `--jmix-dialog-maximized-inset`
- `--jmix-dialog-maximized-width`
- `--jmix-dialog-maximized-height`

### Compatibility

Opt-in; existing applications are unaffected. The header of every dialog now contains one extra button element, hidden unless maximizable is enabled — worth knowing for tests that assert on the dialog header DOM.