### PR TITLE
Option to open the detail view in a dialog from a template-generated list view

### DIFF
--- a/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/template/list-view.ftl
+++ b/jmix-flowui/flowui/src/main/resources/io/jmix/flowui/view/template/list-view.ftl
@@ -4,6 +4,18 @@
       title="${viewTitle}"
       focusComponent="dataGrid">
     <#assign properties = templateHelper.getProperties(entityMetaClass, includeProperties![], excludeProperties![])>
+    <#assign detailDialogMode = detailDialogMode!false>
+    <#macro detailAction id type>
+        <#if detailDialogMode>
+                <action id="${id}" type="${type}">
+                    <properties>
+                        <property name="openMode" value="DIALOG"/>
+                    </properties>
+                </action>
+        <#else>
+                <action id="${id}" type="${type}"/>
+        </#if>
+    </#macro>
     <data>
         <collection id="entityDc"
                     class="${entityMetaClass.javaClass.name}">
@@ -50,8 +62,8 @@
                   minHeight="20em"
                   dataContainer="entityDc">
             <actions>
-                <action id="createAction" type="list_create"/>
-                <action id="editAction" type="list_edit"/>
+                <@detailAction id="createAction" type="list_create"/>
+                <@detailAction id="editAction" type="list_edit"/>
                 <action id="removeAction" type="list_remove"/>
             </actions>
             <columns resizable="true">

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateDialogModeEntity.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateDialogModeEntity.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity.viewtemplate;
+
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.flowui.view.template.DetailViewTemplate;
+import io.jmix.flowui.view.template.ListViewTemplate;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import test_support.entity.TestBaseEntity;
+
+/**
+ * Test entity used to verify that the standard list template opens the detail view in a dialog.
+ */
+@JmixEntity
+@Table(name = "TEST_VIEW_TEMPLATE_DIALOG_MODE")
+@Entity(name = "test_ViewTemplateDialogModeEntity")
+@ListViewTemplate(
+        templateParams = """
+                {"detailDialogMode":true}
+                """
+)
+@DetailViewTemplate
+public class ViewTemplateDialogModeEntity extends TestBaseEntity {
+
+    @Column(name = "NAME")
+    protected String name;
+
+    /**
+     * @return entity name
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Sets the entity name.
+     *
+     * @param name entity name
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jmix-flowui/flowui/src/test/java/view_template/ViewTemplateIntegrationTest.java
+++ b/jmix-flowui/flowui/src/test/java/view_template/ViewTemplateIntegrationTest.java
@@ -27,6 +27,8 @@ import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.flowui.Views;
 import io.jmix.flowui.ViewNavigators;
 import io.jmix.flowui.component.UiComponentUtils;
+import io.jmix.flowui.action.list.CreateAction;
+import io.jmix.flowui.action.list.EditAction;
 import io.jmix.flowui.component.grid.DataGrid;
 import io.jmix.flowui.menu.MenuConfig;
 import io.jmix.flowui.menu.MenuItem;
@@ -36,6 +38,7 @@ import io.jmix.flowui.testassist.FlowuiTestAssistConfiguration;
 import io.jmix.flowui.testassist.UiTest;
 import io.jmix.flowui.testassist.UiTestUtils;
 import io.jmix.flowui.view.ViewControllerUtils;
+import io.jmix.flowui.view.OpenMode;
 import io.jmix.flowui.view.StandardDetailView;
 import io.jmix.flowui.view.View;
 import io.jmix.flowui.view.ViewInfo;
@@ -77,6 +80,7 @@ public class ViewTemplateIntegrationTest {
     protected static final String PARAMS_VIEW_ID = "test_ViewTemplateParamsEntity.browse";
     protected static final String FILTERED_LIST_VIEW_ID = "test_ViewTemplateFilteringEntity.list";
     protected static final String FILTERED_DETAIL_VIEW_ID = "test_ViewTemplateFilteringEntity.edit";
+    protected static final String DIALOG_MODE_LIST_VIEW_ID = "test_ViewTemplateDialogModeEntity.list";
     protected static final String BINDINGS_LIST_VIEW_ID = "test_ViewTemplateBindingsEntity.list";
     protected static final String BINDINGS_DETAIL_VIEW_ID = "test_ViewTemplateBindingsEntity.detail";
     protected static final String MASTER_DETAIL_VIEW_ID = "test_ViewTemplateMasterEntity.detail";
@@ -285,6 +289,42 @@ public class ViewTemplateIntegrationTest {
         assertFalse(detailDescriptor.contains("id=\"systemValueField\""));
         assertFalse(detailDescriptor.contains("id=\"addressField\""));
         assertFalse(detailDescriptor.contains("id=\"tagsField\""));
+    }
+
+    @Test
+    void testListTemplateOpensDetailInDialogWhenDialogModeParamIsSet() {
+        String listDescriptor = getDescriptor(DIALOG_MODE_LIST_VIEW_ID);
+
+        assertTrue(listDescriptor.contains("<property name=\"openMode\" value=\"DIALOG\"/>"));
+
+        View<?> view = views.create(DIALOG_MODE_LIST_VIEW_ID);
+        DataGrid<?> dataGrid = (DataGrid<?>) UiComponentUtils.getComponent(view, "dataGrid");
+
+        CreateAction<?> createAction = (CreateAction<?>) dataGrid.getAction("createAction");
+        EditAction<?> editAction = (EditAction<?>) dataGrid.getAction("editAction");
+
+        assertNotNull(createAction);
+        assertNotNull(editAction);
+        assertEquals(OpenMode.DIALOG, createAction.getOpenMode());
+        assertEquals(OpenMode.DIALOG, editAction.getOpenMode());
+    }
+
+    @Test
+    void testListTemplateKeepsDefaultOpenModeWithoutDialogModeParam() {
+        String listDescriptor = getDescriptor(LIST_VIEW_ID);
+
+        assertFalse(listDescriptor.contains("openMode"));
+
+        View<?> view = views.create(LIST_VIEW_ID);
+        DataGrid<?> dataGrid = (DataGrid<?>) UiComponentUtils.getComponent(view, "dataGrid");
+
+        CreateAction<?> createAction = (CreateAction<?>) dataGrid.getAction("createAction");
+        EditAction<?> editAction = (EditAction<?>) dataGrid.getAction("editAction");
+
+        assertNotNull(createAction);
+        assertNotNull(editAction);
+        assertNull(createAction.getOpenMode());
+        assertNull(editAction.getOpenMode());
     }
 
     @Test


### PR DESCRIPTION
### Summary

The standard list-view template can now generate `list_create` and `list_edit` actions that open the detail view in a dialog instead of navigating to it. The option is opt-in; template-generated views that don't set it are unchanged.

### What was done

- Added a `detailDialogMode` boolean parameter to the standard list template (`io/jmix/flowui/view/template/list-view.ftl`, module `flowui`), passed through the `templateParams` attribute of `@ListViewTemplate`.
- When the parameter is `true`, the generated `list_create` and `list_edit` actions get `openMode` set to `DIALOG`. The `list_remove` action is unaffected.

### How to use

Set the parameter in the `templateParams` attribute of the annotation:

```java
@ListViewTemplate(
        templateParams = """
                {"detailDialogMode":true}
                """
)
public class Customer {
```