### PR TITLE
Base view class and studio view template for read only show page of an entity

### DIFF
--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/action/StudioActionPropertyGroups.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/action/StudioActionPropertyGroups.java
@@ -567,6 +567,30 @@ final class StudioActionPropertyGroups {
                             xmlAttribute = StudioXmlAttributes.ICON,
                             type = StudioPropertyType.ICON,
                             category = StudioProperty.Category.LOOK_AND_FEEL,
+                            defaultValue = "EYE",
+                            setParameterFqn = "com.vaadin.flow.component.Component"),
+                    @StudioProperty(
+                            xmlAttribute = StudioXmlAttributes.ID,
+                            type = StudioPropertyType.COMPONENT_ID,
+                            category = StudioProperty.Category.GENERAL,
+                            required = true,
+                            initialValue = "entityRead"),
+                    @StudioProperty(
+                            xmlAttribute = StudioXmlAttributes.TEXT,
+                            type = StudioPropertyType.LOCALIZED_STRING,
+                            category = StudioProperty.Category.GENERAL,
+                            defaultValue = "msg:///actions.entityPicker.read.description")
+            }
+    )
+    public interface EntityReadActionComponent extends BaseAction {
+    }
+
+    @StudioPropertyGroup(
+            properties = {
+                    @StudioProperty(
+                            xmlAttribute = StudioXmlAttributes.ICON,
+                            type = StudioPropertyType.ICON,
+                            category = StudioProperty.Category.LOOK_AND_FEEL,
                             defaultValue = "SEARCH",
                             setParameterFqn = "com.vaadin.flow.component.Component"),
                     @StudioProperty(

--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/action/StudioListDataComponentActions.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/action/StudioListDataComponentActions.java
@@ -108,7 +108,7 @@ interface StudioListDataComponentActions {
 
     @StudioAction(
             type = "list_read",
-            description = "Opens a detail view for an entity instance in read-only mode",
+            description = "Shows an entity instance in its read view, or in its detail view opened in read-only mode",
             classFqn = "io.jmix.flowui.action.list.ReadAction",
             documentationLink = "%VERSION%/flow-ui/actions/list-actions.html#list_read",
             availableInViewWizard = true,

--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/action/StudioPickerActions.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/action/StudioPickerActions.java
@@ -94,6 +94,25 @@ interface StudioPickerActions {
     void entityOpenAction();
 
     @StudioAction(
+            type = "entity_read",
+            description = "Shows an entity using the entity read view",
+            classFqn = "io.jmix.flowui.action.entitypicker.EntityReadAction",
+            unsupportedTarget = {
+                    "io.jmix.flowui.app.main.StandardMainView",
+                    "io.jmix.tabbedmode.app.main.StandardTabbedModeMainView",
+                    "io.jmix.flowui.component.valuepicker.JmixValuePicker",
+                    "io.jmix.flowui.component.valuepicker.JmixMultiValuePicker"
+            },
+            documentationLink = "%VERSION%/flow-ui/actions/entity-picker-actions.html#entity_read",
+            propertyGroups = StudioActionPropertyGroups.EntityReadActionComponent.class,
+            items = {
+                    @StudioPropertiesItem(xmlAttribute = StudioXmlAttributes.VIEW_ID, type = StudioPropertyType.STRING),
+                    @StudioPropertiesItem(xmlAttribute = StudioXmlAttributes.VIEW_CLASS, type = StudioPropertyType.STRING)
+            }
+    )
+    void entityReadAction();
+
+    @StudioAction(
             type = "entity_openComposition",
             description = "Opens a one-to-one composition entity using the entity detail view",
             classFqn = "io.jmix.flowui.action.entitypicker.EntityOpenCompositionAction",

--- a/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/component/preview/loader/PreviewActionSupport.java
+++ b/jmix-flowui/flowui-kit/src/main/java/io/jmix/flowui/kit/meta/component/preview/loader/PreviewActionSupport.java
@@ -149,6 +149,7 @@ public final class PreviewActionSupport {
             Map.entry("entity_lookup", new ActionDefaults(null, JmixFontIcon.ENTITY_LOOKUP_ACTION)),
             Map.entry("entity_clear", new ActionDefaults(null, JmixFontIcon.ENTITY_CLEAR_ACTION)),
             Map.entry("entity_open", new ActionDefaults(null, JmixFontIcon.ENTITY_OPEN_ACTION)),
+            Map.entry("entity_read", new ActionDefaults(null, JmixFontIcon.READ_ACTION)),
             Map.entry("value_clear", new ActionDefaults(null, JmixFontIcon.VALUE_CLEAR_ACTION)),
             // add-on action types: icon only, the text falls back to the humanized action id
             Map.entry("sec_showRoleAssignments",
@@ -158,7 +159,7 @@ public final class PreviewActionSupport {
 
     /** Picker-style types whose runtime buttons are icon-only; everything else gets a text. */
     private static final Set<String> ICON_ONLY_TYPES =
-            Set.of("entity_lookup", "entity_clear", "entity_open", "value_clear");
+            Set.of("entity_lookup", "entity_clear", "entity_open", "entity_read", "value_clear");
 
     /** Types of the implicit view actions that exist at runtime without an {@code <action>} element. */
     private static final Map<String, String> IMPLICIT_ACTION_TYPES = Map.of(

--- a/jmix-flowui/flowui-starter/src/main/java/io/jmix/autoconfigure/flowui/FlowuiAutoConfiguration.java
+++ b/jmix-flowui/flowui-starter/src/main/java/io/jmix/autoconfigure/flowui/FlowuiAutoConfiguration.java
@@ -103,6 +103,15 @@ public class FlowuiAutoConfiguration {
         return new DetailViewNavigationProcessor(viewSupport, viewRegistry, navigationSupport, routeSupport);
     }
 
+    @Bean("flowui_ReadViewNavigationProcessor")
+    @ConditionalOnMissingBean
+    public ReadViewNavigationProcessor readViewNavigationProcessor(ViewSupport viewSupport,
+                                                                   ViewRegistry viewRegistry,
+                                                                   ViewNavigationSupport navigationSupport,
+                                                                   RouteSupport routeSupport) {
+        return new ReadViewNavigationProcessor(viewSupport, viewRegistry, navigationSupport, routeSupport);
+    }
+
     @Bean("flowui_ListViewNavigationProcessor")
     @ConditionalOnMissingBean
     public ListViewNavigationProcessor listViewNavigationProcessor(ViewSupport viewSupport,

--- a/jmix-flowui/flowui-starter/src/main/java/io/jmix/autoconfigure/flowui/FlowuiAutoConfiguration.java
+++ b/jmix-flowui/flowui-starter/src/main/java/io/jmix/autoconfigure/flowui/FlowuiAutoConfiguration.java
@@ -29,6 +29,7 @@ import io.jmix.flowui.sys.ViewSupport;
 import io.jmix.flowui.view.ViewAttributes;
 import io.jmix.flowui.view.ViewRegistry;
 import io.jmix.flowui.view.builder.DetailWindowBuilderProcessor;
+import io.jmix.flowui.view.builder.ReadWindowBuilderProcessor;
 import io.jmix.flowui.view.builder.EditedEntityTransformer;
 import io.jmix.flowui.view.builder.LookupWindowBuilderProcessor;
 import io.jmix.flowui.view.builder.WindowBuilderProcessor;
@@ -153,6 +154,17 @@ public class FlowuiAutoConfiguration {
             @Nullable List<EditedEntityTransformer> editedEntityTransformers) {
         return new DetailWindowBuilderProcessor(applicationContext, views, viewRegistry, metadata, extendedEntities,
                 viewProperties, uiAccessChecker, editedEntityTransformers);
+    }
+
+    @Bean("flowui_ReadWindowBuilderProcessor")
+    @ConditionalOnMissingBean
+    public ReadWindowBuilderProcessor readWindowBuilderProcessor(ApplicationContext applicationContext,
+                                                                 Views views,
+                                                                 ViewRegistry viewRegistry,
+                                                                 UiAccessChecker uiAccessChecker,
+                                                                 DetailWindowBuilderProcessor detailBuilderProcessor) {
+        return new ReadWindowBuilderProcessor(applicationContext, views, viewRegistry, uiAccessChecker,
+                detailBuilderProcessor);
     }
 
     @Bean("flowui_LookupWindowBuilderProcessor")

--- a/jmix-flowui/flowui-starter/src/main/java/io/jmix/autoconfigure/flowui/FlowuiAutoConfiguration.java
+++ b/jmix-flowui/flowui-starter/src/main/java/io/jmix/autoconfigure/flowui/FlowuiAutoConfiguration.java
@@ -161,10 +161,8 @@ public class FlowuiAutoConfiguration {
     public ReadWindowBuilderProcessor readWindowBuilderProcessor(ApplicationContext applicationContext,
                                                                  Views views,
                                                                  ViewRegistry viewRegistry,
-                                                                 UiAccessChecker uiAccessChecker,
-                                                                 DetailWindowBuilderProcessor detailBuilderProcessor) {
-        return new ReadWindowBuilderProcessor(applicationContext, views, viewRegistry, uiAccessChecker,
-                detailBuilderProcessor);
+                                                                 UiAccessChecker uiAccessChecker) {
+        return new ReadWindowBuilderProcessor(applicationContext, views, viewRegistry, uiAccessChecker);
     }
 
     @Bean("flowui_LookupWindowBuilderProcessor")

--- a/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/FlowuiTestAssistConfiguration.java
+++ b/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/FlowuiTestAssistConfiguration.java
@@ -137,10 +137,8 @@ public class FlowuiTestAssistConfiguration {
     public ReadWindowBuilderProcessor readWindowBuilderProcessor(ApplicationContext applicationContext,
                                                                  Views views,
                                                                  ViewRegistry viewRegistry,
-                                                                 UiAccessChecker uiAccessChecker,
-                                                                 DetailWindowBuilderProcessor detailBuilderProcessor) {
-        return new ReadWindowBuilderProcessor(applicationContext, views, viewRegistry, uiAccessChecker,
-                detailBuilderProcessor);
+                                                                 UiAccessChecker uiAccessChecker) {
+        return new ReadWindowBuilderProcessor(applicationContext, views, viewRegistry, uiAccessChecker);
     }
 
     @Bean("flowui_DetailWindowBuilderProcessor")

--- a/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/FlowuiTestAssistConfiguration.java
+++ b/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/FlowuiTestAssistConfiguration.java
@@ -29,6 +29,7 @@ import io.jmix.flowui.testassist.navigation.ViewNavigationDelegate;
 import io.jmix.flowui.view.ViewAttributes;
 import io.jmix.flowui.view.ViewRegistry;
 import io.jmix.flowui.view.builder.DetailWindowBuilderProcessor;
+import io.jmix.flowui.view.builder.ReadWindowBuilderProcessor;
 import io.jmix.flowui.view.builder.EditedEntityTransformer;
 import io.jmix.flowui.view.builder.LookupWindowBuilderProcessor;
 import io.jmix.flowui.view.builder.WindowBuilderProcessor;
@@ -130,6 +131,16 @@ public class FlowuiTestAssistConfiguration {
                                                          ViewRegistry viewRegistry,
                                                          UiAccessChecker uiAccessChecker) {
         return new WindowBuilderProcessor(applicationContext, views, viewRegistry, uiAccessChecker);
+    }
+
+    @Bean("flowui_ReadWindowBuilderProcessor")
+    public ReadWindowBuilderProcessor readWindowBuilderProcessor(ApplicationContext applicationContext,
+                                                                 Views views,
+                                                                 ViewRegistry viewRegistry,
+                                                                 UiAccessChecker uiAccessChecker,
+                                                                 DetailWindowBuilderProcessor detailBuilderProcessor) {
+        return new ReadWindowBuilderProcessor(applicationContext, views, viewRegistry, uiAccessChecker,
+                detailBuilderProcessor);
     }
 
     @Bean("flowui_DetailWindowBuilderProcessor")

--- a/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/FlowuiTestAssistConfiguration.java
+++ b/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/FlowuiTestAssistConfiguration.java
@@ -22,6 +22,7 @@ import io.jmix.flowui.*;
 import io.jmix.flowui.sys.UiAccessChecker;
 import io.jmix.flowui.sys.ViewSupport;
 import io.jmix.flowui.testassist.navigation.TestDetailViewNavigationProcessor;
+import io.jmix.flowui.testassist.navigation.TestReadViewNavigationProcessor;
 import io.jmix.flowui.testassist.navigation.TestListViewNavigationProcessor;
 import io.jmix.flowui.testassist.navigation.TestViewNavigationProcessor;
 import io.jmix.flowui.testassist.navigation.ViewNavigationDelegate;
@@ -73,6 +74,16 @@ public class FlowuiTestAssistConfiguration {
                                          ListViewNavigationProcessor listViewNavigationProcessor,
                                          ViewNavigationProcessor viewNavigationProcessor) {
         return new ViewNavigators(detailViewNavigationProcessor, listViewNavigationProcessor, viewNavigationProcessor);
+    }
+
+    @Bean("ui_TestReadViewNavigationProcessor")
+    public ReadViewNavigationProcessor readViewNavigationProcessor(ViewSupport viewSupport,
+                                                                   ViewRegistry viewRegistry,
+                                                                   ViewNavigationSupport navigationSupport,
+                                                                   RouteSupport routeSupport,
+                                                                   ViewNavigationDelegate<?> navigationDelegate) {
+        return new TestReadViewNavigationProcessor(viewSupport, viewRegistry, navigationSupport, routeSupport,
+                (ViewNavigationDelegate<ReadViewNavigator<?>>) navigationDelegate);
     }
 
     @Bean("ui_TestDetailViewNavigationProcessor")

--- a/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/navigation/TestReadViewNavigationProcessor.java
+++ b/jmix-flowui/flowui-test-assist/src/main/java/io/jmix/flowui/testassist/navigation/TestReadViewNavigationProcessor.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.testassist.navigation;
+
+import com.vaadin.flow.function.SerializableConsumer;
+import io.jmix.flowui.sys.ViewSupport;
+import io.jmix.flowui.view.StandardReadView;
+import io.jmix.flowui.view.ViewRegistry;
+import io.jmix.flowui.view.navigation.*;
+
+import java.net.URL;
+
+/**
+ * The main goal of this class is supporting backward navigation in UI integration tests.
+ * <p>
+ * The {@link ReadViewNavigationProcessor} is used for preparing and performing navigation to the
+ * inheritor of {@link StandardReadView}.
+ * <p>
+ * In UI integration tests there is no client-side, so backward navigation URL should be got by another way.
+ * This is why {@link TestReadViewNavigationProcessor} replaces {@link ReadViewNavigationProcessor} and
+ * delegates building backward navigation URL to {@link ViewNavigationDelegate}.
+ */
+public class TestReadViewNavigationProcessor extends ReadViewNavigationProcessor {
+
+    protected ViewNavigationDelegate<ReadViewNavigator<?>> navigationDelegate;
+
+    public TestReadViewNavigationProcessor(ViewSupport viewSupport, ViewRegistry viewRegistry,
+                                           ViewNavigationSupport navigationSupport, RouteSupport routeSupport,
+                                           ViewNavigationDelegate<ReadViewNavigator<?>> navigationDelegate) {
+        super(viewSupport, viewRegistry, navigationSupport, routeSupport);
+
+        this.navigationDelegate = navigationDelegate;
+    }
+
+    @Override
+    public void processNavigation(ReadViewNavigator<?> navigator) {
+        super.processNavigation(navigator);
+
+        navigationDelegate.saveCurrentNavigation(
+                getViewClass(navigator),
+                getRouteParameters(navigator),
+                getQueryParameters(navigator));
+    }
+
+    @Override
+    protected void fetchCurrentURL(SerializableConsumer<URL> callback) {
+        callback.accept(navigationDelegate.fetchCurrentUrl());
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/DialogWindows.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/DialogWindows.java
@@ -174,6 +174,55 @@ public class DialogWindows {
     }
 
     /**
+     * Creates a builder that opens a read view for an entity selected in the list component.
+     *
+     * @param listDataComponent the component which provides an entity to show
+     * @see #read(View, Class)
+     */
+    public <E, V extends View<?>> ReadWindowBuilder<E, V> read(ListDataComponent<E> listDataComponent) {
+        checkNotNullArgument(listDataComponent);
+
+        View<?> origin = UiComponentUtils.getView((Component) listDataComponent);
+        Class<E> beanType = getBeanType(listDataComponent);
+
+        ReadWindowBuilder<E, V> builder =
+                new ReadWindowBuilder<>(origin, beanType, readBuilderProcessor::build);
+
+        E selected = listDataComponent.getSingleSelectedItem();
+        if (selected != null) {
+            builder.readEntity(selected);
+        }
+
+        return builder;
+    }
+
+    /**
+     * Creates a builder that opens a read view for an entity set to the picker component.
+     *
+     * @param picker the component which provides an entity to show
+     * @see #read(View, Class)
+     */
+    @SuppressWarnings("unchecked")
+    public <E, V extends View<?>> ReadWindowBuilder<E, V> read(EntityPickerComponent<E> picker) {
+        checkNotNullArgument(picker);
+        checkState(picker instanceof HasValue,
+                "A component must implement " + HasValue.class.getSimpleName());
+
+        View<?> origin = UiComponentUtils.getView((Component) picker);
+        Class<E> beanType = getBeanType(picker);
+
+        ReadWindowBuilder<E, V> builder =
+                new ReadWindowBuilder<>(origin, beanType, readBuilderProcessor::build);
+
+        E value = ((HasValue<?, E>) picker).getValue();
+        if (value != null) {
+            builder.readEntity(value);
+        }
+
+        return builder;
+    }
+
+    /**
      * Creates a lookup view builder for an entity class.
      * <p>
      * Example of opening a view for selecting an entity:

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/DialogWindows.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/DialogWindows.java
@@ -47,6 +47,9 @@ public class DialogWindows {
     protected LookupWindowBuilderProcessor lookupBuilderProcessor;
     protected ObjectProvider<OpenedDialogWindows> openedDialogWindows;
 
+    @Autowired
+    protected ReadWindowBuilderProcessor readBuilderProcessor;
+
     public DialogWindows(WindowBuilderProcessor windowBuilderProcessor,
                          DetailWindowBuilderProcessor detailBuilderProcessor,
                          LookupWindowBuilderProcessor lookupBuilderProcessor,
@@ -149,6 +152,25 @@ public class DialogWindows {
         }
 
         return builder;
+    }
+
+    /**
+     * Creates a read view builder for an entity class.
+     * <p>
+     * Example:
+     * <pre>{@code
+     * dialogWindows.read(this, Customer.class)
+     *         .readEntity(customersTable.getSingleSelectedItem())
+     *         .open();
+     * }</pre>
+     *
+     * @param origin      calling view
+     * @param entityClass shown entity class
+     */
+    public <E, V extends View<?>> ReadWindowBuilder<E, V> read(View<?> origin, Class<E> entityClass) {
+        checkNotNullArgument(entityClass);
+
+        return new ReadWindowBuilder<>(origin, entityClass, readBuilderProcessor::build);
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/UiComponentProperties.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/UiComponentProperties.java
@@ -75,6 +75,7 @@ public class UiComponentProperties {
 
     String pickerLookupShortcut;
     String pickerOpenShortcut;
+    String pickerReadShortcut;
     String pickerClearShortcut;
 
     /**
@@ -184,6 +185,7 @@ public class UiComponentProperties {
             @DefaultValue("3000") int defaultNotificationDuration,
             String pickerLookupShortcut,
             String pickerOpenShortcut,
+            String pickerReadShortcut,
             String pickerClearShortcut,
             @DefaultValue({"20", "50", "100", "500", "1000", "5000"}) List<Integer> paginationItemsPerPageItems,
             @Nullable Map<String, String> entityFieldFqn,
@@ -217,6 +219,7 @@ public class UiComponentProperties {
 
         this.pickerLookupShortcut = pickerLookupShortcut;
         this.pickerOpenShortcut = pickerOpenShortcut;
+        this.pickerReadShortcut = pickerReadShortcut;
         this.pickerClearShortcut = pickerClearShortcut;
 
         this.paginationItemsPerPageItems = paginationItemsPerPageItems;
@@ -307,6 +310,10 @@ public class UiComponentProperties {
 
     public String getPickerOpenShortcut() {
         return pickerOpenShortcut;
+    }
+
+    public String getPickerReadShortcut() {
+        return pickerReadShortcut;
     }
 
     public String getPickerClearShortcut() {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/ViewNavigators.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/ViewNavigators.java
@@ -27,6 +27,7 @@ import io.jmix.flowui.data.HasType;
 import io.jmix.flowui.view.View;
 import io.jmix.flowui.view.ViewController;
 import io.jmix.flowui.view.navigation.*;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import static com.google.common.base.Preconditions.checkState;
 import static io.jmix.core.common.util.Preconditions.checkNotNullArgument;
@@ -39,6 +40,9 @@ public class ViewNavigators {
     protected DetailViewNavigationProcessor detailViewNavigationProcessor;
     protected ListViewNavigationProcessor listViewNavigationProcessor;
     protected ViewNavigationProcessor viewNavigationProcessor;
+
+    @Autowired
+    protected ReadViewNavigationProcessor readViewNavigationProcessor;
 
     public ViewNavigators(DetailViewNavigationProcessor detailViewNavigationProcessor,
                           ListViewNavigationProcessor listViewNavigationProcessor,
@@ -126,6 +130,25 @@ public class ViewNavigators {
 
         return navigator
                 .withBackwardNavigation(true);
+    }
+
+    /**
+     * Creates a read view navigator for an entity class.
+     * <p>
+     * Example of navigating to a view showing an entity:
+     * <pre>{@code
+     * viewNavigators.readView(this, Customer.class)
+     *         .readEntity(customersTable.getSingleSelectedItem())
+     *         .navigate();
+     * }</pre>
+     *
+     * @param origin      calling view
+     * @param entityClass shown entity class
+     */
+    public <E> ReadViewNavigator<E> readView(View<?> origin, Class<E> entityClass) {
+        checkNotNullArgument(entityClass);
+
+        return new ReadViewNavigator<>(origin, entityClass, readViewNavigationProcessor::processNavigation);
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/ViewNavigators.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/ViewNavigators.java
@@ -152,6 +152,57 @@ public class ViewNavigators {
     }
 
     /**
+     * Creates a read view navigator to show an entity selected in the list component.
+     *
+     * @param listDataComponent the component which provides an entity to show
+     * @see #readView(View, Class)
+     */
+    public <E> ReadViewNavigator<E> readView(ListDataComponent<E> listDataComponent) {
+        checkNotNullArgument(listDataComponent);
+
+        View<?> origin = UiComponentUtils.getView((Component) listDataComponent);
+        Class<E> beanType = getBeanType(listDataComponent);
+
+        ReadViewNavigator<E> navigator =
+                new ReadViewNavigator<>(origin, beanType, readViewNavigationProcessor::processNavigation);
+
+        E selected = listDataComponent.getSingleSelectedItem();
+        if (selected != null) {
+            navigator.readEntity(selected);
+        }
+
+        return navigator
+                .withBackwardNavigation(true);
+    }
+
+    /**
+     * Creates a read view navigator to show an entity selected in the picker component.
+     *
+     * @param picker the component which provides an entity to show
+     * @see #readView(View, Class)
+     */
+    @SuppressWarnings("unchecked")
+    public <E> ReadViewNavigator<E> readView(EntityPickerComponent<E> picker) {
+        checkNotNullArgument(picker);
+        checkState(picker instanceof HasValue,
+                "A component must implement " + HasValue.class.getSimpleName());
+
+        View<?> origin = UiComponentUtils.getView((Component) picker);
+        Class<E> beanType = getBeanType(picker);
+
+        ReadViewNavigator<E> navigator =
+                new ReadViewNavigator<>(origin, beanType, readViewNavigationProcessor::processNavigation);
+
+        E value = ((HasValue<?, E>) picker).getValue();
+        if (value != null) {
+            navigator.readEntity(value);
+        }
+
+        return navigator
+                .withBackwardNavigation(true);
+    }
+
+    /**
      * Creates a list view navigator for an entity class.
      * <p>
      * Example of navigating to a view for editing an entity and returning to the calling view:

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/action/entitypicker/EntityReadAction.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/action/entitypicker/EntityReadAction.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.action.entitypicker;
+
+import com.vaadin.flow.component.HasValue;
+import io.jmix.core.DevelopmentException;
+import io.jmix.core.Messages;
+import io.jmix.core.entity.EntityValues;
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.flowui.DialogWindows;
+import io.jmix.flowui.Notifications;
+import io.jmix.flowui.UiComponentProperties;
+import io.jmix.flowui.action.ActionType;
+import io.jmix.flowui.action.ViewOpeningAction;
+import io.jmix.flowui.action.valuepicker.PickerAction;
+import io.jmix.flowui.component.EntityPickerComponent;
+import io.jmix.flowui.icon.Icons;
+import io.jmix.flowui.kit.component.KeyCombination;
+import io.jmix.flowui.kit.icon.JmixFontIcon;
+import io.jmix.flowui.sys.ActionViewInitializer;
+import io.jmix.flowui.view.DialogWindow;
+import io.jmix.flowui.view.OpenMode;
+import io.jmix.flowui.view.View;
+import io.jmix.flowui.view.builder.ReadWindowBuilder;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkState;
+
+/**
+ * Shows the entity set to an entity picker component in a read view.
+ * <p>
+ * The view is resolved as {@link io.jmix.flowui.action.list.ReadAction} resolves it: the view annotated with
+ * {@link io.jmix.flowui.view.PrimaryReadView}, otherwise the view with the {@code <entity>.read} id, otherwise
+ * the entity's detail view opened in the read-only mode. In contrast to {@link EntityOpenAction} the action
+ * never saves: it requires no UPDATE permission and stays enabled on a read-only view.
+ *
+ * @param <E> entity type
+ */
+@ActionType(EntityReadAction.ID)
+public class EntityReadAction<E> extends PickerAction<EntityReadAction<E>, EntityPickerComponent<E>, E>
+        implements ViewOpeningAction {
+
+    private static final Logger log = LoggerFactory.getLogger(EntityReadAction.class);
+
+    public static final String ID = "entity_read";
+
+    protected Messages messages;
+    protected Notifications notifications;
+    protected DialogWindows dialogWindows;
+
+    protected ActionViewInitializer viewInitializer = new ActionViewInitializer();
+
+    public EntityReadAction() {
+        this(ID);
+    }
+
+    public EntityReadAction(String id) {
+        super(id);
+    }
+
+    @Autowired
+    public void setDialogWindows(DialogWindows dialogWindows) {
+        this.dialogWindows = dialogWindows;
+    }
+
+    @Autowired
+    public void setNotifications(Notifications notifications) {
+        this.notifications = notifications;
+    }
+
+    @Autowired
+    public void setMessages(Messages messages) {
+        this.messages = messages;
+        this.text = messages.getMessage("actions.entityPicker.read.description");
+    }
+
+    @Autowired
+    protected void setUiComponentProperties(UiComponentProperties uiComponentProperties) {
+        setShortcutCombination(KeyCombination.create(uiComponentProperties.getPickerReadShortcut()));
+    }
+
+    @Autowired
+    protected void setIcons(Icons icons) {
+        // Check for 'null' for backward compatibility because 'icon' can be set in
+        // the 'initAction()' method which is called before injection.
+        if (this.icon == null) {
+            this.icon = icons.get(JmixFontIcon.READ_ACTION);
+        }
+    }
+
+    @Override
+    public void setTarget(@Nullable EntityPickerComponent<E> target) {
+        checkState(target == null || target instanceof HasValue,
+                "A component must implement " + HasValue.class.getSimpleName());
+
+        super.setTarget(target);
+    }
+
+    @Nullable
+    @Override
+    public OpenMode getOpenMode() {
+        // Read view opens in a dialog window only
+        return OpenMode.DIALOG;
+    }
+
+    @Override
+    public void setOpenMode(@Nullable OpenMode openMode) {
+        log.warn("{} doesn't support setting {}", ID, OpenMode.class.getSimpleName());
+    }
+
+    @Nullable
+    @Override
+    public String getViewId() {
+        return viewInitializer.getViewId();
+    }
+
+    @Override
+    public void setViewId(@Nullable String viewId) {
+        viewInitializer.setViewId(viewId);
+    }
+
+    @Nullable
+    @Override
+    public Class<? extends View> getViewClass() {
+        return viewInitializer.getViewClass();
+    }
+
+    @Override
+    public void setViewClass(@Nullable Class<? extends View> viewClass) {
+        viewInitializer.setViewClass(viewClass);
+    }
+
+    @Nullable
+    @Override
+    public RouteParametersProvider getRouteParametersProvider() {
+        // Read view opens in a dialog window only
+        return null;
+    }
+
+    @Override
+    public void setRouteParametersProvider(@Nullable RouteParametersProvider provider) {
+        log.warn("{} doesn't support setting {}", ID, RouteParametersProvider.class.getSimpleName());
+    }
+
+    @Nullable
+    @Override
+    public QueryParametersProvider getQueryParametersProvider() {
+        // Read view opens in a dialog window only
+        return null;
+    }
+
+    @Override
+    public void setQueryParametersProvider(@Nullable QueryParametersProvider provider) {
+        log.warn("{} doesn't support setting {}", ID, QueryParametersProvider.class.getSimpleName());
+    }
+
+    @Override
+    public <V extends View<?>> void setAfterCloseHandler(
+            @Nullable Consumer<DialogWindow.AfterCloseEvent<V>> afterCloseHandler) {
+        viewInitializer.setAfterCloseHandler(afterCloseHandler);
+    }
+
+    @Override
+    public <V extends View<?>> Consumer<DialogWindow.AfterCloseEvent<V>> getAfterCloseHandler() {
+        return viewInitializer.getAfterCloseHandler();
+    }
+
+    @Override
+    public <V extends View<?>> void setViewConfigurer(@Nullable Consumer<V> viewConfigurer) {
+        viewInitializer.setViewConfigurer(viewConfigurer);
+    }
+
+    @Override
+    public <V extends View<?>> Consumer<V> getViewConfigurer() {
+        return viewInitializer.getViewConfigurer();
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void execute() {
+        if (isEmpty()) {
+            return;
+        }
+
+        E entity = ((HasValue<?, E>) target).getValue();
+        if (entity != null && EntityValues.isSoftDeleted(entity)) {
+            notifications.show(messages.getMessage("actions.entityPicker.read.isDeleted"));
+            return;
+        }
+
+        MetaClass metaClass = target.getMetaClass();
+        if (metaClass == null) {
+            throw new DevelopmentException("Neither metaClass nor dataContainer/property is specified " +
+                    "for the " + target.getClass().getSimpleName(), "action ID", getId());
+        }
+
+        ReadWindowBuilder<E, View<?>> builder = dialogWindows.read(target);
+
+        builder = viewInitializer.initWindowBuilder(builder);
+
+        builder.build().open();
+    }
+
+    /**
+     * Sets the id of the view to open and returns the action for chaining.
+     *
+     * @param viewId id of the view to open
+     * @return this instance for chaining
+     */
+    public EntityReadAction<E> withViewId(@Nullable String viewId) {
+        setViewId(viewId);
+        return this;
+    }
+
+    /**
+     * Sets the class of the view to open and returns the action for chaining.
+     *
+     * @param viewClass class of the view to open
+     * @return this instance for chaining
+     */
+    public EntityReadAction<E> withViewClass(@Nullable Class<? extends View> viewClass) {
+        setViewClass(viewClass);
+        return this;
+    }
+
+    /**
+     * Sets the handler that configures the view before it is shown and returns the action for chaining.
+     *
+     * @param viewConfigurer handler to set
+     * @param <V>            view type
+     * @return this instance for chaining
+     */
+    public <V extends View<?>> EntityReadAction<E> withViewConfigurer(@Nullable Consumer<V> viewConfigurer) {
+        setViewConfigurer(viewConfigurer);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected boolean isEmpty() {
+        return ((HasValue<?, E>) target).isEmpty();
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/action/list/ReadAction.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/action/list/ReadAction.java
@@ -36,6 +36,9 @@ import io.jmix.flowui.sys.ActionViewInitializer;
 import io.jmix.flowui.view.*;
 import io.jmix.flowui.view.builder.DetailWindowBuilder;
 import io.jmix.flowui.view.navigation.DetailViewNavigator;
+import io.jmix.flowui.view.navigation.ReadViewNavigator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.jspecify.annotations.Nullable;
 
@@ -46,10 +49,13 @@ import java.util.function.Function;
 public class ReadAction<E> extends SecuredListDataComponentAction<ReadAction<E>, E>
         implements ViewOpeningAction {
 
+    private static final Logger log = LoggerFactory.getLogger(ReadAction.class);
+
     public static final String ID = "list_read";
 
     protected ViewNavigators viewNavigators;
     protected DialogWindows dialogWindows;
+    protected ViewRegistry viewRegistry;
 
     protected ActionViewInitializer viewInitializer = new ActionViewInitializer();
     protected Consumer<E> afterSaveHandler;
@@ -238,6 +244,11 @@ public class ReadAction<E> extends SecuredListDataComponentAction<ReadAction<E>,
         this.dialogWindows = dialogWindows;
     }
 
+    @Autowired
+    public void setViewRegistry(ViewRegistry viewRegistry) {
+        this.viewRegistry = viewRegistry;
+    }
+
     @Override
     public void setText(@Nullable String text) {
         super.setText(text);
@@ -330,7 +341,64 @@ public class ReadAction<E> extends SecuredListDataComponentAction<ReadAction<E>,
         dialogWindow.open();
     }
 
-    protected void navigate(E editedEntity) {
+    protected void navigate(E entity) {
+        if (isReadViewResolved(entity)) {
+            navigateToReadView(entity);
+        } else {
+            navigateToDetailView(entity);
+        }
+    }
+
+    /**
+     * Returns the class of the view the action opens: an explicitly configured view class or id,
+     * otherwise the view resolved for the entity by {@link ViewRegistry#getReadViewInfo(Object)}.
+     *
+     * @param entity entity to show
+     * @return the class of the view the action opens
+     */
+    protected Class<? extends View> resolveViewClass(E entity) {
+        Class<? extends View> viewClass = viewInitializer.getViewClass();
+        if (viewClass != null) {
+            return viewClass;
+        }
+
+        String viewId = viewInitializer.getViewId();
+        if (viewId != null) {
+            return viewRegistry.getViewInfo(viewId).getControllerClass();
+        }
+
+        return viewRegistry.getReadViewInfo(entity).getControllerClass();
+    }
+
+    protected boolean isReadViewResolved(E entity) {
+        return ReadView.class.isAssignableFrom(resolveViewClass(entity));
+    }
+
+    protected void navigateToReadView(E entity) {
+        warnOnInapplicableSaveHooks();
+
+        ReadViewNavigator<E> navigator = viewNavigators.readView(target)
+                .readEntity(entity)
+                .withBackwardNavigation(true);
+
+        navigator = viewInitializer.initNavigator(navigator);
+
+        ActionHandlerValidator.validate(this, OpenMode.NAVIGATION);
+
+        navigator.navigate();
+    }
+
+    /**
+     * Logs a warning if the action carries handlers that apply only to a detail view opened for editing.
+     */
+    protected void warnOnInapplicableSaveHooks() {
+        if (afterSaveHandler != null || transformation != null) {
+            log.warn("'{}' action is configured with 'afterSaveHandler' or 'transformation', which do not " +
+                    "apply to a read view and will not be invoked", getId());
+        }
+    }
+
+    protected void navigateToDetailView(E editedEntity) {
         DetailViewNavigator<E> navigator = viewNavigators.detailView((target))
                 .editEntity(editedEntity)
                 .withBackwardNavigation(true)

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/action/list/ReadAction.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/action/list/ReadAction.java
@@ -35,6 +35,7 @@ import io.jmix.flowui.kit.icon.JmixFontIcon;
 import io.jmix.flowui.sys.ActionViewInitializer;
 import io.jmix.flowui.view.*;
 import io.jmix.flowui.view.builder.DetailWindowBuilder;
+import io.jmix.flowui.view.builder.ReadWindowBuilder;
 import io.jmix.flowui.view.navigation.DetailViewNavigator;
 import io.jmix.flowui.view.navigation.ReadViewNavigator;
 import org.slf4j.Logger;
@@ -304,7 +305,31 @@ public class ReadAction<E> extends SecuredListDataComponentAction<ReadAction<E>,
         }
     }
 
-    protected void openDialog(E editedEntity) {
+    protected void openDialog(E entity) {
+        if (isReadViewResolved(entity)) {
+            openReadViewDialog(entity);
+        } else {
+            openDetailViewDialog(entity);
+        }
+    }
+
+    protected void openReadViewDialog(E entity) {
+        warnOnInapplicableSaveHooks();
+
+        ReadWindowBuilder<E, View<?>> builder = dialogWindows.read(target);
+
+        builder = viewInitializer.initWindowBuilder(builder);
+
+        builder = builder.readEntity(entity);
+
+        DialogWindow<View<?>> dialogWindow = builder.build();
+
+        ActionHandlerValidator.validate(this, OpenMode.DIALOG);
+
+        dialogWindow.open();
+    }
+
+    protected void openDetailViewDialog(E editedEntity) {
         DetailWindowBuilder<E, View<?>> builder = dialogWindows.detail(target);
 
         builder = viewInitializer.initWindowBuilder(builder);

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ActionViewInitializer.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ActionViewInitializer.java
@@ -24,6 +24,7 @@ import io.jmix.flowui.view.builder.DetailWindowBuilder;
 import io.jmix.flowui.view.builder.LookupWindowBuilder;
 import io.jmix.flowui.view.builder.WindowBuilder;
 import io.jmix.flowui.view.navigation.DetailViewNavigator;
+import io.jmix.flowui.view.navigation.ReadViewNavigator;
 import io.jmix.flowui.view.navigation.ViewNavigator;
 import org.jspecify.annotations.Nullable;
 
@@ -113,6 +114,26 @@ public class ActionViewInitializer {
     }
 
     public <E> DetailViewNavigator<E> initNavigator(DetailViewNavigator<E> navigator) {
+        if (viewClass != null) {
+            navigator = navigator.withViewClass(viewClass);
+        }
+
+        if (viewId != null) {
+            navigator = navigator.withViewId(viewId);
+        }
+
+        if (routeParametersProvider != null) {
+            navigator = navigator.withRouteParameters(routeParametersProvider.getRouteParameters());
+        }
+
+        if (queryParametersProvider != null) {
+            navigator = navigator.withQueryParameters(queryParametersProvider.getQueryParameters());
+        }
+
+        return navigator;
+    }
+
+    public <E> ReadViewNavigator<E> initNavigator(ReadViewNavigator<E> navigator) {
         if (viewClass != null) {
             navigator = navigator.withViewClass(viewClass);
         }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ActionViewInitializer.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/sys/ActionViewInitializer.java
@@ -22,6 +22,7 @@ import io.jmix.flowui.view.DialogWindow.AfterCloseEvent;
 import io.jmix.flowui.view.View;
 import io.jmix.flowui.view.builder.DetailWindowBuilder;
 import io.jmix.flowui.view.builder.LookupWindowBuilder;
+import io.jmix.flowui.view.builder.ReadWindowBuilder;
 import io.jmix.flowui.view.builder.WindowBuilder;
 import io.jmix.flowui.view.navigation.DetailViewNavigator;
 import io.jmix.flowui.view.navigation.ReadViewNavigator;
@@ -154,6 +155,26 @@ public class ActionViewInitializer {
     }
 
     public <E, V extends View<?>> DetailWindowBuilder<E, V> initWindowBuilder(DetailWindowBuilder<E, V> windowBuilder) {
+        if (viewClass != null) {
+            windowBuilder = windowBuilder.withViewClass((Class) viewClass);
+        }
+
+        if (viewId != null) {
+            windowBuilder = windowBuilder.withViewId(viewId);
+        }
+
+        if (afterCloseHandler != null) {
+            windowBuilder = windowBuilder.withAfterCloseListener((Consumer) afterCloseHandler);
+        }
+
+        if (viewConfigurer != null) {
+            windowBuilder = windowBuilder.withViewConfigurer((Consumer) viewConfigurer);
+        }
+
+        return windowBuilder;
+    }
+
+    public <E, V extends View<?>> ReadWindowBuilder<E, V> initWindowBuilder(ReadWindowBuilder<E, V> windowBuilder) {
         if (viewClass != null) {
             windowBuilder = windowBuilder.withViewClass((Class) viewClass);
         }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/PrimaryReadView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/PrimaryReadView.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.view;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation for read view controllers that sets this controller as default read view for entities
+ * of the specified type.
+ *
+ * @see ReadView
+ * @see StandardReadView
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PrimaryReadView {
+
+    /**
+     * Entity class for which the view is a default read view.
+     */
+    Class<?> value();
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ReadEntityContainer.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ReadEntityContainer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.view;
+
+import java.lang.annotation.Target;
+import java.lang.annotation.*;
+
+/**
+ * Annotation for read view controllers which specifies a data container that holds the shown entity.
+ *
+ * @see StandardReadView
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface ReadEntityContainer {
+
+    /**
+     * Specifies the ID of the data container that holds the shown entity.
+     *
+     * @return the ID of the data container
+     */
+    String value();
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ReadView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ReadView.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.view;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Interface of views that display an entity instance without editing it.
+ *
+ * @param <E> type of entity
+ */
+@NullMarked
+public interface ReadView<E> {
+
+    /**
+     * Sets the entity instance to show. The view reloads the instance by its id, so what is displayed
+     * always matches the view's fetch plan.
+     *
+     * @param entity entity instance to show
+     */
+    void setEntityToRead(E entity);
+
+    /**
+     * Returns the currently shown entity instance.
+     *
+     * @return currently shown entity instance
+     * @throws IllegalStateException if the entity isn't loaded yet, for example in {@link View.InitEvent}
+     */
+    default E getEntity() {
+        E entity = getEntityOrNull();
+        if (entity == null) {
+            throw new IllegalStateException("Entity isn't loaded yet");
+        }
+
+        return entity;
+    }
+
+    /**
+     * Returns the currently shown entity instance or {@code null} if it isn't loaded yet.
+     *
+     * @return currently shown entity instance or {@code null} if it isn't loaded yet
+     */
+    @Nullable
+    E getEntityOrNull();
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardReadView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardReadView.java
@@ -53,10 +53,15 @@ public class StandardReadView<E> extends StandardView implements ReadView<E> {
     @Internal
     public StandardReadView() {
         addBeforeShowListener(this::onBeforeShow);
+        addReadyListener(this::onReady);
     }
 
     private void onBeforeShow(BeforeShowEvent event) {
         setupEntityToRead();
+    }
+
+    private void onReady(ReadyEvent event) {
+        applyReadOnlyState();
     }
 
     @Override
@@ -170,6 +175,15 @@ public class StandardReadView<E> extends StandardView implements ReadView<E> {
         return (InstanceLoader<E>) loader;
     }
 
+    /**
+     * Makes data-bound components of the view read-only and disables actions that adjust themselves when a
+     * view is read-only. Invoked on {@link ReadyEvent}, i.e. after the view's own {@link BeforeShowEvent}
+     * handlers have created their components.
+     */
+    protected void applyReadOnlyState() {
+        getReadOnlyViewsSupport().setViewReadOnly(this, true);
+    }
+
     private Class<?> getSerializedIdType() {
         MetaClass entityMetaClass = getEntityContainer().getEntityMetaClass();
         MetaProperty primaryKeyProperty = getMetadataTools().getPrimaryKeyProperty(entityMetaClass);
@@ -179,6 +193,10 @@ public class StandardReadView<E> extends StandardView implements ReadView<E> {
         }
 
         return primaryKeyProperty.getJavaType();
+    }
+
+    private ReadOnlyViewsSupport getReadOnlyViewsSupport() {
+        return getApplicationContext().getBean(ReadOnlyViewsSupport.class);
     }
 
     private MetadataTools getMetadataTools() {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardReadView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardReadView.java
@@ -31,6 +31,7 @@ import io.jmix.flowui.model.HasLoader;
 import io.jmix.flowui.model.InstanceContainer;
 import io.jmix.flowui.model.InstanceLoader;
 import io.jmix.flowui.view.navigation.UrlParamSerializer;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -38,6 +39,7 @@ import org.jspecify.annotations.Nullable;
  *
  * @param <E> entity class
  */
+@NullMarked
 public class StandardReadView<E> extends StandardView implements ReadView<E> {
 
     public static final String DEFAULT_ROUTE_PARAM = "id";

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardReadView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardReadView.java
@@ -16,6 +16,7 @@
 
 package io.jmix.flowui.view;
 
+import com.google.common.base.Strings;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import io.jmix.core.MetadataTools;
 import io.jmix.core.annotation.Internal;
@@ -106,15 +107,39 @@ public class StandardReadView<E> extends StandardView implements ReadView<E> {
 
     protected InstanceContainer<E> getEntityContainer() {
         ReadEntityContainer annotation = getClass().getAnnotation(ReadEntityContainer.class);
+        if (annotation == null || Strings.isNullOrEmpty(annotation.value())) {
+            throw new IllegalStateException(
+                    String.format("'%s' does not declare @%s", getClass(),
+                            ReadEntityContainer.class.getSimpleName())
+            );
+        }
+
+        if (annotation.value().contains(".")) {
+            throw new UnsupportedOperationException(
+                    String.format("Can't obtain shown entity container with id: '%s'", annotation.value()));
+        }
+
         return getViewData().getContainer(annotation.value());
     }
 
     @SuppressWarnings("unchecked")
     protected InstanceLoader<E> getEntityLoader() {
         InstanceContainer<E> container = getEntityContainer();
-        DataLoader loader = container instanceof HasLoader
-                ? ((HasLoader) container).getLoader()
-                : null;
+        DataLoader loader = null;
+
+        if (container instanceof HasLoader containerWithLoader) {
+            loader = containerWithLoader.getLoader();
+        }
+
+        if (loader == null) {
+            throw new IllegalStateException("Loader of shown entity container not found");
+        }
+
+        if (!(loader instanceof InstanceLoader)) {
+            throw new IllegalStateException(String.format(
+                    "Loader %s of shown entity container %s must implement %s",
+                    loader, container, InstanceLoader.class.getSimpleName()));
+        }
 
         return (InstanceLoader<E>) loader;
     }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardReadView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardReadView.java
@@ -20,6 +20,8 @@ import com.google.common.base.Strings;
 import com.vaadin.flow.router.BeforeEnterEvent;
 import io.jmix.core.MetadataTools;
 import io.jmix.core.annotation.Internal;
+import io.jmix.core.common.util.Preconditions;
+import io.jmix.core.entity.EntityValues;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.flowui.DialogWindows;
@@ -40,6 +42,8 @@ public class StandardReadView<E> extends StandardView implements ReadView<E> {
 
     public static final String DEFAULT_ROUTE_PARAM = "id";
 
+    @Nullable
+    private E entityToRead;
     @Nullable
     private String serializedEntityIdToRead;
 
@@ -96,13 +100,35 @@ public class StandardReadView<E> extends StandardView implements ReadView<E> {
 
     @Override
     public void setEntityToRead(E entity) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        Preconditions.checkNotNullArgument(entity);
+
+        this.entityToRead = entity;
+        setupEntityToRead(entity);
+    }
+
+    /**
+     * Invoked when the view is opened in a dialog window or when {@link #setEntityToRead(Object)} is called
+     * explicitly. Puts the id of the given instance on the loader, so the shown entity is read through the
+     * view's own fetch plan.
+     *
+     * @param entityToRead entity instance to show
+     */
+    protected void setupEntityToRead(E entityToRead) {
+        Object entityId = EntityValues.getId(entityToRead);
+        if (entityId == null) {
+            throw new IllegalArgumentException(String.format(
+                    "Cannot show an entity with no id in %s. A read view shows a stored entity",
+                    getClass().getName()));
+        }
+
+        getEntityLoader().setEntityId(entityId);
     }
 
     @Nullable
     @Override
     public E getEntityOrNull() {
-        return getEntityContainer().getItemOrNull();
+        E item = getEntityContainer().getItemOrNull();
+        return item != null ? item : entityToRead;
     }
 
     protected InstanceContainer<E> getEntityContainer() {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardReadView.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/StandardReadView.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.view;
+
+import com.vaadin.flow.router.BeforeEnterEvent;
+import io.jmix.core.MetadataTools;
+import io.jmix.core.annotation.Internal;
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.metamodel.model.MetaProperty;
+import io.jmix.flowui.DialogWindows;
+import io.jmix.flowui.ViewNavigators;
+import io.jmix.flowui.model.DataLoader;
+import io.jmix.flowui.model.HasLoader;
+import io.jmix.flowui.model.InstanceContainer;
+import io.jmix.flowui.model.InstanceLoader;
+import io.jmix.flowui.view.navigation.UrlParamSerializer;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Base class of entity read views: views that show an entity instance and cannot edit it.
+ *
+ * @param <E> entity class
+ */
+public class StandardReadView<E> extends StandardView implements ReadView<E> {
+
+    public static final String DEFAULT_ROUTE_PARAM = "id";
+
+    @Nullable
+    private String serializedEntityIdToRead;
+
+    /**
+     * Create views using {@link ViewNavigators} or {@link DialogWindows}.
+     */
+    @Internal
+    public StandardReadView() {
+        addBeforeShowListener(this::onBeforeShow);
+    }
+
+    private void onBeforeShow(BeforeShowEvent event) {
+        setupEntityToRead();
+    }
+
+    @Override
+    public void beforeEnter(BeforeEnterEvent event) {
+        findEntityId(event);
+
+        super.beforeEnter(event);
+    }
+
+    @Internal
+    @Override
+    protected void processBeforeEnterInternal(BeforeEnterEvent event) {
+        super.processBeforeEnterInternal(event);
+
+        findEntityId(event);
+    }
+
+    protected void findEntityId(BeforeEnterEvent event) {
+        String routeParamName = getRouteParamName();
+        serializedEntityIdToRead = event.getRouteParameters().get(routeParamName)
+                .orElseThrow(() ->
+                        new IllegalStateException(String.format("Route parameter '%s' not found",
+                                routeParamName)));
+    }
+
+    protected String getRouteParamName() {
+        return DEFAULT_ROUTE_PARAM;
+    }
+
+    /**
+     * Invoked on {@link BeforeShowEvent}. Sets the entity id on the loader; the load itself is performed
+     * by the {@code dataLoadCoordinator} facet.
+     */
+    protected void setupEntityToRead() {
+        if (serializedEntityIdToRead != null) {
+            Object entityId = getUrlParamSerializer().deserialize(getSerializedIdType(),
+                    serializedEntityIdToRead);
+            getEntityLoader().setEntityId(entityId);
+        }
+    }
+
+    @Override
+    public void setEntityToRead(E entity) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Nullable
+    @Override
+    public E getEntityOrNull() {
+        return getEntityContainer().getItemOrNull();
+    }
+
+    protected InstanceContainer<E> getEntityContainer() {
+        ReadEntityContainer annotation = getClass().getAnnotation(ReadEntityContainer.class);
+        return getViewData().getContainer(annotation.value());
+    }
+
+    @SuppressWarnings("unchecked")
+    protected InstanceLoader<E> getEntityLoader() {
+        InstanceContainer<E> container = getEntityContainer();
+        DataLoader loader = container instanceof HasLoader
+                ? ((HasLoader) container).getLoader()
+                : null;
+
+        return (InstanceLoader<E>) loader;
+    }
+
+    private Class<?> getSerializedIdType() {
+        MetaClass entityMetaClass = getEntityContainer().getEntityMetaClass();
+        MetaProperty primaryKeyProperty = getMetadataTools().getPrimaryKeyProperty(entityMetaClass);
+        if (primaryKeyProperty == null) {
+            throw new IllegalStateException(String.format(
+                    "Entity %s has no primary key", entityMetaClass.getName()));
+        }
+
+        return primaryKeyProperty.getJavaType();
+    }
+
+    private MetadataTools getMetadataTools() {
+        return getApplicationContext().getBean(MetadataTools.class);
+    }
+
+    private UrlParamSerializer getUrlParamSerializer() {
+        return getApplicationContext().getBean(UrlParamSerializer.class);
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ViewControllerUtils.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ViewControllerUtils.java
@@ -418,6 +418,16 @@ public final class ViewControllerUtils {
     }
 
     /**
+     * Returns the route parameter name associated with the given read view.
+     *
+     * @param readView the read view instance from which to retrieve the route parameter name
+     * @return the route parameter name
+     */
+    public static String getRouteParamName(StandardReadView<?> readView) {
+        return readView.getRouteParamName();
+    }
+
+    /**
      * Returns a list of application event listeners associated with a given {@link View}.
      *
      * @param view the {@link View} for which to retrieve the application event listeners

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ViewRegistry.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ViewRegistry.java
@@ -74,6 +74,7 @@ public class ViewRegistry implements ApplicationContextAware {
     public static final String DETAIL_VIEW_SUFFIX = ".detail";
     public static final String LIST_VIEW_SUFFIX = ".list";
     public static final String LOOKUP_VIEW_SUFFIX = ".lookup";
+    public static final String READ_VIEW_SUFFIX = ".read";
 
     protected Metadata metadata;
     protected Resources resources;
@@ -90,6 +91,7 @@ public class ViewRegistry implements ApplicationContextAware {
     protected Map<Class<?>, ViewInfo> primaryDetailViews = new HashMap<>();
     protected Map<Class<?>, ViewInfo> primaryListViews = new HashMap<>();
     protected Map<Class<?>, ViewInfo> primaryLookupViews = new HashMap<>();
+    protected Map<Class<?>, ViewInfo> primaryReadViews = new HashMap<>();
 
     protected List<ViewControllersConfiguration> configurations = Collections.emptyList();
 
@@ -206,6 +208,7 @@ public class ViewRegistry implements ApplicationContextAware {
         primaryDetailViews.clear();
         primaryListViews.clear();
         primaryLookupViews.clear();
+        primaryReadViews.clear();
 
         loadViewConfigurations();
         loadViewTemplateConfigurations();
@@ -285,6 +288,7 @@ public class ViewRegistry implements ApplicationContextAware {
         registerPrimaryDetailView(viewInfo, annotationMetadata);
         registerPrimaryListView(viewInfo, annotationMetadata);
         registerPrimaryLookupView(viewInfo, annotationMetadata);
+        registerPrimaryReadView(viewInfo, annotationMetadata);
 
         views.put(id, viewInfo);
     }
@@ -305,6 +309,12 @@ public class ViewRegistry implements ApplicationContextAware {
         getAnnotationValue(annotationMetadata, PrimaryLookupView.class)
                 .ifPresent(aClass ->
                         primaryLookupViews.put(aClass, viewInfo));
+    }
+
+    protected void registerPrimaryReadView(ViewInfo viewInfo, AnnotationMetadata annotationMetadata) {
+        getAnnotationValue(annotationMetadata, PrimaryReadView.class)
+                .ifPresent(aClass ->
+                        primaryReadViews.put(aClass, viewInfo));
     }
 
     protected Optional<Class<?>> getAnnotationValue(AnnotationMetadata annotationMetadata,
@@ -493,6 +503,56 @@ public class ViewRegistry implements ApplicationContextAware {
     public ViewInfo getDetailViewInfo(Object entity) {
         MetaClass metaClass = metadata.getClass(entity);
         return getDetailViewInfo(metaClass);
+    }
+
+    /**
+     * Returns standard id of the read view for an entity, for example {@code Customer.read}.
+     *
+     * @param metaClass entity metaclass
+     */
+    public String getReadViewId(MetaClass metaClass) {
+        return getMetaClassViewId(metaClass, READ_VIEW_SUFFIX);
+    }
+
+    /**
+     * Returns read view information by entity metaclass.
+     *
+     * @param metaClass entity metaclass
+     * @return view's registration information
+     * @throws NoSuchViewException if no read view is registered for the entity
+     */
+    public ViewInfo getReadViewInfo(MetaClass metaClass) {
+        return getViewInfo(getReadViewIdInternal(metaClass));
+    }
+
+    /**
+     * Returns read view information by entity class.
+     *
+     * @param entityClass entity class
+     * @return view's registration information
+     * @throws NoSuchViewException if no read view is registered for the entity
+     */
+    public ViewInfo getReadViewInfo(Class<?> entityClass) {
+        MetaClass metaClass = metadata.getSession().getClass(entityClass);
+        return getReadViewInfo(metaClass);
+    }
+
+    /**
+     * Returns read view information by entity instance.
+     *
+     * @param entity entity instance
+     * @return view's registration information
+     * @throws NoSuchViewException if no read view is registered for the entity
+     */
+    public ViewInfo getReadViewInfo(Object entity) {
+        MetaClass metaClass = metadata.getClass(entity);
+        return getReadViewInfo(metaClass);
+    }
+
+    protected String getReadViewIdInternal(MetaClass metaClass) {
+        MetaClass originalMetaClass = extendedEntities.getOriginalOrThisMetaClass(metaClass);
+        ViewInfo viewInfo = primaryReadViews.get(originalMetaClass.getJavaClass());
+        return viewInfo != null ? viewInfo.getId() : getReadViewId(metaClass);
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ViewRegistry.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/ViewRegistry.java
@@ -522,7 +522,7 @@ public class ViewRegistry implements ApplicationContextAware {
      * @throws NoSuchViewException if no read view is registered for the entity
      */
     public ViewInfo getReadViewInfo(MetaClass metaClass) {
-        return getViewInfo(getReadViewIdInternal(metaClass));
+        return getViewInfo(getAvailableReadViewId(metaClass));
     }
 
     /**
@@ -658,6 +658,23 @@ public class ViewRegistry implements ApplicationContextAware {
         return hasView(id) ? id : getListViewIdInternal(metaClass);
     }
 
+    /**
+     * Returns read view id by entity metaclass determined by the following procedure:
+     * <ol>
+     *     <li>If a view annotated with @{@link PrimaryReadView} exists, its id is used</li>
+     *     <li>Otherwise, if a view with {@code <entity_name>.read} id exists, its id is used</li>
+     *     <li>Otherwise, if a view annotated with @{@link PrimaryDetailView} exists, its id is used</li>
+     *     <li>Otherwise, a view with {@code <entity_name>.detail} id is used</li>
+     * </ol>
+     *
+     * @param metaClass entity metaclass
+     * @return view's id
+     */
+    public String getAvailableReadViewId(MetaClass metaClass) {
+        String id = getReadViewIdInternal(metaClass);
+        return hasView(id) ? id : getDetailViewIdInternal(metaClass);
+    }
+
 
     protected String getListViewIdInternal(MetaClass metaClass) {
         MetaClass originalMetaClass = extendedEntities.getOriginalOrThisMetaClass(metaClass);
@@ -669,6 +686,12 @@ public class ViewRegistry implements ApplicationContextAware {
         MetaClass originalMetaClass = extendedEntities.getOriginalOrThisMetaClass(metaClass);
         ViewInfo viewInfo = primaryLookupViews.get(originalMetaClass.getJavaClass());
         return viewInfo != null ? viewInfo.getId() : getLookupViewId(metaClass);
+    }
+
+    protected String getDetailViewIdInternal(MetaClass metaClass) {
+        MetaClass originalMetaClass = extendedEntities.getOriginalOrThisMetaClass(metaClass);
+        ViewInfo viewInfo = primaryDetailViews.get(originalMetaClass.getJavaClass());
+        return viewInfo != null ? viewInfo.getId() : getDetailViewId(metaClass);
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowBuilder.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.view.builder;
+
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.HasValue;
+import com.vaadin.flow.component.dialog.Dialog;
+import io.jmix.flowui.component.ListDataComponent;
+import io.jmix.flowui.view.DialogWindow;
+import io.jmix.flowui.view.DialogWindow.AfterCloseEvent;
+import io.jmix.flowui.view.DialogWindow.AfterOpenEvent;
+import io.jmix.flowui.view.ReadView;
+import io.jmix.flowui.view.View;
+import io.jmix.flowui.view.ViewController;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static io.jmix.core.common.util.Preconditions.checkNotNullArgument;
+
+/**
+ * Provides a fluent interface to configure and open a read view in a {@link DialogWindow}.
+ *
+ * @param <E> shown entity type
+ * @param <V> a view type which is opened in a dialog window
+ */
+public class ReadWindowBuilder<E, V extends View<?>> extends AbstractWindowBuilder<V> {
+
+    protected final Class<E> entityClass;
+
+    @Nullable
+    protected E entity;
+
+    @Nullable
+    protected ListDataComponent<E> listDataComponent;
+    @Nullable
+    protected HasValue<?, E> field;
+
+    public ReadWindowBuilder(View<?> origin,
+                             Class<E> entityClass,
+                             Function<? extends ReadWindowBuilder<E, V>, DialogWindow<V>> handler) {
+        super(origin, handler);
+        checkNotNullArgument(entityClass);
+
+        this.entityClass = entityClass;
+    }
+
+    protected ReadWindowBuilder(ReadWindowBuilder<E, V> builder) {
+        super(builder.origin, builder.handler);
+
+        this.entity = builder.entity;
+
+        this.listDataComponent = builder.listDataComponent;
+        this.field = builder.field;
+
+        this.entityClass = builder.entityClass;
+        this.viewId = builder.viewId;
+
+        this.afterOpenListener = builder.afterOpenListener;
+        this.afterCloseListener = builder.afterCloseListener;
+        this.draggedListener = builder.draggedListener;
+        this.resizeListener = builder.resizeListener;
+        this.viewConfigurer = builder.viewConfigurer;
+    }
+
+    /**
+     * Sets the entity instance to show and returns the builder for chaining.
+     *
+     * @param entity entity instance to show
+     * @return this instance for chaining
+     */
+    public ReadWindowBuilder<E, V> readEntity(E entity) {
+        checkNotNullArgument(entity);
+
+        this.entity = entity;
+        return this;
+    }
+
+    /**
+     * Sets the list data component that is updated with the entity after it is saved.
+     * <p>
+     * It matters only if view resolution falls back to a detail view and the user enables editing there:
+     * the saved entity is then set to the component the same way the detail view builder does it.
+     *
+     * @param listDataComponent the list data component to set
+     * @return this instance for chaining
+     */
+    public ReadWindowBuilder<E, V> withListDataComponent(@Nullable ListDataComponent<E> listDataComponent) {
+        this.listDataComponent = listDataComponent;
+        return this;
+    }
+
+    /**
+     * Sets the field that is updated with the entity after it is saved.
+     * <p>
+     * It matters only if view resolution falls back to a detail view and the user enables editing there.
+     *
+     * @param field the field to set
+     * @return this instance for chaining
+     */
+    public ReadWindowBuilder<E, V> withField(@Nullable HasValue<?, E> field) {
+        this.field = field;
+        return this;
+    }
+
+    /**
+     * @return the list data component to update after the entity is saved, or an empty {@link Optional}
+     */
+    public Optional<ListDataComponent<E>> getListDataComponent() {
+        return Optional.ofNullable(listDataComponent);
+    }
+
+    /**
+     * @return the field to update after the entity is saved, or an empty {@link Optional}
+     */
+    public Optional<HasValue<?, E>> getField() {
+        return Optional.ofNullable(field);
+    }
+
+    /**
+     * Sets the opened view class.
+     *
+     * @param viewClass opened view class
+     * @param <T>       view type
+     * @return {@link ReadWindowClassBuilder} instance for chaining
+     */
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    public <T extends View<?> & ReadView<E>> ReadWindowClassBuilder<E, T> withViewClass(Class<T> viewClass) {
+        return new ReadWindowClassBuilder(this, viewClass);
+    }
+
+    /**
+     * Sets identifier of the opened view as specified in the {@link ViewController} annotation.
+     *
+     * @param viewId identifier of the opened view as specified in the {@link ViewController} annotation
+     * @return this instance for chaining
+     */
+    public ReadWindowBuilder<E, V> withViewId(@Nullable String viewId) {
+        this.viewId = viewId;
+        return this;
+    }
+
+    @Override
+    public ReadWindowBuilder<E, V> withAfterOpenListener(@Nullable Consumer<AfterOpenEvent<V>> listener) {
+        super.withAfterOpenListener(listener);
+        return this;
+    }
+
+    @Override
+    public ReadWindowBuilder<E, V> withAfterCloseListener(@Nullable Consumer<AfterCloseEvent<V>> listener) {
+        super.withAfterCloseListener(listener);
+        return this;
+    }
+
+    @Override
+    public ReadWindowBuilder<E, V> withDraggedListener(
+            @Nullable ComponentEventListener<Dialog.DialogDraggedEvent> listener) {
+        super.withDraggedListener(listener);
+        return this;
+    }
+
+    @Override
+    public ReadWindowBuilder<E, V> withResizeListener(
+            @Nullable ComponentEventListener<Dialog.DialogResizeEvent> listener) {
+        super.withResizeListener(listener);
+        return this;
+    }
+
+    @Override
+    public ReadWindowBuilder<E, V> withViewConfigurer(@Nullable Consumer<V> configurer) {
+        super.withViewConfigurer(configurer);
+        return this;
+    }
+
+    /**
+     * @return the class of the shown entity
+     */
+    public Class<E> getEntityClass() {
+        return entityClass;
+    }
+
+    /**
+     * @return the entity instance to show, or an empty {@link Optional} if it is not set
+     */
+    public Optional<E> getEntity() {
+        return Optional.ofNullable(entity);
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowBuilder.java
@@ -17,9 +17,7 @@
 package io.jmix.flowui.view.builder;
 
 import com.vaadin.flow.component.ComponentEventListener;
-import com.vaadin.flow.component.HasValue;
 import com.vaadin.flow.component.dialog.Dialog;
-import io.jmix.flowui.component.ListDataComponent;
 import io.jmix.flowui.view.DialogWindow;
 import io.jmix.flowui.view.DialogWindow.AfterCloseEvent;
 import io.jmix.flowui.view.DialogWindow.AfterOpenEvent;
@@ -47,11 +45,6 @@ public class ReadWindowBuilder<E, V extends View<?>> extends AbstractWindowBuild
     @Nullable
     protected E entity;
 
-    @Nullable
-    protected ListDataComponent<E> listDataComponent;
-    @Nullable
-    protected HasValue<?, E> field;
-
     public ReadWindowBuilder(View<?> origin,
                              Class<E> entityClass,
                              Function<? extends ReadWindowBuilder<E, V>, DialogWindow<V>> handler) {
@@ -65,9 +58,6 @@ public class ReadWindowBuilder<E, V extends View<?>> extends AbstractWindowBuild
         super(builder.origin, builder.handler);
 
         this.entity = builder.entity;
-
-        this.listDataComponent = builder.listDataComponent;
-        this.field = builder.field;
 
         this.entityClass = builder.entityClass;
         this.viewId = builder.viewId;
@@ -90,47 +80,6 @@ public class ReadWindowBuilder<E, V extends View<?>> extends AbstractWindowBuild
 
         this.entity = entity;
         return this;
-    }
-
-    /**
-     * Sets the list data component that is updated with the entity after it is saved.
-     * <p>
-     * It matters only if view resolution falls back to a detail view and the user enables editing there:
-     * the saved entity is then set to the component the same way the detail view builder does it.
-     *
-     * @param listDataComponent the list data component to set
-     * @return this instance for chaining
-     */
-    public ReadWindowBuilder<E, V> withListDataComponent(@Nullable ListDataComponent<E> listDataComponent) {
-        this.listDataComponent = listDataComponent;
-        return this;
-    }
-
-    /**
-     * Sets the field that is updated with the entity after it is saved.
-     * <p>
-     * It matters only if view resolution falls back to a detail view and the user enables editing there.
-     *
-     * @param field the field to set
-     * @return this instance for chaining
-     */
-    public ReadWindowBuilder<E, V> withField(@Nullable HasValue<?, E> field) {
-        this.field = field;
-        return this;
-    }
-
-    /**
-     * @return the list data component to update after the entity is saved, or an empty {@link Optional}
-     */
-    public Optional<ListDataComponent<E>> getListDataComponent() {
-        return Optional.ofNullable(listDataComponent);
-    }
-
-    /**
-     * @return the field to update after the entity is saved, or an empty {@link Optional}
-     */
-    public Optional<HasValue<?, E>> getField() {
-        return Optional.ofNullable(field);
     }
 
     /**

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowBuilderProcessor.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowBuilderProcessor.java
@@ -18,7 +18,6 @@ package io.jmix.flowui.view.builder;
 
 import io.jmix.flowui.Views;
 import io.jmix.flowui.sys.UiAccessChecker;
-import io.jmix.flowui.sys.ViewDescriptorUtils;
 import io.jmix.flowui.view.*;
 import org.springframework.context.ApplicationContext;
 
@@ -30,16 +29,11 @@ import org.springframework.context.ApplicationContext;
  */
 public class ReadWindowBuilderProcessor extends AbstractWindowBuilderProcessor {
 
-    protected DetailWindowBuilderProcessor detailBuilderProcessor;
-
     public ReadWindowBuilderProcessor(ApplicationContext applicationContext,
                                       Views views,
                                       ViewRegistry viewRegistry,
-                                      UiAccessChecker uiAccessChecker,
-                                      DetailWindowBuilderProcessor detailBuilderProcessor) {
+                                      UiAccessChecker uiAccessChecker) {
         super(applicationContext, views, viewRegistry, uiAccessChecker);
-
-        this.detailBuilderProcessor = detailBuilderProcessor;
     }
 
     /**
@@ -51,12 +45,6 @@ public class ReadWindowBuilderProcessor extends AbstractWindowBuilderProcessor {
      * @return built dialog window
      */
     public <E, V extends View<?>> DialogWindow<V> build(ReadWindowBuilder<E, V> builder) {
-        Class<V> viewClass = getViewClass(builder);
-
-        if (!ReadView.class.isAssignableFrom(viewClass)) {
-            return buildFallbackDetailWindow(builder, viewClass);
-        }
-
         V view = createView(builder);
 
         DialogWindow<V> dialog = createDialog(view);
@@ -67,52 +55,25 @@ public class ReadWindowBuilderProcessor extends AbstractWindowBuilderProcessor {
         return dialog;
     }
 
-    /**
-     * Builds a dialog window for a detail view that view resolution returned instead of a read view.
-     * <p>
-     * The window is built by {@link DetailWindowBuilderProcessor}, so the detail view behaves exactly as it
-     * does when opened for editing - in particular, the list data component and the field are updated if
-     * the user enables editing and saves the entity - and then the view is switched to the read-only mode.
-     *
-     * @param builder   builder that provides the shown entity and the dialog configuration
-     * @param viewClass resolved detail view class
-     * @param <E>       shown entity type
-     * @param <V>       view type
-     * @return built dialog window
-     */
-    protected <E, V extends View<?>> DialogWindow<V> buildFallbackDetailWindow(ReadWindowBuilder<E, V> builder,
-                                                                              Class<V> viewClass) {
-        DetailWindowBuilder<E, V> detailBuilder = new DetailWindowBuilder<>(builder.getOrigin(),
-                builder.getEntityClass(), detailBuilderProcessor::build);
-
-        detailBuilder.withViewId(ViewDescriptorUtils.getInferredViewId(viewClass))
-                .editEntity(getEntity(builder));
-
-        builder.getListDataComponent().ifPresent(detailBuilder::withListDataComponent);
-        builder.getField().ifPresent(detailBuilder::withField);
-        builder.getAfterOpenListener().ifPresent(detailBuilder::withAfterOpenListener);
-        builder.getAfterCloseListener().ifPresent(detailBuilder::withAfterCloseListener);
-        builder.getDraggedListener().ifPresent(detailBuilder::withDraggedListener);
-        builder.getResizeListener().ifPresent(detailBuilder::withResizeListener);
-        builder.getViewConfigurer().ifPresent(detailBuilder::withViewConfigurer);
-
-        DialogWindow<V> dialog = detailBuilder.build();
-
-        View<?> view = dialog.getView();
-        if (view instanceof ReadOnlyAwareView readOnlyAwareView) {
-            readOnlyAwareView.setReadOnly(true);
-        } else {
-            throw new IllegalStateException(String.format("%s '%s' does not implement %s: %s",
-                    View.class.getSimpleName(), view.getId().orElse(null),
-                    ReadOnlyAwareView.class.getSimpleName(), view.getClass()));
-        }
-
-        return dialog;
-    }
-
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"unchecked", "rawtypes"})
     protected <E, V extends View<?>> void setupEntity(ReadWindowBuilder<E, V> builder, V view) {
-        ((ReadView<E>) view).setEntityToRead(getEntity(builder));
+        E entity = getEntity(builder);
+
+        if (view instanceof ReadView readView) {
+            readView.setEntityToRead(entity);
+        } else if (view instanceof DetailView detailView) {
+            // View resolution fell back to a detail view, so it must be shown in the read-only mode.
+            detailView.setEntityToEdit(entity);
+
+            if (view instanceof ReadOnlyAwareView readOnlyAwareView) {
+                readOnlyAwareView.setReadOnly(true);
+            }
+        } else {
+            throw new IllegalStateException(String.format("%s '%s' implements neither %s nor %s: %s",
+                    View.class.getSimpleName(), view.getId().orElse(null),
+                    ReadView.class.getSimpleName(), DetailView.class.getSimpleName(),
+                    view.getClass()));
+        }
     }
 
     protected <E, V extends View<?>> E getEntity(ReadWindowBuilder<E, V> builder) {

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowBuilderProcessor.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowBuilderProcessor.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.view.builder;
+
+import io.jmix.flowui.Views;
+import io.jmix.flowui.sys.UiAccessChecker;
+import io.jmix.flowui.sys.ViewDescriptorUtils;
+import io.jmix.flowui.view.*;
+import org.springframework.context.ApplicationContext;
+
+/**
+ * The processor that builds a {@link DialogWindow} showing an entity in a read view.
+ * <p>
+ * If view resolution falls back to a detail view, the entity is set to it and the view is switched
+ * to the read-only mode.
+ */
+public class ReadWindowBuilderProcessor extends AbstractWindowBuilderProcessor {
+
+    protected DetailWindowBuilderProcessor detailBuilderProcessor;
+
+    public ReadWindowBuilderProcessor(ApplicationContext applicationContext,
+                                      Views views,
+                                      ViewRegistry viewRegistry,
+                                      UiAccessChecker uiAccessChecker,
+                                      DetailWindowBuilderProcessor detailBuilderProcessor) {
+        super(applicationContext, views, viewRegistry, uiAccessChecker);
+
+        this.detailBuilderProcessor = detailBuilderProcessor;
+    }
+
+    /**
+     * Builds a dialog window for the given builder.
+     *
+     * @param builder builder that provides the shown entity and the dialog configuration
+     * @param <E>     shown entity type
+     * @param <V>     view type
+     * @return built dialog window
+     */
+    public <E, V extends View<?>> DialogWindow<V> build(ReadWindowBuilder<E, V> builder) {
+        Class<V> viewClass = getViewClass(builder);
+
+        if (!ReadView.class.isAssignableFrom(viewClass)) {
+            return buildFallbackDetailWindow(builder, viewClass);
+        }
+
+        V view = createView(builder);
+
+        DialogWindow<V> dialog = createDialog(view);
+        initDialog(builder, dialog);
+
+        setupEntity(builder, view);
+
+        return dialog;
+    }
+
+    /**
+     * Builds a dialog window for a detail view that view resolution returned instead of a read view.
+     * <p>
+     * The window is built by {@link DetailWindowBuilderProcessor}, so the detail view behaves exactly as it
+     * does when opened for editing - in particular, the list data component and the field are updated if
+     * the user enables editing and saves the entity - and then the view is switched to the read-only mode.
+     *
+     * @param builder   builder that provides the shown entity and the dialog configuration
+     * @param viewClass resolved detail view class
+     * @param <E>       shown entity type
+     * @param <V>       view type
+     * @return built dialog window
+     */
+    protected <E, V extends View<?>> DialogWindow<V> buildFallbackDetailWindow(ReadWindowBuilder<E, V> builder,
+                                                                              Class<V> viewClass) {
+        DetailWindowBuilder<E, V> detailBuilder = new DetailWindowBuilder<>(builder.getOrigin(),
+                builder.getEntityClass(), detailBuilderProcessor::build);
+
+        detailBuilder.withViewId(ViewDescriptorUtils.getInferredViewId(viewClass))
+                .editEntity(getEntity(builder));
+
+        builder.getListDataComponent().ifPresent(detailBuilder::withListDataComponent);
+        builder.getField().ifPresent(detailBuilder::withField);
+        builder.getAfterOpenListener().ifPresent(detailBuilder::withAfterOpenListener);
+        builder.getAfterCloseListener().ifPresent(detailBuilder::withAfterCloseListener);
+        builder.getDraggedListener().ifPresent(detailBuilder::withDraggedListener);
+        builder.getResizeListener().ifPresent(detailBuilder::withResizeListener);
+        builder.getViewConfigurer().ifPresent(detailBuilder::withViewConfigurer);
+
+        DialogWindow<V> dialog = detailBuilder.build();
+
+        View<?> view = dialog.getView();
+        if (view instanceof ReadOnlyAwareView readOnlyAwareView) {
+            readOnlyAwareView.setReadOnly(true);
+        } else {
+            throw new IllegalStateException(String.format("%s '%s' does not implement %s: %s",
+                    View.class.getSimpleName(), view.getId().orElse(null),
+                    ReadOnlyAwareView.class.getSimpleName(), view.getClass()));
+        }
+
+        return dialog;
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <E, V extends View<?>> void setupEntity(ReadWindowBuilder<E, V> builder, V view) {
+        ((ReadView<E>) view).setEntityToRead(getEntity(builder));
+    }
+
+    protected <E, V extends View<?>> E getEntity(ReadWindowBuilder<E, V> builder) {
+        return builder.getEntity().orElseThrow(() -> new IllegalStateException(
+                String.format("Read view of %s cannot be opened, entity is not set",
+                        builder.getEntityClass())));
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    protected <V extends View<?>> Class<V> inferViewClass(DialogWindowBuilder<V> builder) {
+        ReadWindowBuilder<?, V> readBuilder = (ReadWindowBuilder<?, V>) builder;
+
+        Class<?> entityClass = readBuilder.getEntity()
+                .map(Object::getClass)
+                .orElse((Class) readBuilder.getEntityClass());
+
+        return (Class<V>) viewRegistry.getReadViewInfo(entityClass).getControllerClass();
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowClassBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowClassBuilder.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.view.builder;
+
+import com.vaadin.flow.component.ComponentEventListener;
+import com.vaadin.flow.component.dialog.Dialog;
+import io.jmix.flowui.view.DialogWindow;
+import io.jmix.flowui.view.DialogWindow.AfterCloseEvent;
+import io.jmix.flowui.view.DialogWindow.AfterOpenEvent;
+import io.jmix.flowui.view.ReadView;
+import io.jmix.flowui.view.View;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Provides a fluent interface to configure and open a read view with the specific class
+ * in a {@link DialogWindow}.
+ *
+ * @param <E> shown entity type
+ * @param <V> a view type which is opened in a dialog window
+ */
+public class ReadWindowClassBuilder<E, V extends View<?> & ReadView<E>> extends ReadWindowBuilder<E, V>
+        implements DialogWindowClassBuilder<V> {
+
+    protected Class<V> viewClass;
+
+    protected ReadWindowClassBuilder(ReadWindowBuilder<E, V> builder, Class<V> viewClass) {
+        super(builder);
+
+        this.viewClass = viewClass;
+    }
+
+    public ReadWindowClassBuilder(View<?> origin,
+                                  Class<E> entityClass,
+                                  Class<V> viewClass,
+                                  Function<? extends ReadWindowClassBuilder<E, V>, DialogWindow<V>> handler) {
+        super(origin, entityClass, handler);
+
+        this.viewClass = viewClass;
+    }
+
+    @Override
+    public ReadWindowClassBuilder<E, V> readEntity(E entity) {
+        super.readEntity(entity);
+        return this;
+    }
+
+    public ReadWindowClassBuilder<E, V> withViewId(@Nullable String viewId) {
+        this.viewId = viewId;
+        return this;
+    }
+
+    @Override
+    public ReadWindowClassBuilder<E, V> withAfterOpenListener(@Nullable Consumer<AfterOpenEvent<V>> listener) {
+        super.withAfterOpenListener(listener);
+        return this;
+    }
+
+    @Override
+    public ReadWindowClassBuilder<E, V> withAfterCloseListener(@Nullable Consumer<AfterCloseEvent<V>> listener) {
+        super.withAfterCloseListener(listener);
+        return this;
+    }
+
+    @Override
+    public ReadWindowClassBuilder<E, V> withDraggedListener(
+            @Nullable ComponentEventListener<Dialog.DialogDraggedEvent> listener) {
+        super.withDraggedListener(listener);
+        return this;
+    }
+
+    @Override
+    public ReadWindowClassBuilder<E, V> withResizeListener(
+            @Nullable ComponentEventListener<Dialog.DialogResizeEvent> listener) {
+        super.withResizeListener(listener);
+        return this;
+    }
+
+    @Override
+    public ReadWindowClassBuilder<E, V> withViewConfigurer(@Nullable Consumer<V> configurer) {
+        super.withViewConfigurer(configurer);
+        return this;
+    }
+
+    @Override
+    public Optional<Class<V>> getViewClass() {
+        return Optional.of(viewClass);
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowClassBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowClassBuilder.java
@@ -23,6 +23,7 @@ import io.jmix.flowui.view.DialogWindow.AfterCloseEvent;
 import io.jmix.flowui.view.DialogWindow.AfterOpenEvent;
 import io.jmix.flowui.view.ReadView;
 import io.jmix.flowui.view.View;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
@@ -36,6 +37,7 @@ import java.util.function.Function;
  * @param <E> shown entity type
  * @param <V> a view type which is opened in a dialog window
  */
+@NullMarked
 public class ReadWindowClassBuilder<E, V extends View<?> & ReadView<E>> extends ReadWindowBuilder<E, V>
         implements DialogWindowClassBuilder<V> {
 

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowClassBuilder.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/builder/ReadWindowClassBuilder.java
@@ -64,9 +64,9 @@ public class ReadWindowClassBuilder<E, V extends View<?> & ReadView<E>> extends 
         return this;
     }
 
+    @Override
     public ReadWindowClassBuilder<E, V> withViewId(@Nullable String viewId) {
-        this.viewId = viewId;
-        return this;
+        throw new UnsupportedOperationException(getClass().getSimpleName() + " doesn't support 'viewId'");
     }
 
     @Override

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/ReadViewClassNavigator.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/ReadViewClassNavigator.java
@@ -19,6 +19,7 @@ package io.jmix.flowui.view.navigation;
 import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.RouteParameters;
 import io.jmix.flowui.view.View;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Optional;
@@ -32,11 +33,13 @@ import java.util.function.Consumer;
  * @param <E> the type of the entity shown by the view
  * @param <V> the type of the view being navigated to
  */
+@NullMarked
 public class ReadViewClassNavigator<E, V extends View<?>> extends ReadViewNavigator<E>
         implements SupportsAfterViewNavigationHandler<V> {
 
     protected Class<V> viewClass;
 
+    @Nullable
     protected Consumer<AfterViewNavigationEvent<V>> afterNavigationHandler;
 
     public ReadViewClassNavigator(View<?> origin,

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/ReadViewClassNavigator.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/ReadViewClassNavigator.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.view.navigation;
+
+import com.vaadin.flow.router.QueryParameters;
+import com.vaadin.flow.router.RouteParameters;
+import io.jmix.flowui.view.View;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+/**
+ * Facilitates navigation to a read view of a specific type with additional configuration options.
+ * This class extends {@link ReadViewNavigator} to provide the ability to specify a particular view class
+ * and to handle a callback after successful navigation to a view.
+ *
+ * @param <E> the type of the entity shown by the view
+ * @param <V> the type of the view being navigated to
+ */
+public class ReadViewClassNavigator<E, V extends View<?>> extends ReadViewNavigator<E>
+        implements SupportsAfterViewNavigationHandler<V> {
+
+    protected Class<V> viewClass;
+
+    protected Consumer<AfterViewNavigationEvent<V>> afterNavigationHandler;
+
+    public ReadViewClassNavigator(View<?> origin,
+                                  Class<E> entityClass,
+                                  Consumer<? extends ReadViewNavigator<E>> handler,
+                                  Class<V> viewClass) {
+        super(origin, entityClass, handler);
+
+        this.viewClass = viewClass;
+    }
+
+    protected ReadViewClassNavigator(ReadViewNavigator<E> viewNavigator,
+                                     Class<V> viewClass) {
+        super(viewNavigator);
+
+        this.viewClass = viewClass;
+    }
+
+    @Override
+    public ReadViewClassNavigator<E, V> readEntity(E entity) {
+        super.readEntity(entity);
+        return this;
+    }
+
+    @Override
+    public ReadViewClassNavigator<E, V> withViewId(@Nullable String viewId) {
+        throw new UnsupportedOperationException(getClass().getSimpleName() + " doesn't support 'viewId'");
+    }
+
+    @Override
+    public ReadViewClassNavigator<E, V> withRouteParameters(@Nullable RouteParameters routeParameters) {
+        super.withRouteParameters(routeParameters);
+        return this;
+    }
+
+    @Override
+    public ReadViewClassNavigator<E, V> withQueryParameters(@Nullable QueryParameters queryParameters) {
+        super.withQueryParameters(queryParameters);
+        return this;
+    }
+
+    @Override
+    public ReadViewClassNavigator<E, V> withBackwardNavigation(boolean backwardNavigation) {
+        super.withBackwardNavigation(backwardNavigation);
+        return this;
+    }
+
+    /**
+     * Adds a handler that will be invoked if navigation to a view actually happened.
+     * <p>
+     * Note: this handler is invoked after all lifecycle events of a view.
+     * <pre>{@code
+     *     viewNavigators.readView(Foo.class)
+     *         .readEntity(someFoo)
+     *         .withViewClass(FooReadView.class)
+     *         .withAfterNavigationHandler(navigationEvent -> {
+     *             FooReadView view = navigationEvent.getView();
+     *             view.setBar("bar");
+     *         }).navigate();
+     * }</pre>
+     *
+     * @param handler a handler to set
+     * @return this instance for chaining
+     */
+    public ReadViewClassNavigator<E, V> withAfterNavigationHandler(
+            Consumer<AfterViewNavigationEvent<V>> handler) {
+        this.afterNavigationHandler = handler;
+        return this;
+    }
+
+    @Override
+    public Optional<Consumer<AfterViewNavigationEvent<V>>> getAfterNavigationHandler() {
+        return Optional.ofNullable(afterNavigationHandler);
+    }
+
+    @Override
+    public Optional<Class<? extends View>> getViewClass() {
+        return Optional.of(viewClass);
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/ReadViewNavigationProcessor.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/ReadViewNavigationProcessor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.view.navigation;
+
+import com.vaadin.flow.router.RouteParameters;
+import io.jmix.core.entity.EntityValues;
+import io.jmix.flowui.sys.ViewSupport;
+import io.jmix.flowui.view.StandardReadView;
+import io.jmix.flowui.view.View;
+import io.jmix.flowui.view.ViewRegistry;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * The navigation processor implementation that is responsible for processing navigation
+ * to read views using a {@link ReadViewNavigator} instance.
+ */
+public class ReadViewNavigationProcessor extends AbstractNavigationProcessor<ReadViewNavigator<?>> {
+
+    protected RouteSupport routeSupport;
+
+    public ReadViewNavigationProcessor(ViewSupport viewSupport,
+                                       ViewRegistry viewRegistry,
+                                       ViewNavigationSupport navigationSupport,
+                                       RouteSupport routeSupport) {
+        super(viewSupport, viewRegistry, navigationSupport);
+
+        this.routeSupport = routeSupport;
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    protected Class<? extends View> inferViewClass(ReadViewNavigator<?> navigator) {
+        Class<?> entityClass = navigator.getEntity()
+                .map(Object::getClass)
+                .orElse((Class) navigator.getEntityClass());
+
+        return viewRegistry.getReadViewInfo(entityClass).getControllerClass();
+    }
+
+    @Override
+    protected RouteParameters getRouteParameters(ReadViewNavigator<?> navigator) {
+        return navigator.getRouteParameters()
+                .orElseGet(() -> {
+                    Object entity = navigator.getEntity().orElseThrow(() -> new IllegalStateException(
+                            String.format("Read view of %s cannot be opened, entity is not set",
+                                    navigator.getEntityClass())));
+                    Object id = requireNonNull(EntityValues.getId(entity));
+
+                    return routeSupport.createRouteParameters(StandardReadView.DEFAULT_ROUTE_PARAM, id);
+                });
+    }
+
+    @Override
+    protected void fireAfterViewNavigation(ReadViewNavigator<?> navigator, View<?> view) {
+        if (navigator instanceof SupportsAfterViewNavigationHandler<?> handlerSupport
+                && handlerSupport.getAfterNavigationHandler().isPresent()) {
+            super.fireAfterViewNavigation(navigator, view);
+        }
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/ReadViewNavigationProcessor.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/ReadViewNavigationProcessor.java
@@ -16,9 +16,12 @@
 
 package io.jmix.flowui.view.navigation;
 
+import com.vaadin.flow.router.QueryParameters;
 import com.vaadin.flow.router.RouteParameters;
 import io.jmix.core.entity.EntityValues;
 import io.jmix.flowui.sys.ViewSupport;
+import io.jmix.flowui.view.ReadView;
+import io.jmix.flowui.view.StandardDetailView;
 import io.jmix.flowui.view.StandardReadView;
 import io.jmix.flowui.view.View;
 import io.jmix.flowui.view.ViewRegistry;
@@ -63,6 +66,19 @@ public class ReadViewNavigationProcessor extends AbstractNavigationProcessor<Rea
 
                     return routeSupport.createRouteParameters(StandardReadView.DEFAULT_ROUTE_PARAM, id);
                 });
+    }
+
+    @Override
+    protected QueryParameters getQueryParameters(ReadViewNavigator<?> navigator) {
+        QueryParameters queryParameters = super.getQueryParameters(navigator);
+
+        if (!ReadView.class.isAssignableFrom(getViewClass(navigator))) {
+            // View resolution fell back to a detail view, so it must be opened in the read-only mode.
+            return routeSupport.addQueryParameter(queryParameters,
+                    StandardDetailView.MODE_PARAM, StandardDetailView.MODE_READONLY);
+        }
+
+        return queryParameters;
     }
 
     @Override

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/ReadViewNavigator.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/navigation/ReadViewNavigator.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.flowui.view.navigation;
+
+import com.vaadin.flow.router.QueryParameters;
+import com.vaadin.flow.router.RouteParameters;
+import io.jmix.flowui.view.View;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static io.jmix.core.common.util.Preconditions.checkNotNullArgument;
+
+/**
+ * Provides a fluent interface for navigating to a read view of an entity.
+ *
+ * @param <E> the type of the entity shown by the view
+ */
+public class ReadViewNavigator<E> extends AbstractViewNavigator {
+
+    protected final Class<E> entityClass;
+
+    @Nullable
+    protected E entity;
+
+    public ReadViewNavigator(View<?> origin,
+                             Class<E> entityClass,
+                             Consumer<? extends ReadViewNavigator<E>> handler) {
+        super(origin, handler);
+        checkNotNullArgument(entityClass);
+
+        this.entityClass = entityClass;
+    }
+
+    protected ReadViewNavigator(ReadViewNavigator<E> viewNavigator) {
+        super(viewNavigator);
+
+        this.entityClass = viewNavigator.entityClass;
+        this.entity = viewNavigator.entity;
+    }
+
+    /**
+     * Sets the entity instance to show.
+     *
+     * @param entity entity instance to show
+     * @return this instance for chaining
+     */
+    public ReadViewNavigator<E> readEntity(E entity) {
+        checkNotNullArgument(entity);
+
+        this.entity = entity;
+        return this;
+    }
+
+    @Override
+    public ReadViewNavigator<E> withViewId(@Nullable String viewId) {
+        super.withViewId(viewId);
+        return this;
+    }
+
+    /**
+     * Sets the opened view by its class.
+     *
+     * @param viewClass view class
+     * @return this instance for chaining
+     */
+    public <V extends View<?>> ReadViewClassNavigator<E, V> withViewClass(Class<V> viewClass) {
+        return new ReadViewClassNavigator<>(this, viewClass);
+    }
+
+    @Override
+    public ReadViewNavigator<E> withRouteParameters(@Nullable RouteParameters routeParameters) {
+        super.withRouteParameters(routeParameters);
+        return this;
+    }
+
+    @Override
+    public ReadViewNavigator<E> withQueryParameters(@Nullable QueryParameters queryParameters) {
+        super.withQueryParameters(queryParameters);
+        return this;
+    }
+
+    @Override
+    public ReadViewNavigator<E> withBackwardNavigation(boolean backwardNavigation) {
+        super.withBackwardNavigation(backwardNavigation);
+        return this;
+    }
+
+    /**
+     * @return the class of the shown entity
+     */
+    public Class<E> getEntityClass() {
+        return entityClass;
+    }
+
+    /**
+     * @return the entity instance to show, or an empty {@link Optional} if it is not set
+     */
+    public Optional<E> getEntity() {
+        return Optional.ofNullable(entity);
+    }
+}

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/support/DataComponentsLoaderSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/support/DataComponentsLoaderSupport.java
@@ -76,11 +76,41 @@ public class DataComponentsLoaderSupport {
     }
 
     public void load(HasDataComponents dataHolder, Element element) {
-        load(dataHolder, element, null);
+        load(dataHolder, element, null, false);
     }
 
     public void load(HasDataComponents dataHolder, Element element,
                      @Nullable HasDataComponents hostDataHolder) {
+        load(dataHolder, element, hostDataHolder, false);
+    }
+
+    /**
+     * Loads data components declared in the given {@code data} element into the given holder.
+     *
+     * @param dataHolder    holder to load data components into
+     * @param element       {@code data} element
+     * @param forceReadOnly {@code true} to create a read-only data context regardless of the
+     *                      {@code readOnly} attribute of the element
+     */
+    public void load(HasDataComponents dataHolder, Element element, boolean forceReadOnly) {
+        load(dataHolder, element, null, forceReadOnly);
+    }
+
+    /**
+     * Loads data components declared in the given {@code data} element into the given holder.
+     * <p>
+     * If the host data holder has a data context, the loaded holder shares it and {@code forceReadOnly}
+     * has no effect. Otherwise, a new data context is created, and it is read-only if
+     * {@code forceReadOnly} is {@code true} or the element declares the {@code readOnly} attribute.
+     *
+     * @param dataHolder     holder to load data components into
+     * @param element        {@code data} element
+     * @param hostDataHolder host data holder or {@code null} if there is no host
+     * @param forceReadOnly  {@code true} to create a read-only data context regardless of the
+     *                       {@code readOnly} attribute of the element
+     */
+    public void load(HasDataComponents dataHolder, Element element,
+                     @Nullable HasDataComponents hostDataHolder, boolean forceReadOnly) {
         Preconditions.checkNotNullArgument(dataHolder, HasDataComponents.class.getSimpleName() + " is null");
         Preconditions.checkNotNullArgument(element, "Element is null");
 
@@ -90,7 +120,7 @@ public class DataComponentsLoaderSupport {
         if (hostDataContext != null) {
             dataHolder.setDataContext(hostDataContext);
         } else {
-            boolean readOnly = loadReadOnly(element);
+            boolean readOnly = forceReadOnly || loadReadOnly(element);
             DataContext dataContext = readOnly ? new NoopDataContext(applicationContext) : factory.createDataContext();
             dataHolder.setDataContext(dataContext);
         }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/support/ViewLoaderSupport.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/xml/layout/support/ViewLoaderSupport.java
@@ -19,6 +19,7 @@ package io.jmix.flowui.xml.layout.support;
 import io.jmix.flowui.facet.Facet;
 import io.jmix.flowui.kit.action.Action;
 import io.jmix.flowui.model.ViewData;
+import io.jmix.flowui.view.ReadView;
 import io.jmix.flowui.view.View;
 import io.jmix.flowui.view.ViewActions;
 import io.jmix.flowui.view.ViewControllerUtils;
@@ -77,7 +78,7 @@ public class ViewLoaderSupport implements ApplicationContextAware {
         Element dataElement = element.element("data");
         if (dataElement != null) {
             ViewData viewData = ViewControllerUtils.getViewData(view);
-            dataComponentsLoaderSupport.load(viewData, dataElement);
+            dataComponentsLoaderSupport.load(viewData, dataElement, view instanceof ReadView);
             ((ComponentLoaderContext) context).setDataHolder(viewData);
         }
     }

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/messages.properties
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/messages.properties
@@ -39,6 +39,8 @@ actions.valuePicker.dateInterval.description=Open a dialog to select a date inte
 actions.entityPicker.lookup.description=Open a lookup view to select a related entity
 actions.entityPicker.open.description=Open a detail view for a selected related entity
 actions.entityPicker.open.isDeleted=Object has been deleted
+actions.entityPicker.read.description=Open a read view for a selected related entity
+actions.entityPicker.read.isDeleted=Object has been deleted
 actions.multiValuePicker.select.description=Open values selection view
 
 actions.genericFilter.AddCondition=Add

--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/layout.xsd
@@ -1270,6 +1270,7 @@
                     <xs:enumeration value="entity_lookup"/>
                     <xs:enumeration value="entity_open"/>
                     <xs:enumeration value="entity_openComposition"/>
+                    <xs:enumeration value="entity_read"/>
                     <xs:enumeration value="list_create"/>
                     <xs:enumeration value="list_edit"/>
                     <xs:enumeration value="list_remove"/>

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/EntityReadActionTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/EntityReadActionTest.groovy
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.standardreadview
+
+import component.standardreadview.view.CustomerListTestView
+import component.standardreadview.view.CustomerDetailFallbackTestView
+import component.standardreadview.view.OrderListTestView
+import component.standardreadview.view.OrderReadTestView
+import io.jmix.core.DataManager
+import io.jmix.flowui.kit.component.KeyCombination
+import io.jmix.flowui.testassist.UiTestUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import test_support.entity.sales.Customer
+import test_support.entity.sales.Order
+import test_support.spec.FlowuiTestSpecification
+
+@SpringBootTest(properties = 'jmix.ui.component.picker-read-shortcut = Control-Alt-R')
+class EntityReadActionTest extends FlowuiTestSpecification {
+
+    @Autowired
+    DataManager dataManager
+
+    Order order
+
+    @Override
+    void setup() {
+        registerViewBasePackages("component.standardreadview.view")
+
+        order = dataManager.create(Order)
+        order.number = 'order-1'
+        dataManager.save(order)
+    }
+
+    @Override
+    void cleanup() {
+        dataManager.remove(order)
+    }
+
+    def "action opens the read view for the picker value"() {
+        given: "a view with the order set to its picker"
+        def listView = navigateToView(OrderListTestView)
+        listView.orderPicker.setValue(order)
+
+        when: "performing the picker's read action"
+        def action = listView.orderPicker.getAction('read')
+        action.actionPerform(listView.orderPicker)
+
+        then: "the read view is shown in a dialog with the entity loaded"
+        def view = UiTestUtils.getLastOpenedViewDialog()
+        view instanceof OrderReadTestView
+        (view as OrderReadTestView).getEntity().id == order.id
+    }
+
+    def "action opens the fallback detail view read-only"() {
+        given: "a customer, whose only view in this package is a detail view"
+        def customer = dataManager.create(Customer)
+        customer.name = 'customer-1'
+        dataManager.save(customer)
+
+        and: "a view with the customer set to its picker"
+        def listView = navigateToView(CustomerListTestView)
+        listView.customerPicker.setValue(customer)
+
+        when: "performing the picker's read action"
+        def action = listView.customerPicker.getAction('read')
+        action.actionPerform(listView.customerPicker)
+
+        then: "the detail view is shown read-only"
+        def view = UiTestUtils.getLastOpenedViewDialog()
+        view instanceof CustomerDetailFallbackTestView
+        (view as CustomerDetailFallbackTestView).isReadOnly()
+
+        cleanup:
+        dataManager.remove(dataManager.load(Customer).id(customer.id).one())
+    }
+
+    def "action takes its shortcut from the application property"() {
+        given: "a view with a picker declaring the read action"
+        def listView = navigateToView(OrderListTestView)
+
+        expect: "the action carries the configured shortcut"
+        listView.orderPicker.getAction('read').shortcutCombination == KeyCombination.create('Control-Alt-R')
+    }
+
+    def "action does nothing when the picker is empty"() {
+        given: "a view whose picker has no value"
+        def listView = navigateToView(OrderListTestView)
+
+        when: "performing the picker's read action"
+        listView.orderPicker.getAction('read').actionPerform(listView.orderPicker)
+
+        then: "no dialog is opened"
+        UiTestUtils.getOpenedViewDialogs().isEmpty()
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadActionTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadActionTest.groovy
@@ -23,6 +23,7 @@ import component.standardreadview.view.OrderReadTestView
 import io.jmix.core.DataManager
 import io.jmix.flowui.action.list.ReadAction
 import io.jmix.flowui.testassist.UiTestUtils
+import io.jmix.flowui.view.OpenMode
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import test_support.entity.sales.Customer
@@ -81,6 +82,40 @@ class ReadActionTest extends FlowuiTestSpecification {
 
         then: "the detail view is shown in the read-only mode"
         def view = UiTestUtils.getCurrentView()
+        view instanceof CustomerDetailFallbackTestView
+        (view as CustomerDetailFallbackTestView).isReadOnly()
+    }
+
+    def "action opens the read view in a dialog"() {
+        given: "an order selected in the list and the action set to open a dialog"
+        def listView = navigateToView(OrderListTestView)
+        listView.ordersDataGrid.select(listView.ordersDc.getItems().find { it.id == order.id })
+
+        def action = listView.ordersDataGrid.getAction('read') as ReadAction
+        action.setOpenMode(OpenMode.DIALOG)
+
+        when: "the read action is performed"
+        action.actionPerform(listView.ordersDataGrid)
+
+        then: "the read view is shown in a dialog with the entity loaded"
+        def view = UiTestUtils.getLastOpenedViewDialog()
+        view instanceof OrderReadTestView
+        (view as OrderReadTestView).getEntity().id == order.id
+    }
+
+    def "action opens the fallback detail view in a dialog read-only"() {
+        given: "a customer selected in the list and the action set to open a dialog"
+        def listView = navigateToView(CustomerListTestView)
+        listView.customersDataGrid.select(listView.customersDc.getItems().find { it.id == customer.id })
+
+        def action = listView.customersDataGrid.getAction('read') as ReadAction
+        action.setOpenMode(OpenMode.DIALOG)
+
+        when: "the read action is performed"
+        action.actionPerform(listView.customersDataGrid)
+
+        then: "the detail view is shown in a dialog in the read-only mode"
+        def view = UiTestUtils.getLastOpenedViewDialog()
         view instanceof CustomerDetailFallbackTestView
         (view as CustomerDetailFallbackTestView).isReadOnly()
     }

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadActionTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadActionTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.standardreadview
+
+import component.standardreadview.view.CustomerDetailFallbackTestView
+import component.standardreadview.view.CustomerListTestView
+import component.standardreadview.view.OrderListTestView
+import component.standardreadview.view.OrderReadTestView
+import io.jmix.core.DataManager
+import io.jmix.flowui.action.list.ReadAction
+import io.jmix.flowui.testassist.UiTestUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import test_support.entity.sales.Customer
+import test_support.entity.sales.Order
+import test_support.spec.FlowuiTestSpecification
+
+@SpringBootTest
+class ReadActionTest extends FlowuiTestSpecification {
+
+    @Autowired
+    DataManager dataManager
+
+    Order order
+    Customer customer
+
+    @Override
+    void setup() {
+        registerViewBasePackages("component.standardreadview.view")
+
+        order = dataManager.create(Order)
+        order.number = 'order-1'
+        dataManager.save(order)
+
+        customer = dataManager.create(Customer)
+        customer.name = 'customer-1'
+        dataManager.save(customer)
+    }
+
+    @Override
+    void cleanup() {
+        dataManager.remove(order)
+        dataManager.remove(customer)
+    }
+
+    def "action opens the read view when the entity has one"() {
+        given: "an order selected in the list"
+        def listView = navigateToView(OrderListTestView)
+        listView.ordersDataGrid.select(listView.ordersDc.getItems().find { it.id == order.id })
+
+        when: "the read action is performed"
+        listView.ordersDataGrid.getAction('read').actionPerform(listView.ordersDataGrid)
+
+        then: "the read view is shown with the entity loaded"
+        def view = UiTestUtils.getCurrentView()
+        view instanceof OrderReadTestView
+        (view as OrderReadTestView).getEntity().id == order.id
+    }
+
+    def "action opens the detail view read-only when the entity has no read view"() {
+        given: "a customer selected in the list"
+        def listView = navigateToView(CustomerListTestView)
+        listView.customersDataGrid.select(listView.customersDc.getItems().find { it.id == customer.id })
+
+        when: "the read action is performed"
+        listView.customersDataGrid.getAction('read').actionPerform(listView.customersDataGrid)
+
+        then: "the detail view is shown in the read-only mode"
+        def view = UiTestUtils.getCurrentView()
+        view instanceof CustomerDetailFallbackTestView
+        (view as CustomerDetailFallbackTestView).isReadOnly()
+    }
+
+    def "action honors an explicitly configured view class"() {
+        given: "a customer selected in the list and the view class set on the action"
+        def listView = navigateToView(CustomerListTestView)
+        listView.customersDataGrid.select(listView.customersDc.getItems().find { it.id == customer.id })
+
+        def action = listView.customersDataGrid.getAction('read') as ReadAction
+        action.setViewClass(CustomerDetailFallbackTestView)
+
+        when: "the read action is performed"
+        action.actionPerform(listView.customersDataGrid)
+
+        then: "the configured view is opened, read-only as a detail view"
+        def view = UiTestUtils.getCurrentView()
+        view instanceof CustomerDetailFallbackTestView
+        (view as CustomerDetailFallbackTestView).isReadOnly()
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadViewOpeningTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadViewOpeningTest.groovy
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.standardreadview
+
+import component.standardreadview.view.OrderReadTestView
+import component.standardreadview.view.ReadBlankTestView
+import io.jmix.core.DataManager
+import io.jmix.flowui.ViewNavigators
+import io.jmix.flowui.testassist.UiTestUtils
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import test_support.entity.sales.Order
+import test_support.spec.FlowuiTestSpecification
+
+@SpringBootTest
+class ReadViewOpeningTest extends FlowuiTestSpecification {
+
+    @Autowired
+    ViewNavigators navigators
+    @Autowired
+    DataManager dataManager
+
+    Order order
+
+    @Override
+    void setup() {
+        registerViewBasePackages("component.standardreadview.view")
+
+        order = dataManager.create(Order)
+        order.number = 'order-1'
+        dataManager.save(order)
+    }
+
+    @Override
+    void cleanup() {
+        dataManager.remove(order)
+    }
+
+    def "navigator opens the read view resolved for the entity"() {
+        when: "navigating with the read view navigator"
+        def origin = navigateToView(ReadBlankTestView)
+        navigators.readView(origin, Order)
+                .readEntity(order)
+                .navigate()
+
+        then: "the read view is shown with the entity loaded"
+        def view = UiTestUtils.getCurrentView()
+        view instanceof OrderReadTestView
+        (view as OrderReadTestView).getEntity().id == order.id
+    }
+
+    def "navigator requires an entity"() {
+        when: "navigating without an entity"
+        def origin = navigateToView(ReadBlankTestView)
+        navigators.readView(origin, Order).navigate()
+
+        then:
+        thrown(IllegalStateException)
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadViewOpeningTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadViewOpeningTest.groovy
@@ -17,6 +17,7 @@
 package component.standardreadview
 
 import component.standardreadview.view.CustomerDetailFallbackTestView
+import component.standardreadview.view.OrderListTestView
 import component.standardreadview.view.OrderReadTestView
 import component.standardreadview.view.ReadBlankTestView
 import io.jmix.core.DataManager
@@ -121,6 +122,60 @@ class ReadViewOpeningTest extends FlowuiTestSpecification {
 
         cleanup:
         dataManager.remove(customer)
+    }
+
+    def "navigator takes the origin and the entity off a list component"() {
+        given: "a list view with the order selected in its grid"
+        def listView = navigateToView(OrderListTestView)
+        listView.ordersDataGrid.select(listView.ordersDc.getItems().find { it.id == order.id })
+
+        when: "navigating from the grid"
+        navigators.readView(listView.ordersDataGrid).navigate()
+
+        then: "the read view shows the selected entity"
+        def view = UiTestUtils.getCurrentView()
+        view instanceof OrderReadTestView
+        (view as OrderReadTestView).getEntity().id == order.id
+    }
+
+    def "dialog takes the origin and the entity off a list component"() {
+        given: "a list view with the order selected in its grid"
+        def listView = navigateToView(OrderListTestView)
+        listView.ordersDataGrid.select(listView.ordersDc.getItems().find { it.id == order.id })
+
+        when: "opening a dialog from the grid"
+        def dialog = dialogWindows.read(listView.ordersDataGrid).open()
+
+        then: "the read view shows the selected entity"
+        dialog.view instanceof OrderReadTestView
+        (dialog.view as OrderReadTestView).getEntity().id == order.id
+    }
+
+    def "navigator takes the entity off a picker component"() {
+        given: "a view with the order set to its picker"
+        def listView = navigateToView(OrderListTestView)
+        listView.orderPicker.setValue(order)
+
+        when: "navigating from the picker"
+        navigators.readView(listView.orderPicker).navigate()
+
+        then: "the read view shows the picker value"
+        def view = UiTestUtils.getCurrentView()
+        view instanceof OrderReadTestView
+        (view as OrderReadTestView).getEntity().id == order.id
+    }
+
+    def "dialog takes the entity off a picker component"() {
+        given: "a view with the order set to its picker"
+        def listView = navigateToView(OrderListTestView)
+        listView.orderPicker.setValue(order)
+
+        when: "opening a dialog from the picker"
+        def dialog = dialogWindows.read(listView.orderPicker).open()
+
+        then: "the read view shows the picker value"
+        dialog.view instanceof OrderReadTestView
+        (dialog.view as OrderReadTestView).getEntity().id == order.id
     }
 
     def "navigator requires an entity"() {

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadViewOpeningTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadViewOpeningTest.groovy
@@ -16,6 +16,7 @@
 
 package component.standardreadview
 
+import component.standardreadview.view.CustomerDetailFallbackTestView
 import component.standardreadview.view.OrderReadTestView
 import component.standardreadview.view.ReadBlankTestView
 import io.jmix.core.DataManager
@@ -23,6 +24,7 @@ import io.jmix.flowui.ViewNavigators
 import io.jmix.flowui.testassist.UiTestUtils
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import test_support.entity.sales.Customer
 import test_support.entity.sales.Order
 import test_support.spec.FlowuiTestSpecification
 
@@ -61,6 +63,27 @@ class ReadViewOpeningTest extends FlowuiTestSpecification {
         def view = UiTestUtils.getCurrentView()
         view instanceof OrderReadTestView
         (view as OrderReadTestView).getEntity().id == order.id
+    }
+
+    def "navigator falls back to the detail view opened read-only"() {
+        given: "a customer, whose only view in this package is a detail view"
+        def customer = dataManager.create(Customer)
+        customer.name = 'customer-1'
+        dataManager.save(customer)
+
+        when: "navigating with the read view navigator"
+        def origin = navigateToView(ReadBlankTestView)
+        navigators.readView(origin, Customer)
+                .readEntity(customer)
+                .navigate()
+
+        then: "the detail view is shown in read-only mode"
+        def view = UiTestUtils.getCurrentView()
+        view instanceof CustomerDetailFallbackTestView
+        (view as CustomerDetailFallbackTestView).isReadOnly()
+
+        cleanup:
+        dataManager.remove(customer)
     }
 
     def "navigator requires an entity"() {

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadViewOpeningTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadViewOpeningTest.groovy
@@ -20,6 +20,7 @@ import component.standardreadview.view.CustomerDetailFallbackTestView
 import component.standardreadview.view.OrderReadTestView
 import component.standardreadview.view.ReadBlankTestView
 import io.jmix.core.DataManager
+import io.jmix.flowui.DialogWindows
 import io.jmix.flowui.ViewNavigators
 import io.jmix.flowui.testassist.UiTestUtils
 import org.springframework.beans.factory.annotation.Autowired
@@ -33,6 +34,8 @@ class ReadViewOpeningTest extends FlowuiTestSpecification {
 
     @Autowired
     ViewNavigators navigators
+    @Autowired
+    DialogWindows dialogWindows
     @Autowired
     DataManager dataManager
 
@@ -81,6 +84,40 @@ class ReadViewOpeningTest extends FlowuiTestSpecification {
         def view = UiTestUtils.getCurrentView()
         view instanceof CustomerDetailFallbackTestView
         (view as CustomerDetailFallbackTestView).isReadOnly()
+
+        cleanup:
+        dataManager.remove(customer)
+    }
+
+    def "dialog opens the read view resolved for the entity"() {
+        when: "opening the read view in a dialog"
+        def origin = navigateToView(ReadBlankTestView)
+        def dialog = dialogWindows.read(origin, Order)
+                .readEntity(order)
+                .open()
+
+        then: "the read view shows the entity read through the loader"
+        dialog.view instanceof OrderReadTestView
+        (dialog.view as OrderReadTestView).getEntity().id == order.id
+    }
+
+    def "dialog falls back to the detail view opened read-only"() {
+        given: "a customer, whose only view in this package is a detail view"
+        def customer = dataManager.create(Customer)
+        customer.name = 'customer-1'
+        dataManager.save(customer)
+
+        when: "opening it in a dialog with the read builder"
+        def origin = navigateToView(ReadBlankTestView)
+        def dialog = dialogWindows.read(origin, Customer)
+                .readEntity(customer)
+                .open()
+
+        then: "the detail view is shown read-only with the entity set"
+        dialog.view instanceof CustomerDetailFallbackTestView
+        def view = dialog.view as CustomerDetailFallbackTestView
+        view.isReadOnly()
+        view.getEditedEntity().id == customer.id
 
         cleanup:
         dataManager.remove(customer)

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadViewOpeningTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/ReadViewOpeningTest.groovy
@@ -178,6 +178,54 @@ class ReadViewOpeningTest extends FlowuiTestSpecification {
         (dialog.view as OrderReadTestView).getEntity().id == order.id
     }
 
+    def "navigator opens the view given by the view class"() {
+        when: "navigating with an explicitly configured view class"
+        def origin = navigateToView(ReadBlankTestView)
+        navigators.readView(origin, Order)
+                .withViewClass(OrderReadTestView)
+                .readEntity(order)
+                .navigate()
+
+        then: "that view is shown with the entity loaded"
+        def view = UiTestUtils.getCurrentView()
+        view instanceof OrderReadTestView
+        (view as OrderReadTestView).getEntity().id == order.id
+    }
+
+    def "dialog opens the view given by the view class"() {
+        when: "opening a dialog with an explicitly configured view class"
+        def origin = navigateToView(ReadBlankTestView)
+        def dialog = dialogWindows.read(origin, Order)
+                .withViewClass(OrderReadTestView)
+                .readEntity(order)
+                .open()
+
+        then: "that view is shown with the entity loaded"
+        dialog.view instanceof OrderReadTestView
+        (dialog.view as OrderReadTestView).getEntity().id == order.id
+    }
+
+    def "a view id cannot be set on top of a view class"() {
+        given: "an origin view"
+        def origin = navigateToView(ReadBlankTestView)
+
+        when: "setting a view id on the navigator that already has a view class"
+        navigators.readView(origin, Order)
+                .withViewClass(OrderReadTestView)
+                .withViewId('test_Order.read')
+
+        then:
+        thrown(UnsupportedOperationException)
+
+        when: "setting a view id on the dialog builder that already has a view class"
+        dialogWindows.read(origin, Order)
+                .withViewClass(OrderReadTestView)
+                .withViewId('test_Order.read')
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
     def "navigator requires an entity"() {
         when: "navigating without an entity"
         def origin = navigateToView(ReadBlankTestView)

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/StandardReadViewTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/StandardReadViewTest.groovy
@@ -22,7 +22,9 @@ import component.standardreadview.view.OrderReadTestView
 import component.standardreadview.view.ReadBlankTestView
 import io.jmix.core.DataManager
 import io.jmix.flowui.ViewNavigators
+import io.jmix.flowui.model.impl.NoopDataContext
 import io.jmix.flowui.testassist.UiTestUtils
+import io.jmix.flowui.view.ViewControllerUtils
 import io.jmix.flowui.view.navigation.RouteSupport
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -62,6 +64,22 @@ class StandardReadViewTest extends FlowuiTestSpecification {
                 .navigate()
 
         UiTestUtils.getCurrentView() as OrderReadTestView
+    }
+
+    def "read view always gets a read-only data context"() {
+        when: "navigating to a read view whose descriptor does not declare readOnly"
+        def view = navigateToReadView(order.id)
+        def dataContext = ViewControllerUtils.getViewData(view).getDataContext()
+
+        then: "the context is the no-op one"
+        dataContext instanceof NoopDataContext
+
+        when: "an attribute of the shown entity is changed"
+        view.getEntity().number = 'changed'
+
+        then: "nothing is tracked"
+        !dataContext.hasChanges()
+        !dataContext.isModified(view.getEntity())
     }
 
     def "read view without @ReadEntityContainer fails with a meaningful message"() {

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/StandardReadViewTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/StandardReadViewTest.groovy
@@ -16,6 +16,8 @@
 
 package component.standardreadview
 
+import component.standardreadview.view.NoContainerReadTestView
+import component.standardreadview.view.NoLoaderReadTestView
 import component.standardreadview.view.OrderReadTestView
 import component.standardreadview.view.ReadBlankTestView
 import io.jmix.core.DataManager
@@ -60,6 +62,30 @@ class StandardReadViewTest extends FlowuiTestSpecification {
                 .navigate()
 
         UiTestUtils.getCurrentView() as OrderReadTestView
+    }
+
+    def "read view without @ReadEntityContainer fails with a meaningful message"() {
+        when: "navigating to a read view that declares no container"
+        def origin = navigateToView(ReadBlankTestView)
+        navigators.view(origin, NoContainerReadTestView)
+                .withRouteParameters(routeSupport.createRouteParameters('id', order.id))
+                .navigate()
+
+        then: "the failure names the annotation"
+        def e = thrown(IllegalStateException)
+        e.message.contains('ReadEntityContainer')
+    }
+
+    def "read view whose container has no loader fails with a meaningful message"() {
+        when: "navigating to a read view whose container declares no loader"
+        def origin = navigateToView(ReadBlankTestView)
+        navigators.view(origin, NoLoaderReadTestView)
+                .withRouteParameters(routeSupport.createRouteParameters('id', order.id))
+                .navigate()
+
+        then: "the failure names the loader"
+        def e = thrown(IllegalStateException)
+        e.message.contains('Loader')
     }
 
     def "read view loads the entity by the route id"() {

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/StandardReadViewTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/StandardReadViewTest.groovy
@@ -99,8 +99,7 @@ class StandardReadViewTest extends FlowuiTestSpecification {
         dataManager.save(another)
 
         and: "a read view opened on the first one"
-        def first = navigateToReadView(order.id)
-        def firstInstance = first
+        navigateToReadView(order.id)
 
         when: "navigating to the same view with another id"
         def second = navigateToReadView(another.id)

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/StandardReadViewTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/StandardReadViewTest.groovy
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.standardreadview
+
+import component.standardreadview.view.OrderReadTestView
+import component.standardreadview.view.ReadBlankTestView
+import io.jmix.core.DataManager
+import io.jmix.flowui.ViewNavigators
+import io.jmix.flowui.testassist.UiTestUtils
+import io.jmix.flowui.view.navigation.RouteSupport
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import test_support.entity.sales.Order
+import test_support.spec.FlowuiTestSpecification
+
+@SpringBootTest
+class StandardReadViewTest extends FlowuiTestSpecification {
+
+    @Autowired
+    ViewNavigators navigators
+    @Autowired
+    DataManager dataManager
+    @Autowired
+    RouteSupport routeSupport
+
+    Order order
+
+    @Override
+    void setup() {
+        registerViewBasePackages("component.standardreadview.view")
+
+        order = dataManager.create(Order)
+        order.number = 'order-1'
+        dataManager.save(order)
+    }
+
+    @Override
+    void cleanup() {
+        dataManager.remove(order)
+    }
+
+    protected OrderReadTestView navigateToReadView(Object entityId) {
+        def origin = navigateToView(ReadBlankTestView)
+        navigators.view(origin, OrderReadTestView)
+                .withRouteParameters(routeSupport.createRouteParameters('id', entityId))
+                .navigate()
+
+        UiTestUtils.getCurrentView() as OrderReadTestView
+    }
+
+    def "read view loads the entity by the route id"() {
+        when: "navigating to a read view with an entity id in the route"
+        def view = navigateToReadView(order.id)
+
+        then: "the entity is loaded into the container"
+        view.getEntity().id == order.id
+        view.getEntity().number == 'order-1'
+    }
+}

--- a/jmix-flowui/flowui/src/test/groovy/component/standardreadview/StandardReadViewTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/component/standardreadview/StandardReadViewTest.groovy
@@ -21,7 +21,10 @@ import component.standardreadview.view.NoLoaderReadTestView
 import component.standardreadview.view.OrderReadTestView
 import component.standardreadview.view.ReadBlankTestView
 import io.jmix.core.DataManager
+import io.jmix.flowui.DialogWindows
 import io.jmix.flowui.ViewNavigators
+import io.jmix.flowui.component.UiComponentUtils
+import io.jmix.flowui.component.textfield.TypedTextField
 import io.jmix.flowui.model.impl.NoopDataContext
 import io.jmix.flowui.testassist.UiTestUtils
 import io.jmix.flowui.view.ViewControllerUtils
@@ -36,6 +39,8 @@ class StandardReadViewTest extends FlowuiTestSpecification {
 
     @Autowired
     ViewNavigators navigators
+    @Autowired
+    DialogWindows dialogWindows
     @Autowired
     DataManager dataManager
     @Autowired
@@ -64,6 +69,92 @@ class StandardReadViewTest extends FlowuiTestSpecification {
                 .navigate()
 
         UiTestUtils.getCurrentView() as OrderReadTestView
+    }
+
+    def "data-bound components are read-only, unbound ones are untouched"() {
+        when: "navigating to a read view"
+        def view = navigateToReadView(order.id)
+
+        then: "the bound field is read-only and the unbound one is not"
+        (UiComponentUtils.getComponent(view, 'numberField') as TypedTextField).isReadOnly()
+        !(UiComponentUtils.getComponent(view, 'plainField') as TypedTextField).isReadOnly()
+    }
+
+    def "components are read-only when the view is opened in a dialog"() {
+        when: "the read view is opened in a dialog"
+        def origin = navigateToView(ReadBlankTestView)
+        def dialog = dialogWindows.view(origin, OrderReadTestView)
+                .withViewConfigurer { OrderReadTestView it -> it.setEntityToRead(order) }
+                .open()
+        OrderReadTestView view = dialog.view
+
+        then: "the bound field is read-only there as well"
+        (UiComponentUtils.getComponent(view, 'numberField') as TypedTextField).isReadOnly()
+    }
+
+    def "navigating to another id re-reads the entity"() {
+        given: "a second stored order"
+        def another = dataManager.create(Order)
+        another.number = 'order-2'
+        dataManager.save(another)
+
+        and: "a read view opened on the first one"
+        def first = navigateToReadView(order.id)
+        def firstInstance = first
+
+        when: "navigating to the same view with another id"
+        def second = navigateToReadView(another.id)
+
+        then: "the shown entity is the second one"
+        second.getEntity().id == another.id
+        second.getEntity().number == 'order-2'
+
+        cleanup:
+        dataManager.remove(another)
+    }
+
+    def "entity set through setEntityToRead is re-read through the loader"() {
+        given: "an instance whose state differs from the stored one"
+        def detached = dataManager.load(Order).id(order.id).one()
+        detached.number = 'stale'
+
+        when: "the read view is opened in a dialog with that instance"
+        def origin = navigateToView(ReadBlankTestView)
+        def dialog = dialogWindows.view(origin, OrderReadTestView)
+                .withViewConfigurer { OrderReadTestView it -> it.setEntityToRead(detached) }
+                .open()
+        OrderReadTestView view = dialog.view
+
+        then: "the shown entity comes from the loader, not from the passed instance"
+        !view.getEntity().is(detached)
+        view.getEntity().number == 'order-1'
+    }
+
+    def "the passed entity is returned before the load"() {
+        given: "a read view instance that has not been shown yet"
+        def origin = navigateToView(ReadBlankTestView)
+        def dialog = dialogWindows.view(origin, OrderReadTestView).build()
+        OrderReadTestView view = dialog.view
+
+        when: "an entity is passed to it"
+        view.setEntityToRead(order)
+
+        then: "getEntity returns that instance while the container is still empty"
+        view.getEntity().is(order)
+    }
+
+    def "setEntityToRead rejects an entity without an id"() {
+        given: "a read view instance"
+        def origin = navigateToView(ReadBlankTestView)
+        def dialog = dialogWindows.view(origin, OrderReadTestView).build()
+
+        when: "an entity with no id is passed"
+        def unsaved = dataManager.create(Order)
+        unsaved.setId(null)
+        (dialog.view as OrderReadTestView).setEntityToRead(unsaved)
+
+        then:
+        thrown(IllegalArgumentException)
     }
 
     def "read view always gets a read-only data context"() {

--- a/jmix-flowui/flowui/src/test/groovy/view_registry/ViewRegistryTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/view_registry/ViewRegistryTest.groovy
@@ -23,6 +23,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import test_support.entity.Foo
 import test_support.entity.sales.*
 import test_support.spec.FlowuiTestSpecification
+import view_registry.view.address.AddressDetailView
 import view_registry.view.customer.CustomerDetailView
 import view_registry.view.customer.CustomerReadView
 import view_registry.view.customer.CustomerLookupView
@@ -33,6 +34,7 @@ import view_registry.view.product.ProductPrimaryDetailView
 import view_registry.view.product.ProductPrimaryReadView
 import view_registry.view.product.ProductPrimaryLookupView
 import view_registry.view.producttag.ProductTagListView
+import view_registry.view.producttag.ProductTagPrimaryDetailView
 
 @SpringBootTest
 class ViewRegistryTest extends FlowuiTestSpecification {
@@ -154,5 +156,29 @@ class ViewRegistryTest extends FlowuiTestSpecification {
 
         then:
         viewInfo.id == CustomerReadView.VIEW_ID
+    }
+
+    def "read view resolution falls back to @PrimaryDetailView"() {
+        when:
+        def viewInfo = viewRegistry.getReadViewInfo(ProductTag)
+
+        then:
+        viewInfo.id == ProductTagPrimaryDetailView.VIEW_ID
+    }
+
+    def "read view resolution falls back to the detail view id convention"() {
+        when:
+        def viewInfo = viewRegistry.getReadViewInfo(Address)
+
+        then:
+        viewInfo.id == AddressDetailView.VIEW_ID
+    }
+
+    def "no read view and no detail view found"() {
+        when:
+        viewRegistry.getReadViewInfo(Order)
+
+        then:
+        thrown(NoSuchViewException)
     }
 }

--- a/jmix-flowui/flowui/src/test/groovy/view_registry/ViewRegistryTest.groovy
+++ b/jmix-flowui/flowui/src/test/groovy/view_registry/ViewRegistryTest.groovy
@@ -24,11 +24,13 @@ import test_support.entity.Foo
 import test_support.entity.sales.*
 import test_support.spec.FlowuiTestSpecification
 import view_registry.view.customer.CustomerDetailView
+import view_registry.view.customer.CustomerReadView
 import view_registry.view.customer.CustomerLookupView
 import view_registry.view.customer.CustomerPrimaryListView
 import view_registry.view.order.OrderPrimaryListView
 import view_registry.view.product.ProductListView
 import view_registry.view.product.ProductPrimaryDetailView
+import view_registry.view.product.ProductPrimaryReadView
 import view_registry.view.product.ProductPrimaryLookupView
 import view_registry.view.producttag.ProductTagListView
 
@@ -134,5 +136,23 @@ class ViewRegistryTest extends FlowuiTestSpecification {
 
         then:
         thrown(NoSuchViewException)
+    }
+
+    /* Read view */
+
+    def "find read view with @PrimaryReadView"() {
+        when:
+        def viewInfo = viewRegistry.getReadViewInfo(Product)
+
+        then:
+        viewInfo.id == ProductPrimaryReadView.VIEW_ID
+    }
+
+    def "find read view with read view id convention"() {
+        when:
+        def viewInfo = viewRegistry.getReadViewInfo(Customer)
+
+        then:
+        viewInfo.id == CustomerReadView.VIEW_ID
     }
 }

--- a/jmix-flowui/flowui/src/test/java/component/standardreadview/view/CustomerDetailFallbackTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/standardreadview/view/CustomerDetailFallbackTestView.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.standardreadview.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.view.EditedEntityContainer;
+import io.jmix.flowui.view.StandardDetailView;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import test_support.entity.sales.Customer;
+
+// Customer has no read view in this package, so read view resolution falls back to this one.
+@Route(value = "CustomerDetailFallbackTestView/:id")
+@ViewController("test_Customer.detail")
+@ViewDescriptor("customer-detail-fallback-test-view.xml")
+@EditedEntityContainer("customerDc")
+public class CustomerDetailFallbackTestView extends StandardDetailView<Customer> {
+}

--- a/jmix-flowui/flowui/src/test/java/component/standardreadview/view/CustomerListTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/standardreadview/view/CustomerListTestView.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.standardreadview.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.component.grid.DataGrid;
+import io.jmix.flowui.model.CollectionContainer;
+import io.jmix.flowui.view.StandardListView;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import test_support.entity.sales.Customer;
+
+@Route(value = "CustomerListTestView")
+@ViewController("CustomerListTestView")
+@ViewDescriptor("customer-list-test-view.xml")
+public class CustomerListTestView extends StandardListView<Customer> {
+
+    @ViewComponent
+    public CollectionContainer<Customer> customersDc;
+
+    @ViewComponent
+    public DataGrid<Customer> customersDataGrid;
+}

--- a/jmix-flowui/flowui/src/test/java/component/standardreadview/view/CustomerListTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/standardreadview/view/CustomerListTestView.java
@@ -18,6 +18,7 @@ package component.standardreadview.view;
 
 import com.vaadin.flow.router.Route;
 import io.jmix.flowui.component.grid.DataGrid;
+import io.jmix.flowui.component.valuepicker.EntityPicker;
 import io.jmix.flowui.model.CollectionContainer;
 import io.jmix.flowui.view.StandardListView;
 import io.jmix.flowui.view.ViewComponent;
@@ -35,4 +36,7 @@ public class CustomerListTestView extends StandardListView<Customer> {
 
     @ViewComponent
     public DataGrid<Customer> customersDataGrid;
+
+    @ViewComponent
+    public EntityPicker<Customer> customerPicker;
 }

--- a/jmix-flowui/flowui/src/test/java/component/standardreadview/view/NoContainerReadTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/standardreadview/view/NoContainerReadTestView.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.standardreadview.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.view.StandardReadView;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import test_support.entity.sales.Order;
+
+// Declares no @ReadEntityContainer on purpose.
+@Route(value = "NoContainerReadTestView/:id")
+@ViewController("NoContainerReadTestView")
+@ViewDescriptor("no-container-read-test-view.xml")
+public class NoContainerReadTestView extends StandardReadView<Order> {
+}

--- a/jmix-flowui/flowui/src/test/java/component/standardreadview/view/NoLoaderReadTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/standardreadview/view/NoLoaderReadTestView.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.standardreadview.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.view.ReadEntityContainer;
+import io.jmix.flowui.view.StandardReadView;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import test_support.entity.sales.Order;
+
+// The container of this view declares no loader on purpose.
+@Route(value = "NoLoaderReadTestView/:id")
+@ViewController("NoLoaderReadTestView")
+@ViewDescriptor("no-loader-read-test-view.xml")
+@ReadEntityContainer("orderDc")
+public class NoLoaderReadTestView extends StandardReadView<Order> {
+}

--- a/jmix-flowui/flowui/src/test/java/component/standardreadview/view/OrderListTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/standardreadview/view/OrderListTestView.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.standardreadview.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.component.grid.DataGrid;
+import io.jmix.flowui.component.valuepicker.EntityPicker;
+import io.jmix.flowui.model.CollectionContainer;
+import io.jmix.flowui.view.StandardListView;
+import io.jmix.flowui.view.ViewComponent;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import test_support.entity.sales.Order;
+
+@Route(value = "OrderListTestView")
+@ViewController("OrderListTestView")
+@ViewDescriptor("order-list-test-view.xml")
+public class OrderListTestView extends StandardListView<Order> {
+
+    @ViewComponent
+    public CollectionContainer<Order> ordersDc;
+
+    @ViewComponent
+    public DataGrid<Order> ordersDataGrid;
+
+    @ViewComponent
+    public EntityPicker<Order> orderPicker;
+}

--- a/jmix-flowui/flowui/src/test/java/component/standardreadview/view/OrderReadTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/standardreadview/view/OrderReadTestView.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.standardreadview.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.view.ReadEntityContainer;
+import io.jmix.flowui.view.StandardReadView;
+import io.jmix.flowui.view.ViewController;
+import io.jmix.flowui.view.ViewDescriptor;
+import test_support.entity.sales.Order;
+
+@Route(value = "OrderReadTestView/:id")
+@ViewController("OrderReadTestView")
+@ViewDescriptor("order-read-test-view.xml")
+@ReadEntityContainer("orderDc")
+public class OrderReadTestView extends StandardReadView<Order> {
+}

--- a/jmix-flowui/flowui/src/test/java/component/standardreadview/view/OrderReadTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/standardreadview/view/OrderReadTestView.java
@@ -24,7 +24,7 @@ import io.jmix.flowui.view.ViewDescriptor;
 import test_support.entity.sales.Order;
 
 @Route(value = "OrderReadTestView/:id")
-@ViewController("OrderReadTestView")
+@ViewController("test_Order.read")
 @ViewDescriptor("order-read-test-view.xml")
 @ReadEntityContainer("orderDc")
 public class OrderReadTestView extends StandardReadView<Order> {

--- a/jmix-flowui/flowui/src/test/java/component/standardreadview/view/ReadBlankTestView.java
+++ b/jmix-flowui/flowui/src/test/java/component/standardreadview/view/ReadBlankTestView.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package component.standardreadview.view;
+
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.view.StandardView;
+import io.jmix.flowui.view.ViewController;
+
+@Route("ReadBlankTestView")
+@ViewController("ReadBlankTestView")
+public class ReadBlankTestView extends StandardView {
+}

--- a/jmix-flowui/flowui/src/test/java/view_registry/view/address/AddressDetailView.java
+++ b/jmix-flowui/flowui/src/test/java/view_registry/view/address/AddressDetailView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package view_registry.view.address;
+
+import io.jmix.flowui.view.StandardDetailView;
+import io.jmix.flowui.view.ViewController;
+import test_support.entity.sales.Address;
+
+@ViewController(AddressDetailView.VIEW_ID)
+public class AddressDetailView extends StandardDetailView<Address> {
+
+    public static final String VIEW_ID = "test_Address.detail";
+}

--- a/jmix-flowui/flowui/src/test/java/view_registry/view/customer/CustomerReadView.java
+++ b/jmix-flowui/flowui/src/test/java/view_registry/view/customer/CustomerReadView.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package view_registry.view.customer;
+
+import io.jmix.flowui.view.StandardReadView;
+import io.jmix.flowui.view.ViewController;
+import test_support.entity.sales.Customer;
+
+@ViewController(CustomerReadView.VIEW_ID)
+public class CustomerReadView extends StandardReadView<Customer> {
+
+    public static final String VIEW_ID = "test_Customer.read";
+}

--- a/jmix-flowui/flowui/src/test/java/view_registry/view/product/ProductPrimaryReadView.java
+++ b/jmix-flowui/flowui/src/test/java/view_registry/view/product/ProductPrimaryReadView.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package view_registry.view.product;
+
+import io.jmix.flowui.view.PrimaryReadView;
+import io.jmix.flowui.view.StandardReadView;
+import io.jmix.flowui.view.ViewController;
+import test_support.entity.sales.Product;
+
+@PrimaryReadView(Product.class)
+@ViewController(ProductPrimaryReadView.VIEW_ID)
+public class ProductPrimaryReadView extends StandardReadView<Product> {
+
+    public static final String VIEW_ID = "product-primary-read-view";
+}

--- a/jmix-flowui/flowui/src/test/java/view_registry/view/producttag/ProductTagPrimaryDetailView.java
+++ b/jmix-flowui/flowui/src/test/java/view_registry/view/producttag/ProductTagPrimaryDetailView.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package view_registry.view.producttag;
+
+import io.jmix.flowui.view.PrimaryDetailView;
+import io.jmix.flowui.view.StandardDetailView;
+import io.jmix.flowui.view.ViewController;
+import test_support.entity.sales.ProductTag;
+
+@PrimaryDetailView(ProductTag.class)
+@ViewController(ProductTagPrimaryDetailView.VIEW_ID)
+public class ProductTagPrimaryDetailView extends StandardDetailView<ProductTag> {
+
+    public static final String VIEW_ID = "product-tag-primary-detail-view";
+}

--- a/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/customer-detail-fallback-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/customer-detail-fallback-test-view.xml
@@ -1,0 +1,31 @@
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <instance id="customerDc"
+                  class="test_support.entity.sales.Customer">
+            <fetchPlan extends="_base"/>
+            <loader id="customerDl"/>
+        </instance>
+    </data>
+    <facets>
+        <dataLoadCoordinator auto="true"/>
+    </facets>
+    <layout>
+        <textField id="nameField" dataContainer="customerDc" property="name"/>
+    </layout>
+</view>

--- a/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/customer-list-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/customer-list-test-view.xml
@@ -16,12 +16,12 @@
 
 <view xmlns="http://jmix.io/schema/flowui/view">
     <data>
-        <collection id="ordersDc"
-                    class="test_support.entity.sales.Order">
+        <collection id="customersDc"
+                    class="test_support.entity.sales.Customer">
             <fetchPlan extends="_base"/>
-            <loader id="ordersDl" readOnly="true">
+            <loader id="customersDl" readOnly="true">
                 <query>
-                    <![CDATA[select e from test_Order e]]>
+                    <![CDATA[select e from test_Customer e]]>
                 </query>
             </loader>
         </collection>
@@ -30,17 +30,16 @@
         <dataLoadCoordinator auto="true"/>
     </facets>
     <layout>
-        <dataGrid id="ordersDataGrid"
+        <dataGrid id="customersDataGrid"
                   width="100%"
                   minHeight="20em"
-                  dataContainer="ordersDc">
+                  dataContainer="customersDc">
             <actions>
                 <action id="read" type="list_read"/>
             </actions>
             <columns>
-                <column property="number"/>
+                <column property="name"/>
             </columns>
         </dataGrid>
-        <entityPicker id="orderPicker" metaClass="test_Order"/>
     </layout>
 </view>

--- a/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/customer-list-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/customer-list-test-view.xml
@@ -41,5 +41,10 @@
                 <column property="name"/>
             </columns>
         </dataGrid>
+        <entityPicker id="customerPicker" metaClass="test_Customer">
+            <actions>
+                <action id="read" type="entity_read"/>
+            </actions>
+        </entityPicker>
     </layout>
 </view>

--- a/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/no-container-read-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/no-container-read-test-view.xml
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <instance id="orderDc"
+                  class="test_support.entity.sales.Order">
+            <fetchPlan extends="_base"/>
+            <loader id="orderDl"/>
+        </instance>
+    </data>
+    <facets>
+        <dataLoadCoordinator auto="true"/>
+    </facets>
+    <layout/>
+</view>

--- a/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/no-loader-read-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/no-loader-read-test-view.xml
@@ -1,0 +1,25 @@
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <instance id="orderDc"
+                  class="test_support.entity.sales.Order">
+            <fetchPlan extends="_base"/>
+        </instance>
+    </data>
+    <layout/>
+</view>

--- a/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/order-list-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/order-list-test-view.xml
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <collection id="ordersDc"
+                    class="test_support.entity.sales.Order">
+            <fetchPlan extends="_base"/>
+            <loader id="ordersDl" readOnly="true">
+                <query>
+                    <![CDATA[select e from test_Order e]]>
+                </query>
+            </loader>
+        </collection>
+    </data>
+    <facets>
+        <dataLoadCoordinator auto="true"/>
+    </facets>
+    <layout>
+        <dataGrid id="ordersDataGrid"
+                  width="100%"
+                  minHeight="20em"
+                  dataContainer="ordersDc">
+            <columns>
+                <column property="number"/>
+            </columns>
+        </dataGrid>
+        <entityPicker id="orderPicker" metaClass="test_Order"/>
+    </layout>
+</view>

--- a/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/order-list-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/order-list-test-view.xml
@@ -41,6 +41,10 @@
                 <column property="number"/>
             </columns>
         </dataGrid>
-        <entityPicker id="orderPicker" metaClass="test_Order"/>
+        <entityPicker id="orderPicker" metaClass="test_Order">
+            <actions>
+                <action id="read" type="entity_read"/>
+            </actions>
+        </entityPicker>
     </layout>
 </view>

--- a/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/order-read-test-view.xml
+++ b/jmix-flowui/flowui/src/test/resources/component/standardreadview/view/order-read-test-view.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<view xmlns="http://jmix.io/schema/flowui/view">
+    <data>
+        <instance id="orderDc"
+                  class="test_support.entity.sales.Order">
+            <fetchPlan extends="_base"/>
+            <loader id="orderDl"/>
+        </instance>
+    </data>
+    <facets>
+        <dataLoadCoordinator auto="true"/>
+    </facets>
+    <layout>
+        <textField id="numberField" dataContainer="orderDc" property="number"/>
+        <textField id="plainField"/>
+    </layout>
+</view>

--- a/jmix-templates/content/flowui/read-dto/controller.java
+++ b/jmix-templates/content/flowui/read-dto/controller.java
@@ -1,0 +1,24 @@
+package ${packageName};
+
+import ${entity.fqn};<%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%>
+import io.jmix.flowui.view.DefaultMainViewParent;<%} else {%>
+import ${routeLayout.getControllerFqn()};
+<%}%>import com.vaadin.flow.router.Route;
+import io.jmix.core.LoadContext;
+import io.jmix.flowui.view.*;
+
+<%if (classComment) {%>
+${classComment}
+<%}%>@Route(value = "${readRoute}/:${readRouteParam}/read", layout = <%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%> DefaultMainViewParent.class <%} else {%>${routeLayout.getControllerClassName()}.class<%}%>)
+@ViewController(id = "${readId}")
+@ViewDescriptor(path = "${readDescriptorName}.xml")
+@ReadEntityContainer("${dcId}")
+public class ${readControllerName} extends StandardReadView<${entity.className}> {
+<%if (generateDelegates) {%>
+    @Install(to = "${dlId}", target = Target.DATA_LOADER)
+    private ${entity.className} loadDelegate(final LoadContext<${entity.className}> loadContext) {
+        Object id = loadContext.getId();
+        // Here you can load the entity by id from an external storage.
+        return null;
+    }<%}%>
+}

--- a/jmix-templates/content/flowui/read-dto/controller.kt
+++ b/jmix-templates/content/flowui/read-dto/controller.kt
@@ -1,0 +1,25 @@
+package ${packageName}
+
+import ${entity.fqn}<%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%>
+import io.jmix.flowui.view.DefaultMainViewParent<%} else {%>
+import ${routeLayout.getControllerFqn()}<%}%>
+import com.vaadin.flow.router.Route
+import io.jmix.core.LoadContext
+import io.jmix.flowui.view.Target
+import io.jmix.flowui.view.*
+
+<%if (classComment) {%>
+${classComment}
+<%}%>@Route(value = "${readRoute}/:${readRouteParam}/read", layout = <%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%> DefaultMainViewParent::class <%} else {%>${routeLayout.getControllerClassName()}::class<%}%>)
+@ViewController(id = "${api.escapeKotlinDollar(readId)}")
+@ViewDescriptor(path = "${readDescriptorName}.xml")
+@ReadEntityContainer("${dcId}")
+class ${readControllerName} : StandardReadView<${entity.className}>() {
+<%if (generateDelegates) {%>
+    @Install(to = "${dlId}", target = Target.DATA_LOADER)
+    private fun ${dlId}LoadDelegate(loadContext: LoadContext<${entity.className}>): ${entity.className}? {
+        val id = loadContext.id
+        // Here you can load the entity by id from an external storage.
+        return null
+    }<%}%>
+}

--- a/jmix-templates/content/flowui/read-dto/descriptor.xml
+++ b/jmix-templates/content/flowui/read-dto/descriptor.xml
@@ -1,0 +1,46 @@
+<%
+dcId = "${entity.uncapitalizedClassName}Dc"
+dlId = "${entity.uncapitalizedClassName}Dl"
+
+def formXml = api.processSnippet('dto_form.xml',
+        ['entity': entity,
+        'api': api,
+        'dcId': dcId,
+        'formId': 'form',
+        'asideLabelsPosition': asideLabelsPosition])
+%><?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<view xmlns="http://jmix.io/schema/flowui/view"
+      title="${messageKeys['readTitle']}"
+      focusComponent="form">
+    <data>
+        <instance id="${dcId}"
+                  class="${entity.fqn}">
+            <loader id="${dlId}"/>
+        </instance>
+    </data>
+    <facets>
+        <dataLoadCoordinator auto="true"/>
+    </facets>
+    <actions>
+        <action id="closeAction" type="view_close"/>
+    </actions>
+    <%if (readFixedFooter) {%>
+    <layout alignItems="STRETCH"
+            padding="false" spacing="false"
+            expand="contentBox">
+        <vbox id="contentBox" classNames="overflow-auto">
+    <%} else {%>
+    <layout>
+    <%}%>
+        ${formXml}
+        <%if (readFixedFooter) {%>
+        </vbox>
+        <hbox id="readActions"
+              classNames="footer-panel">
+        <%} else {%>
+        <hbox id="readActions">
+        <%}%>
+            <button id="closeButton" action="closeAction"/>
+        </hbox>
+    </layout>
+</view>

--- a/jmix-templates/content/flowui/read-dto/settings.xml
+++ b/jmix-templates/content/flowui/read-dto/settings.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2023 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<template xmlns="http://schemas.haulmont.com/studio/template-settings.xsd"
+          icon="resource://template/template_editor.svg"
+          name="DTO entity read view"
+          order="37">
+    <tags>
+        <tag>ENTITY</tag>
+        <tag>DTO</tag>
+    </tags>
+    <description>
+        <![CDATA[<html>DTO read view with a form and a <i>Close</i> button. The view shows an entity and cannot edit it.</html>]]>
+    </description>
+    <locMessages key="readTitle" expressionKey="${studioUtils.decapitalize(readControllerName)}.title">
+        <message lang="default">
+            <![CDATA[${studioUtils.makeNaturalMessage(entity.className)}]]>
+        </message>
+    </locMessages>
+    <steps>
+        <step name="Entity read view" order="0"/>
+    </steps>
+
+    <property caption="Entity"
+              code="entity"
+              propertyType="ENTITY"
+              required="true"/>
+
+    <property caption="Labels position aside"
+              code="asideLabelsPosition"
+              propertyType="BOOLEAN"
+              preferences="true"/>
+
+    <property caption="Fixed footer"
+              code="readFixedFooter"
+              propertyType="BOOLEAN"
+              preferences="true"/>
+
+    <property caption="Descriptor name"
+              code="readDescriptorName"
+              propertyType="DESCRIPTOR_NAME"
+              sourceName="descriptor"
+              required="true"
+              dynamic="true"
+              advanced="true"
+              valueTemplate="${api.evaluateScript('descriptorFileName.groovy', ['entity': entity])}-read-view">
+        <dependency code="entity"/>
+    </property>
+
+    <property caption="Controller name"
+              code="readControllerName"
+              propertyType="CLASS_NAME"
+              sourceName="controller"
+              required="true"
+              dynamic="true"
+              advanced="true"
+              valueTemplate="${entity.className}ReadView">
+        <dependency code="entity"/>
+    </property>
+
+    <property caption="View Id"
+              code="readId"
+              propertyType="SCREEN_ID"
+              advanced="true"
+              dynamic="true"
+              valueTemplate="${entity.name!=null?entity.name:entity.className}.read"
+              required="true">
+        <dependency code="entity"/>
+    </property>
+
+    <property caption="View route"
+              code="readRoute"
+              propertyType="FLOW_VIEW_ROUTE"
+              advanced="true"
+              dynamic="true"
+              required="true"
+              valueTemplate="${api.pluralForm(entity.uncapitalizedClassName)}">
+        <dependency code="entity"/>
+    </property>
+
+    <property caption="View route parameter"
+              code="readRouteParam"
+              propertyType="STRING"
+              advanced="true"
+              required="true"
+              defaultValue="id"/>
+
+    <property caption="View route layout"
+              code="routeLayout"
+              propertyType="FLOW_VIEW_ROUTE_LAYOUT"
+              visible="false"
+              advanced="true"/>
+
+    <source fileExt="xml"
+            name="descriptor"/>
+    <source fileExt="java"
+            name="controller"/>
+    <source fileExt="kt"
+            name="controller"/>
+</template>

--- a/jmix-templates/content/flowui/read/controller.java
+++ b/jmix-templates/content/flowui/read/controller.java
@@ -1,0 +1,55 @@
+<%
+def dlId="${entity.uncapitalizedClassName}Dl"
+
+private String getRepositoryIdFqn() {
+    try {
+        return repository.getIdFqn()
+    } catch(Exception e) {
+        return "java.util.UUID"
+    }
+}
+
+private String getRepositoryIdClassName() {
+    try {
+        return repository.getIdClassName()
+    } catch(Exception e) {
+        return "UUID"
+    }
+}
+%>
+package ${packageName};
+
+import ${entity.fqn};
+<%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%>
+import io.jmix.flowui.view.DefaultMainViewParent;
+<%} else {%>
+import ${routeLayout.getControllerFqn()};
+<%}%>
+import com.vaadin.flow.router.Route;
+import io.jmix.flowui.view.*;
+<%if (useDataRepositories){%>
+import io.jmix.core.repository.JmixDataRepositoryContext;
+
+import ${repository.getQualifiedName()};
+
+import java.util.Optional;
+import ${getRepositoryIdFqn()};
+
+import org.springframework.beans.factory.annotation.Autowired;
+<%}%>
+<%if (classComment) {%>
+${classComment}
+<%}%>@Route(value = "${readRoute}/:${readRouteParam}/read", layout = <%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%> DefaultMainViewParent.class <%} else {%>${routeLayout.getControllerClassName()}.class<%}%>)
+@ViewController(id = "${readId}")
+@ViewDescriptor(path = "${readDescriptorName}.xml")
+@ReadEntityContainer("${dcId}")
+public class ${readControllerName} extends StandardReadView<${entity.className}> {<%if (useDataRepositories){%>
+
+    @Autowired
+    private ${repository.getQualifiedName()} repository;
+
+    @Install(to = "${dlId}", target = Target.DATA_LOADER, subject = "loadFromRepositoryDelegate")
+    private Optional<${entity.className}> loadDelegate(${getRepositoryIdClassName()} id, JmixDataRepositoryContext context){
+        return repository.findById(id, context);
+    }<%}%>
+}

--- a/jmix-templates/content/flowui/read/controller.kt
+++ b/jmix-templates/content/flowui/read/controller.kt
@@ -1,0 +1,45 @@
+<%
+    def dlId="${entity.uncapitalizedClassName}Dl"
+
+    private String getRepositoryIdFqn() {
+        try {
+            return repository.getIdFqn()
+        } catch(Exception e) {
+            return "java.util.UUID"
+        }
+    }
+
+    private String getRepositoryIdClassName() {
+        try {
+            return repository.getIdClassName()
+        } catch(Exception e) {
+            return "UUID"
+        }
+    }
+%>
+package ${packageName}
+
+import ${entity.fqn}<%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%>
+import io.jmix.flowui.view.DefaultMainViewParent<%} else {%>
+import ${routeLayout.getControllerFqn()}<%}%>
+import com.vaadin.flow.router.Route
+import io.jmix.flowui.view.*
+<%if (useDataRepositories){%>import io.jmix.core.repository.JmixDataRepositoryContext
+import io.jmix.flowui.view.Target
+import ${repository.getQualifiedName()}
+import java.util.Optional
+import ${getRepositoryIdFqn()}
+<%}%>
+<%if (classComment) {%>
+${classComment}
+<%}%>@Route(value = "${readRoute}/:${readRouteParam}/read", layout = <%if (!api.jmixProjectModule.isApplication() || routeLayout == null) {%> DefaultMainViewParent::class <%} else {%>${routeLayout.getControllerClassName()}::class<%}%>)
+@ViewController(id = "${api.escapeKotlinDollar(readId)}")
+@ViewDescriptor(path = "${readDescriptorName}.xml")
+@ReadEntityContainer("${dcId}")
+class ${readControllerName}<%if (useDataRepositories){%>(private val repository: ${repository.getName()})<%}%> : StandardReadView<${entity.className}>() {<%if (useDataRepositories){%>
+
+    @Install(to = "${dlId}", target = Target.DATA_LOADER, subject = "loadFromRepositoryDelegate")
+    private fun loadDelegate(id: ${getRepositoryIdClassName()}, context: JmixDataRepositoryContext): Optional<${entity.className}> {
+        return repository.findById(id, context)
+    }<%}%>
+}

--- a/jmix-templates/content/flowui/read/descriptor.xml
+++ b/jmix-templates/content/flowui/read/descriptor.xml
@@ -1,0 +1,76 @@
+<%
+dcId = "${entity.uncapitalizedClassName}Dc"
+dlId = "${entity.uncapitalizedClassName}Dl"
+def nestedDatasourceProperties = api.evaluateScript('nestedDatasourceProperties.groovy', ['view': readFetchPlan, 'embeddable': false])
+def nestedCollectionDatasourceProperties = api.evaluateScript('nestedCollectionDatasourceProperties.groovy', ['view': readFetchPlan])
+def collectionAttributesTable = []
+nestedCollectionDatasourceProperties.each { prop ->
+    def binding = [
+        'nestedDcProperty': prop,
+        'fetchPlan': readFetchPlan]
+    def tableXml = api.processSnippet('collectionAttributeTable.xml', binding)
+    if (!binding['isError']) {
+        collectionAttributesTable << tableXml
+    }
+}
+def formXml = api.processSnippet('form.xml',
+        ['fetchPlan': readFetchPlan,
+        'api': api,
+        'dcId': dcId,
+        'formId': 'form',
+        'asideLabelsPosition': asideLabelsPosition])
+def optionsDatasourceXml = api.processSnippet('optionsDsSource.xml',
+        ['view': readFetchPlan,
+        'api': api])
+%><?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<view xmlns="http://jmix.io/schema/flowui/view"
+      title="${messageKeys['readTitle']}"
+      focusComponent="form">
+    <data>
+        <instance id="${dcId}"
+                    class="${entity.fqn}"<%if (!entity.isDeepInheritor('com.haulmont.cuba.core.entity.AbstractNotPersistentEntity')) {%> <%if (!is_inline_readFetchPlan) {%>
+                    fetchPlan="${readFetchPlan.name}"<%}%><%}%>> <%if (is_inline_readFetchPlan) {%>
+            ${inline_readFetchPlan}
+                    <%}%><loader id="${dlId}"/>
+        <%
+        nestedDatasourceProperties.each {%>
+        <instance id="${it}Dc" property="${it}"/>
+        <%}
+
+        nestedCollectionDatasourceProperties.each {%>
+            <collection id="${it}Dc" property="${it}"/>
+        <%}
+        %></instance>
+        <%if (optionsDatasourceXml?.trim()) {%>
+            ${optionsDatasourceXml}
+        <%}%>
+    </data>
+    <facets>
+        <dataLoadCoordinator auto="true"/>
+    </facets>
+    <actions>
+        <action id="closeAction" type="view_close"/>
+    </actions>
+    <%if (readFixedFooter) {%>
+    <layout alignItems="STRETCH"
+            padding="false" spacing="false"
+            expand="contentBox">
+        <vbox id="contentBox" classNames="overflow-auto">
+    <%} else {%>
+    <layout>
+    <%}%>
+        ${formXml}
+        <%collectionAttributesTable.each{table ->%>
+            ${table}
+        <%}%>
+        <%if (readFixedFooter) {%>
+        </vbox>
+        <hbox id="readActions"
+              classNames="footer-panel">
+        <%} else {%>
+        <hbox id="readActions">
+        <%}%>
+            <button id="closeButton" action="closeAction"/>
+        </hbox>
+    </layout>
+</view>

--- a/jmix-templates/content/flowui/read/settings.xml
+++ b/jmix-templates/content/flowui/read/settings.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright 2026 Haulmont.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<template xmlns="http://schemas.haulmont.com/studio/template-settings.xsd"
+          icon="resource://template/template_editor.svg"
+          name="Entity read view"
+          order="17">
+    <tags>
+        <tag>ENTITY</tag>
+        <tag>JPA</tag>
+    </tags>
+    <description>
+        <![CDATA[<html>Entity read view with a form and a <i>Close</i> button. The view shows an entity and cannot edit it.</html>]]>
+    </description>
+    <locMessages key="readTitle" expressionKey="${studioUtils.decapitalize(readControllerName)}.title">
+        <message lang="default">
+            <![CDATA[${studioUtils.makeNaturalMessage(entity.className)}]]>
+        </message>
+    </locMessages>
+    <steps>
+        <step name="Entity read view" order="0"/>
+        <step name="Entity read view fetch plan" order="1"
+              description="Read view fetch plan determines entity attributes and associations to be loaded from the database and shown in the view components"/>
+    </steps>
+    <property caption="Entity"
+              code="entity"
+              propertyType="ENTITY"
+              required="true"/>
+
+    <property caption="Use Data Repositories"
+              code="useDataRepositories"
+              propertyType="BOOLEAN"
+              defaultValue="false"
+              advanced="true"/>
+    <property caption="Repository"
+              code="repository"
+              propertyType="DATA_REPOSITORY"
+              advanced="true">
+         <dynamicAttribute name="enabled" source="${useDataRepositories}">
+            <dependency code = "useDataRepositories"/>
+        </dynamicAttribute>
+        <dynamicAttribute name="visible" source="${useDataRepositories}">
+            <dependency code = "useDataRepositories"/>
+        </dynamicAttribute>
+        <dynamicAttribute name="required" source="${useDataRepositories}">
+            <dependency code = "useDataRepositories"/>
+        </dynamicAttribute>
+    </property>
+
+    <property caption="Entity fetch plan"
+              code="readFetchPlan"
+              step="1"
+              propertyType="VIEW_COMPONENT"
+              relatedProperty="entity"
+              required="true"/>
+
+    <property caption="Labels position aside"
+              code="asideLabelsPosition"
+              propertyType="BOOLEAN"
+              preferences="true"/>
+
+    <property caption="Fixed footer"
+              code="readFixedFooter"
+              propertyType="BOOLEAN"
+              preferences="true"/>
+
+    <property caption="Descriptor name"
+              code="readDescriptorName"
+              propertyType="DESCRIPTOR_NAME"
+              sourceName="descriptor"
+              required="true"
+              dynamic="true"
+              advanced="true"
+              valueTemplate="${api.evaluateScript('descriptorFileName.groovy', ['entity': entity])}-read-view">
+        <dependency code="entity"/>
+    </property>
+
+    <property caption="Controller name"
+              code="readControllerName"
+              propertyType="CLASS_NAME"
+              sourceName="controller"
+              required="true"
+              dynamic="true"
+              advanced="true"
+              valueTemplate="${entity.className}ReadView">
+        <dependency code="entity"/>
+    </property>
+
+    <property caption="View Id"
+              code="readId"
+              propertyType="SCREEN_ID"
+              advanced="true"
+              dynamic="true"
+              valueTemplate="${entity.name!=null?entity.name:entity.className}.read"
+              required="true">
+        <dependency code="entity"/>
+    </property>
+
+    <property caption="View route"
+              code="readRoute"
+              propertyType="FLOW_VIEW_ROUTE"
+              advanced="true"
+              dynamic="true"
+              required="true"
+              valueTemplate="${api.pluralForm(entity.uncapitalizedClassName)}">
+        <dependency code="entity"/>
+    </property>
+
+    <property caption="View route parameter"
+              code="readRouteParam"
+              propertyType="STRING"
+              advanced="true"
+              required="true"
+              defaultValue="id"/>
+
+    <property caption="View route layout"
+              code="routeLayout"
+              propertyType="FLOW_VIEW_ROUTE_LAYOUT"
+              visible="false"
+              advanced="true"/>
+
+    <source fileExt="xml"
+            name="descriptor"/>
+    <source fileExt="java"
+            name="controller"/>
+    <source fileExt="kt"
+            name="controller"/>
+</template>

--- a/jmix-translations/content/io/jmix/flowui/messages.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages.properties
@@ -39,6 +39,8 @@ actions.valuePicker.dateInterval.description=Open a dialog to select a date inte
 actions.entityPicker.lookup.description=Open a lookup view to select a related entity
 actions.entityPicker.open.description=Open a detail view for a selected related entity
 actions.entityPicker.open.isDeleted=Object has been deleted
+actions.entityPicker.read.description=Open a read view for a selected related entity
+actions.entityPicker.read.isDeleted=Object has been deleted
 actions.multiValuePicker.select.description=Open values selection view
 
 actions.genericFilter.AddCondition=Add

--- a/jmix-translations/content/io/jmix/flowui/messages_ru.properties
+++ b/jmix-translations/content/io/jmix/flowui/messages_ru.properties
@@ -39,6 +39,8 @@ actions.valuePicker.dateInterval.description=Выбрать временной �
 actions.entityPicker.lookup.description=Открыть экран выбора связанной сущности
 actions.entityPicker.open.description=Открыть экран редактирования выбранной связанной сущности
 actions.entityPicker.open.isDeleted=Объект удалён
+actions.entityPicker.read.description=Открыть экран просмотра выбранной связанной сущности
+actions.entityPicker.read.isDeleted=Объект удалён
 actions.multiValuePicker.select.description=Открыть экран выбора значений
 
 actions.genericFilter.AddCondition=Добавить


### PR DESCRIPTION
# Summary

Added the read view — a view that shows one entity instance and cannot edit it, a sibling of `StandardDetailView` rather than its subclass. It is reachable the same ways a detail view is: by resolution from an entity, from a list or a picker action, by navigation and in a dialog, in plain and tabbed-mode applications, and it is generated by Studio.

### What was done

- Base class and contract in module `flowui`: `ReadView<E>` with `setEntityToRead` / `getEntity`, `StandardReadView<E>` and the `@ReadEntityContainer` annotation naming the instance container. The class guarantees a read-only `DataContext` and read-only data-bound components by construction — descriptors of read views carry no `readOnly` attribute.
- View resolution: the `@PrimaryReadView` annotation and the `<entity>.read` id convention, with a fallback to the entity's detail view opened in read-only mode. `ViewRegistry` gained `getReadViewInfo(...)` and `getAvailableReadViewId(...)`; every entry point shares this single chain.
- Entry points: `ViewNavigators.readView(...)` and `DialogWindows.read(...)`, each taking an explicit entity class, a list component or a picker, plus `ReadViewNavigator` / `ReadWindowBuilder` and their processors.
- Actions: `list_read` (`ReadAction`) now opens the entity's read view when one exists and keeps its previous behavior otherwise; the new `entity_read` (`EntityReadAction`) does the same for `EntityPicker`, so a drill-down from a read view stays read-only. Its shortcut comes from the new `jmix.ui.component.picker-read-shortcut` property.
- Tabbed mode support in the commercial `tabbedmode-flowui` addon: its own read view builder with an adapter over the framework navigator and dialog builder, and replacements for the two framework processors, so all entry points open a read view in a tab instead of navigating to its route.
- Studio: the `Entity read view` and `DTO entity read view` templates in `jmix-templates`, generating the controller, the descriptor with a form over the chosen fetch plan, the `<entity>.read` id and the title message.

### How it works

Opening a read view for an entity resolves the view in one order everywhere: a view annotated `@PrimaryReadView`, otherwise the view registered as `<entity>.read`, otherwise the entity's detail view — which is then opened read-only, so an application that has no read view behaves exactly as before.

The view takes the entity id from its route parameter (or from `setEntityToRead` when opened in a dialog) and loads the instance through its own `InstanceLoader` and fetch plan, so a passed instance is always re-read rather than shown as is. Read-only is enforced in two places the developer cannot forget: the data context created for a read view is a `NoopDataContext`, and on `ReadyEvent` all components bound to a value source become read-only, which also disables actions that adjust themselves on a read-only view. Unbound components and filters are untouched.

Generated views take the route `<plural>/:id/read`, so they do not collide with the detail view's `<plural>/:id`.

### How to use

Generate the view from Studio (`Entity read view`), or write it by hand:

```java
@Route(value = "customers/:id/read", layout = MainView.class)
@ViewController(id = "Customer.read")
@ViewDescriptor(path = "customer-read-view.xml")
@ReadEntityContainer("customerDc")
public class CustomerReadView extends StandardReadView<Customer> {
}
```

Then open it declaratively — `<action id="read" type="list_read"/>` on a data grid, `<action id="read" type="entity_read"/>` on an entity picker (both are offered by the Studio view wizard) — or programmatically with `viewNavigators.readView(this, Customer.class).readEntity(customer).navigate()` or `dialogWindows.read(this, Customer.class).readEntity(customer).open()`.

### Breaking changes

None in signatures. One behavior change worth a release note: `list_read` used to always open the detail view in read-only mode, and now opens a view registered under `<entity>.read` if the application has one. Applications without such a view are unaffected. `UiComponentProperties` gained a constructor parameter for the new shortcut property, which affects only code instantiating that class directly.

### Compatibility

Opt-in: an application sees no change until it adds a read view or a `<entity>.read` view id.
