### PR TITLE
GenericFilter: a condition restored from the URL is duplicated in the data loader and freezes its value

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
@@ -530,6 +530,11 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
         propertyFilter.setOperationEditable(true);
 
         propertyFilter.setParameterName(PropertyConditionUtils.generateParameterName(property));
+        // The component is a throwaway carrier of the URL value: either the value is copied onto a
+        // condition the configuration already owns, or the configuration's root group takes over its
+        // condition. In both cases its own contribution to the data loader condition would be left
+        // behind, so suppress it as AbstractFilterComponentConverter does.
+        propertyFilter.setConditionModificationDelegated(true);
         propertyFilter.setDataLoader(dataLoader);
 
         propertyFilter.setValueComponent(generatePropertyFilterValueComponent(propertyFilter));

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/facet/urlqueryparameters/GenericFilterUrlQueryParametersBinder.java
@@ -530,10 +530,9 @@ public class GenericFilterUrlQueryParametersBinder extends AbstractUrlQueryParam
         propertyFilter.setOperationEditable(true);
 
         propertyFilter.setParameterName(PropertyConditionUtils.generateParameterName(property));
-        // The component is a throwaway carrier of the URL value: either the value is copied onto a
-        // condition the configuration already owns, or the configuration's root group takes over its
-        // condition. In both cases its own contribution to the data loader condition would be left
-        // behind, so suppress it as AbstractFilterComponentConverter does.
+        // A throwaway carrier of the URL value: whether matched onto a configuration condition, adopted
+        // by the root group, or rejected, the component itself is discarded, so it must never contribute
+        // to the data loader condition on its own (as AbstractFilterComponentConverter / GroupFilter.add).
         propertyFilter.setConditionModificationDelegated(true);
         propertyFilter.setDataLoader(dataLoader);
 

--- a/jmix-flowui/flowui/src/test/groovy/component/genericfilter/TestFilterConditions.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/genericfilter/TestFilterConditions.groovy
@@ -35,6 +35,16 @@ class TestFilterConditions {
         return false
     }
 
+    static List<PropertyCondition> propertyConditionsOn(Condition condition, String property) {
+        if (condition instanceof PropertyCondition) {
+            return property == condition.property ? [condition] : []
+        }
+        if (condition instanceof LogicalCondition) {
+            return condition.conditions.collectMany { propertyConditionsOn(it, property) }
+        }
+        return []
+    }
+
     static int countPropertyConditions(Condition condition) {
         if (condition instanceof PropertyCondition) {
             return 1

--- a/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterBaseLeakTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterBaseLeakTest.groovy
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package facet.url_query_parameters
+
+import com.vaadin.flow.router.QueryParameters
+import facet.url_query_parameters.view.GenericFilterBaseLeakTestView
+import facet.url_query_parameters.view.GenericFilterConfigsTestView
+import io.jmix.core.querycondition.Condition
+import io.jmix.core.querycondition.LogicalCondition
+import io.jmix.core.querycondition.PropertyCondition
+import io.jmix.flowui.component.genericfilter.Configuration
+import io.jmix.flowui.component.propertyfilter.PropertyFilter
+import io.jmix.flowui.facet.UrlQueryParametersFacet
+import io.jmix.flowui.facet.urlqueryparameters.GenericFilterUrlQueryParametersBinder
+import org.springframework.boot.test.context.SpringBootTest
+import test_support.spec.FlowuiTestSpecification
+
+/**
+ * Opening a view directly by a URL that already carries generic filter parameters (as happens when
+ * returning to a list view from a detail view) must not leave a stale copy of the URL condition in
+ * the data loader.
+ */
+@SpringBootTest
+class GenericFilterBaseLeakTest extends FlowuiTestSpecification {
+
+    @Override
+    void setup() {
+        registerViewBasePackages("facet.url_query_parameters", "io.jmix.flowui.app")
+    }
+
+    def "a URL condition matched onto a configuration baseline is not left behind in the loader"() {
+        given: "a view opened by a URL that selects a configuration and sets its condition value"
+        def screen = navigateToView(GenericFilterBaseLeakTestView)
+        def binder = getBinder(screen)
+        Configuration byName = screen.ownersFilter.getConfiguration("byName")
+
+        expect: "the filter has not touched the loader condition yet"
+        screen.ownersDl.condition == null
+
+        when:
+        binder.updateState(QueryParameters.simple([
+                (binder.configurationParam): "byName",
+                (binder.conditionParam)    : "property:name_equal_lane"
+        ]))
+
+        then: "the URL value landed on the configuration's own condition"
+        propertyFilterOn(byName, "name").value == "lane"
+
+        when: "the user changes the filter value, as if typing a new one in the field"
+        propertyFilterOn(byName, "name").setValue("mey")
+        screen.ownersFilter.apply()
+
+        then: "the loader still filters by 'name' exactly once, by the new value"
+        namePropertyConditions(screen.ownersDl.condition)*.parameterValue == ["mey"]
+    }
+
+    def "a configuration activated during init: URL value change must not accumulate loader conditions"() {
+        given: "a view whose configuration is made current during init (as a default configuration is)"
+        def screen = navigateToView(GenericFilterConfigsTestView)
+        def binder = GenericFilterReNavigationTest.getBinder(screen)
+        Configuration active = screen.ownersFilter.getConfiguration("active")
+
+        when: "the view is opened by a URL carrying that configuration and a condition value"
+        binder.updateState(QueryParameters.simple([
+                (binder.configurationParam): "active",
+                (binder.conditionParam)    : "property:name_equal_lane"
+        ]))
+
+        and: "the user changes the filter value"
+        GenericFilterReNavigationTest.propertyFilterOn(active, "name").setValue("mey")
+        screen.ownersFilter.apply()
+
+        then: "the loader filters by 'name' exactly once, by the new value"
+        namePropertyConditions(screen.ownersFilter.dataLoader.condition)*.parameterValue == ["mey"]
+    }
+
+    def "a non-logical base condition set by the application must not absorb the URL condition"() {
+        given: "a view opened by a URL with filter parameters"
+        def screen = navigateToView(GenericFilterBaseLeakTestView)
+        def binder = getBinder(screen)
+        Configuration byName = screen.ownersFilter.getConfiguration("byName")
+
+        and: "the application has its own single (non-logical) condition on the loader"
+        screen.ownersDl.condition = PropertyCondition.contains("email", "example.com")
+
+        when:
+        binder.updateState(QueryParameters.simple([
+                (binder.configurationParam): "byName",
+                (binder.conditionParam)    : "property:name_equal_lane"
+        ]))
+
+        and: "the user changes the filter value"
+        propertyFilterOn(byName, "name").setValue("mey")
+        screen.ownersFilter.apply()
+
+        then: "the loader filters by 'name' exactly once, and the application condition is kept"
+        namePropertyConditions(screen.ownersDl.condition)*.parameterValue == ["mey"]
+        allPropertyConditions(screen.ownersDl.condition).any { it.property == "email" }
+    }
+
+    def "workaround: activating the empty configuration in onInit makes the filter capture a clean base"() {
+        given: "a view opened by a URL with filter parameters"
+        def screen = navigateToView(GenericFilterBaseLeakTestView)
+        def binder = getBinder(screen)
+        Configuration byName = screen.ownersFilter.getConfiguration("byName")
+
+        when: "the application forces the base condition capture before the URL is applied"
+        screen.ownersFilter.setCurrentConfiguration(screen.ownersFilter.emptyConfiguration)
+
+        and: "the URL parameters arrive and the user then changes the filter value"
+        binder.updateState(QueryParameters.simple([
+                (binder.configurationParam): "byName",
+                (binder.conditionParam)    : "property:name_equal_lane"
+        ]))
+        propertyFilterOn(byName, "name").setValue("mey")
+        screen.ownersFilter.apply()
+
+        then: "the loader filters by 'name' exactly once, by the new value"
+        namePropertyConditions(screen.ownersDl.condition)*.parameterValue == ["mey"]
+
+        and: "the URL-selected configuration is still the current one"
+        screen.ownersFilter.currentConfiguration.is(byName)
+    }
+
+    // --- helpers ---
+
+    static GenericFilterUrlQueryParametersBinder getBinder(screen) {
+        UrlQueryParametersFacet facet = screen.urlQueryParameters
+        return facet.binders
+                .findAll { it instanceof GenericFilterUrlQueryParametersBinder }
+                .first() as GenericFilterUrlQueryParametersBinder
+    }
+
+    static PropertyFilter propertyFilterOn(Configuration configuration, String property) {
+        return configuration.rootLogicalFilterComponent.filterComponents.find {
+            it instanceof PropertyFilter && ((PropertyFilter) it).property == property
+        } as PropertyFilter
+    }
+
+    static List<PropertyCondition> namePropertyConditions(Condition condition) {
+        return allPropertyConditions(condition).findAll { it.property == "name" }
+    }
+
+    static List<PropertyCondition> allPropertyConditions(Condition condition) {
+        List<PropertyCondition> result = []
+        collectPropertyConditions(condition, result)
+        return result
+    }
+
+    static void collectPropertyConditions(Condition condition, List<PropertyCondition> result) {
+        if (condition instanceof LogicalCondition) {
+            condition.conditions.each { collectPropertyConditions(it, result) }
+        } else if (condition instanceof PropertyCondition) {
+            result.add(condition)
+        }
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterBaseLeakTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterBaseLeakTest.groovy
@@ -19,15 +19,15 @@ package facet.url_query_parameters
 import com.vaadin.flow.router.QueryParameters
 import facet.url_query_parameters.view.GenericFilterBaseLeakTestView
 import facet.url_query_parameters.view.GenericFilterConfigsTestView
-import io.jmix.core.querycondition.Condition
-import io.jmix.core.querycondition.LogicalCondition
 import io.jmix.core.querycondition.PropertyCondition
 import io.jmix.flowui.component.genericfilter.Configuration
-import io.jmix.flowui.component.propertyfilter.PropertyFilter
-import io.jmix.flowui.facet.UrlQueryParametersFacet
-import io.jmix.flowui.facet.urlqueryparameters.GenericFilterUrlQueryParametersBinder
 import org.springframework.boot.test.context.SpringBootTest
 import test_support.spec.FlowuiTestSpecification
+
+import static component.genericfilter.TestFilterConditions.hasPropertyConditionOn
+import static component.genericfilter.TestFilterConditions.propertyConditionsOn
+import static facet.url_query_parameters.TestGenericFilterUrlBinders.getBinder
+import static facet.url_query_parameters.TestGenericFilterUrlBinders.propertyFilterOn
 
 /**
  * Opening a view directly by a URL that already carries generic filter parameters (as happens when
@@ -65,13 +65,13 @@ class GenericFilterBaseLeakTest extends FlowuiTestSpecification {
         screen.ownersFilter.apply()
 
         then: "the loader still filters by 'name' exactly once, by the new value"
-        namePropertyConditions(screen.ownersDl.condition)*.parameterValue == ["mey"]
+        propertyConditionsOn(screen.ownersDl.condition, "name")*.parameterValue == ["mey"]
     }
 
-    def "a configuration activated during init: URL value change must not accumulate loader conditions"() {
-        given: "a view whose configuration is made current during init (as a default configuration is)"
+    def "control: a configuration made current during init never accumulated the URL condition"() {
+        given: "a view whose configuration is made current during init, so the filter has already captured its base"
         def screen = navigateToView(GenericFilterConfigsTestView)
-        def binder = GenericFilterReNavigationTest.getBinder(screen)
+        def binder = getBinder(screen)
         Configuration active = screen.ownersFilter.getConfiguration("active")
 
         when: "the view is opened by a URL carrying that configuration and a condition value"
@@ -81,11 +81,11 @@ class GenericFilterBaseLeakTest extends FlowuiTestSpecification {
         ]))
 
         and: "the user changes the filter value"
-        GenericFilterReNavigationTest.propertyFilterOn(active, "name").setValue("mey")
+        propertyFilterOn(active, "name").setValue("mey")
         screen.ownersFilter.apply()
 
         then: "the loader filters by 'name' exactly once, by the new value"
-        namePropertyConditions(screen.ownersFilter.dataLoader.condition)*.parameterValue == ["mey"]
+        propertyConditionsOn(screen.ownersFilter.dataLoader.condition, "name")*.parameterValue == ["mey"]
     }
 
     def "a non-logical base condition set by the application must not absorb the URL condition"() {
@@ -108,17 +108,17 @@ class GenericFilterBaseLeakTest extends FlowuiTestSpecification {
         screen.ownersFilter.apply()
 
         then: "the loader filters by 'name' exactly once, and the application condition is kept"
-        namePropertyConditions(screen.ownersDl.condition)*.parameterValue == ["mey"]
-        allPropertyConditions(screen.ownersDl.condition).any { it.property == "email" }
+        propertyConditionsOn(screen.ownersDl.condition, "name")*.parameterValue == ["mey"]
+        hasPropertyConditionOn(screen.ownersDl.condition, "email")
     }
 
-    def "workaround: activating the empty configuration in onInit makes the filter capture a clean base"() {
+    def "a base captured before the URL arrives is not disturbed by the URL condition"() {
         given: "a view opened by a URL with filter parameters"
         def screen = navigateToView(GenericFilterBaseLeakTestView)
         def binder = getBinder(screen)
         Configuration byName = screen.ownersFilter.getConfiguration("byName")
 
-        when: "the application forces the base condition capture before the URL is applied"
+        when: "the base condition is captured before the URL is applied"
         screen.ownersFilter.setCurrentConfiguration(screen.ownersFilter.emptyConfiguration)
 
         and: "the URL parameters arrive and the user then changes the filter value"
@@ -130,42 +130,35 @@ class GenericFilterBaseLeakTest extends FlowuiTestSpecification {
         screen.ownersFilter.apply()
 
         then: "the loader filters by 'name' exactly once, by the new value"
-        namePropertyConditions(screen.ownersDl.condition)*.parameterValue == ["mey"]
+        propertyConditionsOn(screen.ownersDl.condition, "name")*.parameterValue == ["mey"]
 
         and: "the URL-selected configuration is still the current one"
         screen.ownersFilter.currentConfiguration.is(byName)
     }
 
-    // --- helpers ---
+    def "a URL condition added to the empty configuration is applied exactly once"() {
+        given: "a view opened by a URL that carries a condition but selects no configuration"
+        def screen = navigateToView(GenericFilterBaseLeakTestView)
+        def binder = getBinder(screen)
+        Configuration empty = screen.ownersFilter.emptyConfiguration
 
-    static GenericFilterUrlQueryParametersBinder getBinder(screen) {
-        UrlQueryParametersFacet facet = screen.urlQueryParameters
-        return facet.binders
-                .findAll { it instanceof GenericFilterUrlQueryParametersBinder }
-                .first() as GenericFilterUrlQueryParametersBinder
-    }
+        expect: "the filter has not touched the loader condition yet"
+        screen.ownersDl.condition == null
 
-    static PropertyFilter propertyFilterOn(Configuration configuration, String property) {
-        return configuration.rootLogicalFilterComponent.filterComponents.find {
-            it instanceof PropertyFilter && ((PropertyFilter) it).property == property
-        } as PropertyFilter
-    }
+        when:
+        binder.updateState(QueryParameters.simple([
+                (binder.conditionParam): "property:name_equal_lane"
+        ]))
 
-    static List<PropertyCondition> namePropertyConditions(Condition condition) {
-        return allPropertyConditions(condition).findAll { it.property == "name" }
-    }
+        then: "the condition was added to the empty configuration, which became current"
+        screen.ownersFilter.currentConfiguration.is(empty)
+        propertyFilterOn(empty, "name").value == "lane"
 
-    static List<PropertyCondition> allPropertyConditions(Condition condition) {
-        List<PropertyCondition> result = []
-        collectPropertyConditions(condition, result)
-        return result
-    }
+        when: "the user changes the filter value"
+        propertyFilterOn(empty, "name").setValue("mey")
+        screen.ownersFilter.apply()
 
-    static void collectPropertyConditions(Condition condition, List<PropertyCondition> result) {
-        if (condition instanceof LogicalCondition) {
-            condition.conditions.each { collectPropertyConditions(it, result) }
-        } else if (condition instanceof PropertyCondition) {
-            result.add(condition)
-        }
+        then: "the loader filters by 'name' exactly once, by the new value"
+        propertyConditionsOn(screen.ownersDl.condition, "name")*.parameterValue == ["mey"]
     }
 }

--- a/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterReNavigationTest.groovy
@@ -25,8 +25,6 @@ import io.jmix.flowui.component.genericfilter.Configuration
 import io.jmix.flowui.component.genericfilter.configuration.RunTimeConfiguration
 import io.jmix.flowui.component.logicalfilter.GroupFilter
 import io.jmix.flowui.component.propertyfilter.PropertyFilter
-import io.jmix.flowui.facet.UrlQueryParametersFacet
-import io.jmix.flowui.facet.urlqueryparameters.GenericFilterUrlQueryParametersBinder
 import io.jmix.flowui.model.CollectionLoader
 import io.jmix.flowui.view.View
 import io.jmix.flowui.view.ViewControllerUtils
@@ -34,6 +32,9 @@ import org.springframework.boot.test.context.SpringBootTest
 import test_support.spec.FlowuiTestSpecification
 
 import java.util.concurrent.atomic.AtomicInteger
+
+import static facet.url_query_parameters.TestGenericFilterUrlBinders.getBinder
+import static facet.url_query_parameters.TestGenericFilterUrlBinders.propertyFilterOn
 
 /**
  * Verifies how a {@link io.jmix.flowui.component.genericfilter.GenericFilter} bound via the
@@ -566,13 +567,6 @@ class GenericFilterReNavigationTest extends FlowuiTestSpecification {
 
     // --- helpers ---
 
-    static GenericFilterUrlQueryParametersBinder getBinder(screen) {
-        UrlQueryParametersFacet facet = screen.urlQueryParameters
-        return facet.binders
-                .findAll { it instanceof GenericFilterUrlQueryParametersBinder }
-                .first() as GenericFilterUrlQueryParametersBinder
-    }
-
     static List currentComponents(screen) {
         return screen.ownersFilter.currentConfiguration.rootLogicalFilterComponent.filterComponents
     }
@@ -581,12 +575,6 @@ class GenericFilterReNavigationTest extends FlowuiTestSpecification {
         return configuration.rootLogicalFilterComponent.filterComponents.any {
             it instanceof PropertyFilter && ((PropertyFilter) it).property == property
         }
-    }
-
-    static PropertyFilter propertyFilterOn(Configuration configuration, String property) {
-        return configuration.rootLogicalFilterComponent.filterComponents.find {
-            it instanceof PropertyFilter && ((PropertyFilter) it).property == property
-        } as PropertyFilter
     }
 
     static List<String> nestedProperties(GroupFilter group) {

--- a/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterUrlQueryParametersBinderTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/GenericFilterUrlQueryParametersBinderTest.groovy
@@ -19,10 +19,11 @@ package facet.url_query_parameters
 import com.vaadin.flow.router.QueryParameters
 import facet.url_query_parameters.view.GenericFilterUrlQueryParamsTestView
 import io.jmix.flowui.component.propertyfilter.PropertyFilter
-import io.jmix.flowui.facet.UrlQueryParametersFacet
 import io.jmix.flowui.facet.urlqueryparameters.GenericFilterUrlQueryParametersBinder
 import org.springframework.boot.test.context.SpringBootTest
 import test_support.spec.FlowuiTestSpecification
+
+import static facet.url_query_parameters.TestGenericFilterUrlBinders.getBinder
 
 /**
  * Sanity check that {@link GenericFilterUrlQueryParametersBinder} does not suffer from the
@@ -81,10 +82,4 @@ class GenericFilterUrlQueryParametersBinderTest extends FlowuiTestSpecification 
         return components.first() as PropertyFilter<?>
     }
 
-    private GenericFilterUrlQueryParametersBinder getBinder(GenericFilterUrlQueryParamsTestView screen) {
-        UrlQueryParametersFacet facet = screen.urlQueryParameters
-        return facet.binders
-                .findAll { it instanceof GenericFilterUrlQueryParametersBinder }
-                .first() as GenericFilterUrlQueryParametersBinder
-    }
 }

--- a/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/TestGenericFilterUrlBinders.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/facet/url_query_parameters/TestGenericFilterUrlBinders.groovy
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package facet.url_query_parameters
+
+import io.jmix.flowui.component.genericfilter.Configuration
+import io.jmix.flowui.component.propertyfilter.PropertyFilter
+import io.jmix.flowui.facet.UrlQueryParametersFacet
+import io.jmix.flowui.facet.urlqueryparameters.GenericFilterUrlQueryParametersBinder
+
+/**
+ * Shared lookups for specs driving a {@link GenericFilterUrlQueryParametersBinder} directly, the way
+ * the {@code urlQueryParameters} facet does on {@code beforeEnter}.
+ */
+class TestGenericFilterUrlBinders {
+
+    static GenericFilterUrlQueryParametersBinder getBinder(screen) {
+        UrlQueryParametersFacet facet = screen.urlQueryParameters
+        return facet.binders
+                .findAll { it instanceof GenericFilterUrlQueryParametersBinder }
+                .first() as GenericFilterUrlQueryParametersBinder
+    }
+
+    static PropertyFilter propertyFilterOn(Configuration configuration, String property) {
+        return configuration.rootLogicalFilterComponent.filterComponents.find {
+            it instanceof PropertyFilter && ((PropertyFilter) it).property == property
+        } as PropertyFilter
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/facet/url_query_parameters/view/GenericFilterBaseLeakTestView.java
+++ b/jmix-flowui/flowui/src/test/java/facet/url_query_parameters/view/GenericFilterBaseLeakTestView.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package facet.url_query_parameters.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.component.genericfilter.GenericFilter;
+import io.jmix.flowui.facet.UrlQueryParametersFacet;
+import io.jmix.flowui.model.CollectionLoader;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import test_support.entity.petclinic.Owner;
+
+/**
+ * A view whose filter carries a non-default design-time configuration, so no configuration is
+ * activated during initialization. Reproduces opening the view directly by a URL that already
+ * carries filter parameters (e.g. returning from a detail view), when the filter has not yet
+ * captured its base data loader condition.
+ */
+@Route("GenericFilterBaseLeakTestView")
+@ViewController
+@ViewDescriptor("generic-filter-base-leak-test-view.xml")
+public class GenericFilterBaseLeakTestView extends StandardView {
+
+    @ViewComponent
+    public GenericFilter ownersFilter;
+
+    @ViewComponent
+    public CollectionLoader<Owner> ownersDl;
+
+    @ViewComponent("urlQueryParameters")
+    public UrlQueryParametersFacet urlQueryParameters;
+}

--- a/jmix-flowui/flowui/src/test/resources/facet/url_query_parameters/view/generic-filter-base-leak-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/facet/url_query_parameters/view/generic-filter-base-leak-test-view.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <collection id="ownersDc" class="test_support.entity.petclinic.Owner">
+            <fetchPlan extends="_base"/>
+            <loader id="ownersDl">
+                <query><![CDATA[select e from pc_Owner e]]></query>
+            </loader>
+        </collection>
+    </data>
+    <facets>
+        <urlQueryParameters id="urlQueryParameters">
+            <genericFilter component="ownersFilter"/>
+        </urlQueryParameters>
+    </facets>
+    <layout>
+        <genericFilter id="ownersFilter" dataLoader="ownersDl">
+            <configurations>
+                <!-- Not default: nothing activates the filter at init, so the filter has not
+                     captured its base data loader condition when the URL parameters arrive. -->
+                <configuration id="byName" name="By name">
+                    <propertyFilter property="name" operation="EQUAL"/>
+                </configuration>
+            </configurations>
+        </genericFilter>
+    </layout>
+</view>


### PR DESCRIPTION
See #5586

The throwaway `PropertyFilter` that `GenericFilterUrlQueryParametersBinder.parsePropertyCondition` creates per URL parameter wrote its own condition into the data loader on `setDataLoader` and was then discarded. Since the lazy base capture (#5425 / #5487) that stray condition is captured into the filter's base condition and re-applied on every load with the URL value frozen. The component is now marked condition-modification-delegated before the loader is assigned, the same way `AbstractFilterComponentConverter` and `GroupFilter.add` already do.

Tests (`GenericFilterBaseLeakTest`, flowui): URL condition matched onto a design-time configuration, condition-only URL branch, a non-logical application base condition; plus a control case (configuration current since init) and a guard for the lazy base capture. Three of the five fail without the fix. Shared helpers `TestGenericFilterUrlBinders` / `TestFilterConditions.propertyConditionsOn` replace copies in three specs.

QA:
- List view with a saved personal default filter configuration: filter, open a record, return with Cancel, change the filter value — the list must follow the new value, not become empty.
- Same with a design-time configuration that is not default, selected by hand before filtering.
- A filter configuration that is default for all users (control): unchanged behaviour.
- Deep link with `genericFilter_*` parameters and no configuration current: the condition is applied once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
