### PR TITLE
LocalDateTime serialization/deserialization error in REST DataStore

### DIFF
--- a/jmix-core/core/src/main/java/io/jmix/core/impl/serialization/EntitySerializationImpl.java
+++ b/jmix-core/core/src/main/java/io/jmix/core/impl/serialization/EntitySerializationImpl.java
@@ -45,12 +45,23 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.util.*;
 
 @Component("core_EntitySerialization")
 public class EntitySerializationImpl implements EntitySerialization {
 
     private static final Logger log = LoggerFactory.getLogger(EntitySerializationImpl.class);
+
+    /**
+     * Types which are serialized and deserialized using datatypes because Gson cannot handle them by itself.
+     */
+    protected static final List<Class<?>> DATATYPE_ADAPTER_CLASSES = List.of(
+            LocalDate.class, LocalDateTime.class, LocalTime.class, OffsetDateTime.class, OffsetTime.class);
 
     @Autowired
     protected MetadataTools metadataTools;
@@ -154,8 +165,8 @@ public class EntitySerializationImpl implements EntitySerialization {
         }
         gsonBuilder
                 .registerTypeHierarchyAdapter(Entity.class, new EntitySerializer(fetchPlan, options))
-                .registerTypeHierarchyAdapter(Date.class, new DateSerializer())
-                .create();
+                .registerTypeHierarchyAdapter(Date.class, new DateSerializer());
+        registerDatatypeAdaptersForSerialization(gsonBuilder);
         if (ArrayUtils.contains(options, EntitySerializationOption.SERIALIZE_NULLS)) {
             gsonBuilder.serializeNulls();
         }
@@ -163,10 +174,31 @@ public class EntitySerializationImpl implements EntitySerialization {
     }
 
     protected Gson createGsonForDeserialization(@Nullable MetaClass metaClass, EntitySerializationOption... options) {
-        return new GsonBuilder()
+        GsonBuilder gsonBuilder = new GsonBuilder()
                 .registerTypeHierarchyAdapter(Entity.class, new EntityDeserializer(metaClass, options))
-                .registerTypeHierarchyAdapter(Date.class, new DateDeserializer())
-                .create();
+                .registerTypeHierarchyAdapter(Date.class, new DateDeserializer());
+        registerDatatypeAdaptersForDeserialization(gsonBuilder);
+        return gsonBuilder.create();
+    }
+
+    /**
+     * Registers serializers for the types that Gson cannot handle by itself, e.g. the {@code java.time} types.
+     * The values are written using the corresponding datatypes.
+     */
+    protected void registerDatatypeAdaptersForSerialization(GsonBuilder gsonBuilder) {
+        for (Class<?> javaClass : DATATYPE_ADAPTER_CLASSES) {
+            gsonBuilder.registerTypeAdapter(javaClass, new DatatypeSerializer<>(javaClass));
+        }
+    }
+
+    /**
+     * Registers deserializers for the types that Gson cannot handle by itself, e.g. the {@code java.time} types.
+     * The values are read using the corresponding datatypes.
+     */
+    protected void registerDatatypeAdaptersForDeserialization(GsonBuilder gsonBuilder) {
+        for (Class<?> javaClass : DATATYPE_ADAPTER_CLASSES) {
+            gsonBuilder.registerTypeAdapter(javaClass, new DatatypeDeserializer<>(javaClass));
+        }
     }
 
     @Nullable
@@ -757,6 +789,39 @@ public class EntitySerializationImpl implements EntitySerialization {
                 return Strings.isNullOrEmpty(formattedDate) ? null : dateDatatype.parse(formattedDate);
             } catch (ParseException e) {
                 throw new EntitySerializationException("Cannot parse date " + formattedDate);
+            }
+        }
+    }
+
+    protected class DatatypeSerializer<T> implements JsonSerializer<T> {
+
+        private final Datatype<T> datatype;
+
+        public DatatypeSerializer(Class<T> javaClass) {
+            datatype = datatypeRegistry.get(javaClass);
+        }
+
+        @Override
+        public JsonElement serialize(T src, Type typeOfSrc, JsonSerializationContext context) {
+            return new JsonPrimitive(datatype.format(src));
+        }
+    }
+
+    protected class DatatypeDeserializer<T> implements JsonDeserializer<T> {
+
+        private final Datatype<T> datatype;
+
+        public DatatypeDeserializer(Class<T> javaClass) {
+            datatype = datatypeRegistry.get(javaClass);
+        }
+
+        @Override
+        public T deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            String formattedValue = json.getAsJsonPrimitive().getAsString();
+            try {
+                return Strings.isNullOrEmpty(formattedValue) ? null : datatype.parse(formattedValue);
+            } catch (ParseException e) {
+                throw new EntitySerializationException("Cannot parse value " + formattedValue);
             }
         }
     }

--- a/jmix-core/core/src/test/groovy/entity_serialization/PojoSerializationTest.groovy
+++ b/jmix-core/core/src/test/groovy/entity_serialization/PojoSerializationTest.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2025 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entity_serialization
+
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import io.jmix.core.CoreConfiguration
+import io.jmix.core.EntitySerialization
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+import test_support.base.TestBaseConfiguration
+
+import java.text.SimpleDateFormat
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+
+@ContextConfiguration(classes = [CoreConfiguration, TestBaseConfiguration])
+class PojoSerializationTest extends Specification {
+
+    @Autowired
+    EntitySerialization entitySerialization
+
+    def "POJO with date and time attributes"() {
+
+        def pojo = new PojoWithDates(
+                date: new SimpleDateFormat('yyyy-MM-dd HH:mm').parse('2025-04-26 18:44'),
+                localDate: LocalDate.parse('2025-04-26'),
+                localDateTime: LocalDateTime.parse('2025-04-26T18:44'),
+                localTime: LocalTime.parse('18:44'),
+                offsetDateTime: OffsetDateTime.parse('2025-04-26T18:44+04:00'),
+                offsetTime: OffsetTime.parse('18:44+04:00'))
+
+        when:
+
+        def json = entitySerialization.objectToJson(pojo)
+
+        then:
+
+        Map jsonFields = new Gson().fromJson(json, new TypeToken<Map<String, Object>>() {}.getType())
+        jsonFields['localDate'] == '2025-04-26'
+        jsonFields['localDateTime'] == '2025-04-26T18:44:00'
+        jsonFields['localTime'] == '18:44:00'
+        jsonFields['offsetDateTime'] == '2025-04-26T18:44:00+04:00'
+        jsonFields['offsetTime'] == '18:44:00+04:00'
+
+        when:
+
+        def restoredPojo = entitySerialization.objectFromJson(json, PojoWithDates)
+
+        then:
+
+        restoredPojo.date == pojo.date
+        restoredPojo.localDate == pojo.localDate
+        restoredPojo.localDateTime == pojo.localDateTime
+        restoredPojo.localTime == pojo.localTime
+        restoredPojo.offsetDateTime == pojo.offsetDateTime
+        restoredPojo.offsetTime == pojo.offsetTime
+    }
+
+    static class PojoWithDates {
+        Date date
+        LocalDate localDate
+        LocalDateTime localDateTime
+        LocalTime localTime
+        OffsetDateTime offsetDateTime
+        OffsetTime offsetTime
+    }
+}

--- a/jmix-restds/restds/src/test/java/remote_service/RemoteServiceTest.java
+++ b/jmix-restds/restds/src/test/java/remote_service/RemoteServiceTest.java
@@ -34,8 +34,11 @@ import test_support.service.SampleService;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -210,6 +213,27 @@ public class RemoteServiceTest extends BaseRestDsIntegrationTest {
         assertThat(resultOffsetDateTime).isEqualTo(offsetDateTime);
 
         // ZonedDateTime is not supported by entities and REST
+    }
+
+    @Test
+    void testDatesInPojo() throws Exception {
+        SampleService.SamplePojoWithDates pojo = new SampleService.SamplePojoWithDates();
+        pojo.setDate(new SimpleDateFormat("yyyy-MM-dd HH:mm").parse("2025-04-26 18:44"));
+        pojo.setLocalDate(LocalDate.parse("2025-04-26"));
+        pojo.setLocalDateTime(LocalDateTime.parse("2025-04-26T18:44"));
+        pojo.setLocalTime(LocalTime.parse("18:44"));
+        pojo.setOffsetDateTime(OffsetDateTime.parse("2025-04-26T18:44+04:00"));
+        pojo.setOffsetTime(OffsetTime.parse("18:44+04:00"));
+
+        SampleService.SamplePojoWithDates resultPojo = sampleService.pojoWithDatesMethod(pojo);
+
+        assertThat(resultPojo).isNotNull();
+        assertThat(resultPojo.getDate()).isEqualTo(pojo.getDate());
+        assertThat(resultPojo.getLocalDate()).isEqualTo(pojo.getLocalDate());
+        assertThat(resultPojo.getLocalDateTime()).isEqualTo(pojo.getLocalDateTime());
+        assertThat(resultPojo.getLocalTime()).isEqualTo(pojo.getLocalTime());
+        assertThat(resultPojo.getOffsetDateTime()).isEqualTo(pojo.getOffsetDateTime());
+        assertThat(resultPojo.getOffsetTime()).isEqualTo(pojo.getOffsetTime());
     }
 
     @Test

--- a/jmix-restds/restds/src/test/java/test_support/service/SampleService.java
+++ b/jmix-restds/restds/src/test/java/test_support/service/SampleService.java
@@ -25,8 +25,11 @@ import test_support.entity.CustomerContact;
 import test_support.entity.Employee;
 
 import java.net.URI;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.util.*;
 
 @NullMarked
@@ -86,6 +89,8 @@ public interface SampleService {
     SamplePojo pojoMethod(SamplePojo param);
 
     SamplePojoWithEntity pojoWithEntityMethod(SamplePojoWithEntity param);
+
+    SamplePojoWithDates pojoWithDatesMethod(SamplePojoWithDates param);
 
     SampleRecord recordMethod(SampleRecord param);
 
@@ -167,6 +172,63 @@ public interface SampleService {
         @Override
         public int hashCode() {
             return Objects.hash(getName(), getCustomer());
+        }
+    }
+
+    class SamplePojoWithDates {
+        private Date date;
+        private LocalDate localDate;
+        private LocalDateTime localDateTime;
+        private LocalTime localTime;
+        private OffsetDateTime offsetDateTime;
+        private OffsetTime offsetTime;
+
+        public Date getDate() {
+            return date;
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+
+        public LocalDate getLocalDate() {
+            return localDate;
+        }
+
+        public void setLocalDate(LocalDate localDate) {
+            this.localDate = localDate;
+        }
+
+        public LocalDateTime getLocalDateTime() {
+            return localDateTime;
+        }
+
+        public void setLocalDateTime(LocalDateTime localDateTime) {
+            this.localDateTime = localDateTime;
+        }
+
+        public LocalTime getLocalTime() {
+            return localTime;
+        }
+
+        public void setLocalTime(LocalTime localTime) {
+            this.localTime = localTime;
+        }
+
+        public OffsetDateTime getOffsetDateTime() {
+            return offsetDateTime;
+        }
+
+        public void setOffsetDateTime(OffsetDateTime offsetDateTime) {
+            this.offsetDateTime = offsetDateTime;
+        }
+
+        public OffsetTime getOffsetTime() {
+            return offsetTime;
+        }
+
+        public void setOffsetTime(OffsetTime offsetTime) {
+            this.offsetTime = offsetTime;
         }
     }
 

--- a/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/SampleService.java
+++ b/jmix-restds/sample-rest-service/src/main/java/io/jmix/samples/restservice/app/SampleService.java
@@ -26,8 +26,11 @@ import io.jmix.samples.restservice.entity.CustomerContact;
 import io.jmix.samples.restservice.entity.Employee;
 
 import java.net.URI;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.OffsetTime;
 import java.util.*;
 
 @RestService("SampleService")
@@ -188,6 +191,11 @@ public class SampleService {
     }
 
     @RestMethod
+    public SamplePojoWithDates pojoWithDatesMethod(SamplePojoWithDates param) {
+        return param;
+    }
+
+    @RestMethod
     public SampleRecord recordMethod(SampleRecord param) {
         return param;
     }
@@ -234,6 +242,63 @@ public class SampleService {
     }
 
     public record MultipleParamsPojo(int number, String str, Customer entity, SamplePojo pojo) {}
+
+    public static class SamplePojoWithDates {
+        private Date date;
+        private LocalDate localDate;
+        private LocalDateTime localDateTime;
+        private LocalTime localTime;
+        private OffsetDateTime offsetDateTime;
+        private OffsetTime offsetTime;
+
+        public Date getDate() {
+            return date;
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+
+        public LocalDate getLocalDate() {
+            return localDate;
+        }
+
+        public void setLocalDate(LocalDate localDate) {
+            this.localDate = localDate;
+        }
+
+        public LocalDateTime getLocalDateTime() {
+            return localDateTime;
+        }
+
+        public void setLocalDateTime(LocalDateTime localDateTime) {
+            this.localDateTime = localDateTime;
+        }
+
+        public LocalTime getLocalTime() {
+            return localTime;
+        }
+
+        public void setLocalTime(LocalTime localTime) {
+            this.localTime = localTime;
+        }
+
+        public OffsetDateTime getOffsetDateTime() {
+            return offsetDateTime;
+        }
+
+        public void setOffsetDateTime(OffsetDateTime offsetDateTime) {
+            this.offsetDateTime = offsetDateTime;
+        }
+
+        public OffsetTime getOffsetTime() {
+            return offsetTime;
+        }
+
+        public void setOffsetTime(OffsetTime offsetTime) {
+            this.offsetTime = offsetTime;
+        }
+    }
 
     public static class SamplePojo {
         private String name;


### PR DESCRIPTION
Fixes #5609

## Problem

Passing a POJO (not an entity) with a `LocalDateTime` field to a `@RemoteService` method fails with `InaccessibleObjectException`, both when the client serializes the parameter and when the server deserializes it.

`EntitySerializationImpl` registers Gson type adapters only for `Entity` and `java.util.Date`. Everything else in a POJO falls back to Gson's reflective adapter, which cannot access `java.time` fields on JDK 17+ because `java.base` does not open that package.

Entity attributes were never affected — `EntitySerializer` writes them through datatypes.

## Solution

Added generic `DatatypeSerializer` / `DatatypeDeserializer` adapters to `EntitySerializationImpl` that format and parse values using the registered Jmix datatype, and registered them for `LocalDate`, `LocalDateTime`, `LocalTime`, `OffsetDateTime` and `OffsetTime` in both `createGsonForSerialization()` and `createGsonForDeserialization()`.

## Tests

- `PojoSerializationTest` in `jmix-core` — round-trips a POJO with all six date/time types and checks the JSON format.
- `RemoteServiceTest.testDatesInPojo()` in `jmix-restds` — full HTTP round trip through `SamplePojoWithDates`, added to both the client service interface and the `sample-rest-service` implementation.