### PR TITLE
Entity Inspector loses unsaved changes of a composition child when its edit dialog is reopened

### DIFF
--- a/jmix-datatools/datatools-flowui/datatools-flowui.gradle
+++ b/jmix-datatools/datatools-flowui/datatools-flowui.gradle
@@ -43,11 +43,12 @@ dependencies {
     testImplementation 'org.liquibase:liquibase-core'
     testImplementation 'org.springframework:spring-orm'
     testImplementation project(':eclipselink')
+    testImplementation project(':flowui-test-assist')
+    testImplementation project(':framework-test-support')
     testImplementation project(':security')
     testImplementation project(':security-data')
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
     testRuntimeOnly 'org.hsqldb:hsqldb'
-    testRuntimeOnly 'org.slf4j:slf4j-simple'
 }

--- a/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/entityinspector/EntityInspectorDetailView.java
+++ b/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/entityinspector/EntityInspectorDetailView.java
@@ -110,6 +110,8 @@ public class EntityInspectorDetailView extends StandardDetailView<Object> {
     protected HashMap<Tab, Component> tabToContentMap = new HashMap();
 
     protected Boolean isNew = true;
+    // Whether the edited entity is loaded from the data store, see initMainContainer().
+    protected boolean entityLoadedFromDataStore;
     protected InstanceContainer container;
     protected String metadataClassName;
     protected String metadataId;
@@ -216,7 +218,14 @@ public class EntityInspectorDetailView extends StandardDetailView<Object> {
 
             loader.setHint(PersistenceHints.SOFT_DELETION, false);
             loader.setContainer(container);
-            loader.load();
+
+            entityLoadedFromDataStore = !doNotReloadEditedEntity(container);
+            if (entityLoadedFromDataStore) {
+                loader.load();
+            } else {
+                // Reloading would discard the changes the entity has in the parent data context.
+                container.setItem(dataContext.merge(entity));
+            }
         } else {
             container.setItem(entity);
         }
@@ -254,7 +263,7 @@ public class EntityInspectorDetailView extends StandardDetailView<Object> {
                 .withOwnerComponent(getContent())
                 .build();
 
-        if (!isNew) {
+        if (!isNew && entityLoadedFromDataStore) {
             getEditedEntityLoader().load();
         }
 

--- a/jmix-datatools/datatools-flowui/src/test/java/entity_inspector/EntityInspectorCompositionTest.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/entity_inspector/EntityInspectorCompositionTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entity_inspector;
+
+import com.google.common.collect.ImmutableMap;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteParameters;
+import io.jmix.core.DataManager;
+import io.jmix.core.Metadata;
+import io.jmix.datatoolsflowui.action.EntityInspectorEditAction;
+import io.jmix.datatoolsflowui.view.entityinspector.EntityInspectorDetailView;
+import io.jmix.flowui.component.ListDataComponent;
+import io.jmix.flowui.component.grid.DataGrid;
+import io.jmix.flowui.data.ContainerDataUnit;
+import io.jmix.flowui.kit.action.Action;
+import io.jmix.flowui.testassist.UiTest;
+import io.jmix.flowui.testassist.UiTestUtils;
+import io.jmix.flowui.view.navigation.UrlParamSerializer;
+import io.jmix.flowui.view.navigation.ViewNavigationSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import test_support.EntityInspectorUiTestConfiguration;
+import test_support.TestFullAccessUiAuthenticator;
+import test_support.entity.InspectorCompositionItem;
+import test_support.entity.InspectorCompositionMaster;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@UiTest(authenticator = TestFullAccessUiAuthenticator.class)
+@SpringBootTest(classes = EntityInspectorUiTestConfiguration.class)
+public class EntityInspectorCompositionTest {
+
+    @Autowired
+    DataManager dataManager;
+    @Autowired
+    Metadata metadata;
+    @Autowired
+    ViewNavigationSupport navigationSupport;
+    @Autowired
+    UrlParamSerializer urlParamSerializer;
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @AfterEach
+    void cleanup() {
+        jdbcTemplate.update("delete from TEST_INSPECTOR_COMPOSITION_ITEM");
+        jdbcTemplate.update("delete from TEST_INSPECTOR_COMPOSITION_MASTER");
+    }
+
+    @Test
+    void testCompositionItemEditedInDialogKeepsUnsavedValueOnReopen() {
+        InspectorCompositionMaster master = metadata.create(InspectorCompositionMaster.class);
+        master.setName("master");
+        master.setItems(new ArrayList<>());
+        dataManager.save(master);
+
+        InspectorCompositionItem item = metadata.create(InspectorCompositionItem.class);
+        item.setName("item");
+        item.setAmount(15);
+        item.setMaster(master);
+        dataManager.save(item);
+
+        EntityInspectorDetailView masterView = navigateToInspector(master);
+        DataGrid<Object> itemsDataGrid = findItemsDataGrid(masterView);
+
+        // the item is edited in the dialog and the dialog is saved into the master view's data context
+        EntityInspectorDetailView itemView = openItemView(itemsDataGrid);
+        InspectorCompositionItem itemToEdit = (InspectorCompositionItem) itemView.getEditedEntity();
+
+        assertEquals(15, itemToEdit.getAmount());
+
+        itemToEdit.setAmount(10);
+        itemView.closeWithSave();
+
+        // the master view is not saved, so the edit exists only in its data context
+        assertEquals(10, getSingleItem(itemsDataGrid).getAmount());
+
+        EntityInspectorDetailView reopenedItemView = openItemView(itemsDataGrid);
+
+        assertEquals(10, ((InspectorCompositionItem) reopenedItemView.getEditedEntity()).getAmount());
+    }
+
+    @Test
+    void testUnchangedCompositionItemIsReloadedOnReopen() {
+        InspectorCompositionMaster master = metadata.create(InspectorCompositionMaster.class);
+        master.setName("master");
+        master.setItems(new ArrayList<>());
+        dataManager.save(master);
+
+        InspectorCompositionItem item = metadata.create(InspectorCompositionItem.class);
+        item.setName("item");
+        item.setAmount(15);
+        item.setMaster(master);
+        dataManager.save(item);
+
+        EntityInspectorDetailView masterView = navigateToInspector(master);
+        DataGrid<Object> itemsDataGrid = findItemsDataGrid(masterView);
+
+        EntityInspectorDetailView itemView = openItemView(itemsDataGrid);
+        itemView.closeWithDiscard();
+
+        jdbcTemplate.update("update TEST_INSPECTOR_COMPOSITION_ITEM set AMOUNT = 20");
+
+        EntityInspectorDetailView reopenedItemView = openItemView(itemsDataGrid);
+
+        assertEquals(20, ((InspectorCompositionItem) reopenedItemView.getEditedEntity()).getAmount());
+    }
+
+    private EntityInspectorDetailView navigateToInspector(InspectorCompositionMaster master) {
+        String entityName = metadata.getClass(InspectorCompositionMaster.class).getName();
+        RouteParameters routeParameters = new RouteParameters(ImmutableMap.of(
+                EntityInspectorDetailView.ROUTE_PARAM_NAME, urlParamSerializer.serialize(entityName),
+                EntityInspectorDetailView.ROUTE_PARAM_ID, urlParamSerializer.serialize(master.getId())
+        ));
+        navigationSupport.navigate(EntityInspectorDetailView.class, routeParameters);
+
+        return UiTestUtils.getCurrentView();
+    }
+
+    private EntityInspectorDetailView openItemView(DataGrid<Object> itemsDataGrid) {
+        itemsDataGrid.select(getSingleItem(itemsDataGrid));
+
+        Action editAction = itemsDataGrid.getAction(EntityInspectorEditAction.ID);
+        assertNotNull(editAction, "The edit action is not created in the entity inspector");
+        editAction.actionPerform(itemsDataGrid);
+
+        return UiTestUtils.getLastOpenedViewDialog();
+    }
+
+    private InspectorCompositionItem getSingleItem(ListDataComponent<Object> itemsDataGrid) {
+        List<Object> items = ((ContainerDataUnit<Object>) itemsDataGrid.getItems()).getContainer().getItems();
+        assertEquals(1, items.size());
+
+        return (InspectorCompositionItem) items.get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private DataGrid<Object> findItemsDataGrid(EntityInspectorDetailView masterView) {
+        DataGrid<Object> dataGrid = (DataGrid<Object>) findDataGrid(masterView.getContent()).orElse(null);
+        assertNotNull(dataGrid, "The 'items' data grid is not created in the entity inspector");
+
+        return dataGrid;
+    }
+
+    private Optional<Component> findDataGrid(Component component) {
+        if (component instanceof DataGrid) {
+            return Optional.of(component);
+        }
+        return component.getChildren()
+                .map(this::findDataGrid)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/EntityInspectorUiTestConfiguration.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/EntityInspectorUiTestConfiguration.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support;
+
+import io.jmix.core.CoreConfiguration;
+import io.jmix.core.annotation.JmixModule;
+import io.jmix.core.security.InMemoryUserRepository;
+import io.jmix.core.security.UserRepository;
+import io.jmix.data.DataConfiguration;
+import io.jmix.datatools.DatatoolsConfiguration;
+import io.jmix.datatoolsflowui.DatatoolsFlowuiConfiguration;
+import io.jmix.eclipselink.EclipselinkConfiguration;
+import io.jmix.flowui.FlowuiConfiguration;
+import io.jmix.flowui.testassist.FlowuiServletTestBeans;
+import io.jmix.flowui.testassist.FlowuiTestAssistConfiguration;
+import io.jmix.security.SecurityConfiguration;
+import io.jmix.security.StandardSecurityConfiguration;
+import io.jmix.securitydata.SecurityDataConfiguration;
+import io.jmix.testsupport.config.CommonCoreTestConfiguration;
+import io.jmix.testsupport.config.HsqlMemDataSourceTestConfiguration;
+import io.jmix.testsupport.config.JpaMainStoreTestConfiguration;
+import io.jmix.testsupport.config.LiquibaseTestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.scripting.ScriptEvaluator;
+import org.springframework.scripting.groovy.GroovyScriptEvaluator;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+@Import({CoreConfiguration.class, DataConfiguration.class, EclipselinkConfiguration.class,
+        FlowuiConfiguration.class, DatatoolsConfiguration.class, DatatoolsFlowuiConfiguration.class,
+        CommonCoreTestConfiguration.class, HsqlMemDataSourceTestConfiguration.class,
+        JpaMainStoreTestConfiguration.class, LiquibaseTestConfiguration.class,
+        FlowuiServletTestBeans.class,
+        FlowuiTestAssistConfiguration.class, SecurityConfiguration.class, SecurityDataConfiguration.class,
+        EntityInspectorUiTestConfiguration.TestStandardSecurityConfiguration.class})
+@JmixModule
+public class EntityInspectorUiTestConfiguration {
+
+    @Bean
+    UserRepository userRepository() {
+        return new InMemoryUserRepository();
+    }
+
+    @Bean
+    ScriptEvaluator scriptEvaluator() {
+        return new GroovyScriptEvaluator();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
+    @EnableWebSecurity
+    public static class TestStandardSecurityConfiguration extends StandardSecurityConfiguration {
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/TestFullAccessUiAuthenticator.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/TestFullAccessUiAuthenticator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support;
+
+import io.jmix.core.security.InMemoryUserRepository;
+import io.jmix.core.security.SecurityContextHelper;
+import io.jmix.flowui.testassist.UiTestAuthenticator;
+import io.jmix.security.role.RoleGrantedAuthorityUtils;
+import org.springframework.context.ApplicationContext;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import test_support.role.InspectorFullAccessRole;
+
+/**
+ * Authenticates UI tests as a user with full access, so that the security constraints registered by the
+ * security module do not interfere with the tested views.
+ */
+public class TestFullAccessUiAuthenticator implements UiTestAuthenticator {
+
+    protected static final String USERNAME = "entity-inspector-full-access";
+
+    @Override
+    public void setupAuthentication(ApplicationContext context) {
+        RoleGrantedAuthorityUtils roleGrantedAuthorityUtils = context.getBean(RoleGrantedAuthorityUtils.class);
+        UserDetails user = User.builder()
+                .username(USERNAME)
+                .password("{noop}")
+                .authorities(roleGrantedAuthorityUtils
+                        .createResourceRoleGrantedAuthority(InspectorFullAccessRole.NAME))
+                .build();
+
+        InMemoryUserRepository userRepository = context.getBean(InMemoryUserRepository.class);
+        if (userRepository.getByUsernameLike(USERNAME).isEmpty()) {
+            userRepository.addUser(user);
+        }
+
+        SecurityContextHelper.setAuthentication(
+                new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities()));
+    }
+
+    @Override
+    public void removeAuthentication(ApplicationContext context) {
+        SecurityContextHelper.setAuthentication(null);
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/InspectorCompositionItem.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/InspectorCompositionItem.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import java.util.UUID;
+
+@Table(name = "TEST_INSPECTOR_COMPOSITION_ITEM")
+@Entity(name = "test_InspectorCompositionItem")
+@JmixEntity
+public class InspectorCompositionItem {
+
+    @Id
+    @Column(name = "ID", nullable = false)
+    @JmixGeneratedValue
+    protected UUID id;
+
+    @Version
+    @Column(name = "VERSION", nullable = false)
+    protected Integer version;
+
+    @InstanceName
+    @Column(name = "NAME")
+    protected String name;
+
+    @Column(name = "AMOUNT")
+    protected Integer amount;
+
+    @JoinColumn(name = "MASTER_ID")
+    @ManyToOne(fetch = FetchType.LAZY)
+    protected InspectorCompositionMaster master;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Integer amount) {
+        this.amount = amount;
+    }
+
+    public InspectorCompositionMaster getMaster() {
+        return master;
+    }
+
+    public void setMaster(InspectorCompositionMaster master) {
+        this.master = master;
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/InspectorCompositionMaster.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/InspectorCompositionMaster.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity;
+
+import io.jmix.core.DeletePolicy;
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.OnDelete;
+import io.jmix.core.metamodel.annotation.Composition;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import java.util.List;
+import java.util.UUID;
+
+@Table(name = "TEST_INSPECTOR_COMPOSITION_MASTER")
+@Entity(name = "test_InspectorCompositionMaster")
+@JmixEntity
+public class InspectorCompositionMaster {
+
+    @Id
+    @Column(name = "ID", nullable = false)
+    @JmixGeneratedValue
+    protected UUID id;
+
+    @Version
+    @Column(name = "VERSION", nullable = false)
+    protected Integer version;
+
+    @InstanceName
+    @Column(name = "NAME")
+    protected String name;
+
+    @Composition
+    @OnDelete(DeletePolicy.CASCADE)
+    @OneToMany(mappedBy = "master")
+    protected List<InspectorCompositionItem> items;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<InspectorCompositionItem> getItems() {
+        return items;
+    }
+
+    public void setItems(List<InspectorCompositionItem> items) {
+        this.items = items;
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/role/InspectorFullAccessRole.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/role/InspectorFullAccessRole.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.role;
+
+import io.jmix.security.model.EntityAttributePolicyAction;
+import io.jmix.security.model.EntityPolicyAction;
+import io.jmix.security.role.annotation.EntityAttributePolicy;
+import io.jmix.security.role.annotation.EntityPolicy;
+import io.jmix.security.role.annotation.ResourceRole;
+import io.jmix.security.role.annotation.SpecificPolicy;
+
+@ResourceRole(name = InspectorFullAccessRole.NAME, code = InspectorFullAccessRole.NAME)
+public interface InspectorFullAccessRole {
+    String NAME = "InspectorFullAccessRole";
+
+    @EntityPolicy(entityName = "*", actions = EntityPolicyAction.ALL)
+    @EntityAttributePolicy(entityName = "*", attributes = "*", action = EntityAttributePolicyAction.MODIFY)
+    @SpecificPolicy(resources = "*")
+    void everything();
+}

--- a/jmix-datatools/datatools-flowui/src/test/resources/test_support/liquibase/test-changelog.xml
+++ b/jmix-datatools/datatools-flowui/src/test/resources/test_support/liquibase/test-changelog.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <property name="uuid.type" dbms="oracle" value="varchar2(32)"/>
+    <property name="uuid.type" dbms="!oracle" value="uuid"/>
+
+    <include file="io/jmix/securitydata/liquibase/changelog.xml"/>
+
+    <changeSet author="test" id="inspector-composition">
+        <createTable tableName="TEST_INSPECTOR_COMPOSITION_MASTER">
+            <column name="ID" type="${uuid.type}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="VERSION" type="int" defaultValue="1">
+                <constraints nullable="false"/>
+            </column>
+            <column name="NAME" type="varchar(255)"/>
+        </createTable>
+
+        <createTable tableName="TEST_INSPECTOR_COMPOSITION_ITEM">
+            <column name="ID" type="${uuid.type}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="VERSION" type="int" defaultValue="1">
+                <constraints nullable="false"/>
+            </column>
+            <column name="NAME" type="varchar(255)"/>
+            <column name="AMOUNT" type="int"/>
+            <column name="MASTER_ID" type="${uuid.type}"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="TEST_INSPECTOR_COMPOSITION_ITEM"
+                                 baseColumnNames="MASTER_ID"
+                                 constraintName="FK_TEST_INSPECTOR_COMPOSITION_ITEM_ON_MASTER"
+                                 referencedTableName="TEST_INSPECTOR_COMPOSITION_MASTER"
+                                 referencedColumnNames="ID"/>
+    </changeSet>
+</databaseChangeLog>

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardDetailView.java
@@ -686,8 +686,23 @@ public class StandardDetailView<T> extends StandardView implements DetailView<T>
     }
 
     private boolean doNotReloadEditedEntity() {
+        return doNotReloadEditedEntity(getEditedEntityContainer());
+    }
+
+    /**
+     * Returns whether the entity passed to {@link #setEntityToEdit(Object)} should be set to the container as is
+     * instead of being reloaded from the data store. It is the case when the entity is modified in a parent data
+     * context and its loaded attributes cover the container's fetch plan. If the entity is not modified in a
+     * parent data context, the entity is used as is only when reloading is turned off by
+     * {@link #setReloadEdited(boolean)}.
+     * <p>
+     * A view that creates the edited entity container itself can invoke this method with the created container
+     * to make the same decision. The method must be invoked after {@link #setEntityToEdit(Object)}.
+     *
+     * @param container container the edited entity is going to be set to
+     */
+    protected boolean doNotReloadEditedEntity(InstanceContainer<T> container) {
         if (isEntityModifiedInParentContext()) {
-            InstanceContainer<T> container = getEditedEntityContainer();
             FetchPlan fetchPlan = container.getFetchPlan();
             if (fetchPlan == null) {
                 MetadataTools metadataTools = getMetadataTools();


### PR DESCRIPTION
### Summary

Entity Inspector no longer discards a `@Composition` child's unsaved edit when the child's dialog is reopened before the master entity is saved. The inspector's detail View always reloaded the edited entity from the data store, bypassing the reload gate that `StandardDetailView` applies for exactly this case.

### What was done

- `flowui`: the reload decision made in `StandardDetailView.setupEntityToEdit(T)` is now available to subclasses as `protected boolean doNotReloadEditedEntity(InstanceContainer<T> container)`. Behavior for existing Views is unchanged.
- `datatools-flowui`: `EntityInspectorDetailView` applies that gate when it builds its edited-entity container, and keeps the instance from the parent `DataContext` instead of loading a fresh one when the gate says so.
- `datatools-flowui`: added the module's first UI test setup (`@UiTest` + `@SpringBootTest`) and two tests driving the real inspector Views through `EntityInspectorEditAction`.

### How it works

When the inspector opens an entity that is modified in a parent `DataContext` and is already loaded with the container's fetch plan, the entity is merged into the View's own context as is; otherwise it is loaded from the data store as before. The same decision suppresses the inspector's second load, so nothing overwrites the in-memory value afterwards. An entity with no unsaved changes is still reloaded on open, so the inspector keeps showing current database state.
