### PR TITLE
Menu icon for template-generated views

### DIFF
--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/menu/MenuConfig.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/menu/MenuConfig.java
@@ -23,6 +23,7 @@ import io.jmix.core.common.xmlparsing.Dom4jTools;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.flowui.UiProperties;
+import io.jmix.flowui.icon.Icons;
 import io.jmix.flowui.kit.component.KeyCombination;
 import io.jmix.flowui.menu.MenuItem.MenuItemParameter;
 import io.jmix.flowui.menu.MenuItem.MenuItemProperty;
@@ -90,6 +91,9 @@ public class MenuConfig {
 
     @Autowired
     protected ViewTemplateDefinitions viewTemplateDefinitions;
+
+    @Autowired
+    protected Icons icons;
 
     @Autowired
     protected ObjectProvider<MenuConfigCustomizer> menuConfigCustomizerProvider;
@@ -305,6 +309,7 @@ public class MenuConfig {
         MenuItem viewItem = new MenuItem(parentItem, definition.getId());
         viewItem.setView(definition.getId());
         viewItem.setTitle(definition.getTitle());
+        loadTemplateMenuItemIcon(definition, viewItem);
 
         if (definition.getType() == ViewTemplateType.DETAIL) {
             viewItem.setRouteParameters(List.of(new MenuItemParameter(
@@ -312,6 +317,20 @@ public class MenuConfig {
         }
 
         return viewItem;
+    }
+
+    protected void loadTemplateMenuItemIcon(ViewTemplateDefinition definition, MenuItem viewItem) {
+        String menuIcon = definition.getMenuIcon();
+        if (StringUtils.isBlank(menuIcon)) {
+            return;
+        }
+
+        try {
+            viewItem.setIcon(icons.get(menuIcon));
+        } catch (Exception e) {
+            log.warn("Cannot resolve menu icon '{}' defined for view template '{}', the icon is ignored",
+                    menuIcon, definition.getId(), e);
+        }
     }
 
     @Nullable

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/DetailViewTemplate.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/DetailViewTemplate.java
@@ -48,6 +48,15 @@ public @interface DetailViewTemplate {
     String parentMenu() default "";
 
     /**
+     * Menu item icon. Accepted values are described in the documentation on default icons,
+     * for example {@code "vaadin:table"} or {@code "TABLE"}.
+     * <p>
+     * If empty, the menu item has no icon. The value is ignored if {@code parentMenu} is empty.
+     * If the value cannot be resolved to an icon, it is ignored and a warning is logged.
+     */
+    String menuIcon() default "";
+
+    /**
      * View id. If empty, the framework uses {@code <entityName>.detail}.
      */
     String viewId() default "";

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/ListViewTemplate.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/ListViewTemplate.java
@@ -48,6 +48,15 @@ public @interface ListViewTemplate {
     String parentMenu() default "";
 
     /**
+     * Menu item icon. Accepted values are described in the documentation on default icons,
+     * for example {@code "vaadin:table"} or {@code "TABLE"}.
+     * <p>
+     * If empty, the menu item has no icon. The value is ignored if {@code parentMenu} is empty.
+     * If the value cannot be resolved to an icon, it is ignored and a warning is logged.
+     */
+    String menuIcon() default "";
+
+    /**
      * View id. If empty, the framework uses {@code <entityName>.list}.
      */
     String viewId() default "";

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/impl/ViewTemplateDefinition.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/impl/ViewTemplateDefinition.java
@@ -32,6 +32,7 @@ public class ViewTemplateDefinition {
     protected Class<? extends View<?>> controllerClass;
     protected String title;
     protected String parentMenu;
+    protected String menuIcon;
 
     /**
      * Creates a template view definition.
@@ -44,6 +45,7 @@ public class ViewTemplateDefinition {
      * @param controllerClass generated controller class
      * @param title          resolved view title
      * @param parentMenu     parent menu item id or an empty string
+     * @param menuIcon       menu item icon id or an empty string
      */
     public ViewTemplateDefinition(String id,
                                   ViewTemplateType type,
@@ -52,7 +54,8 @@ public class ViewTemplateDefinition {
                                   String routePath,
                                   Class<? extends View<?>> controllerClass,
                                   String title,
-                                  String parentMenu) {
+                                  String parentMenu,
+                                  String menuIcon) {
         this.id = id;
         this.type = type;
         this.entityMetaClass = entityMetaClass;
@@ -61,6 +64,7 @@ public class ViewTemplateDefinition {
         this.controllerClass = controllerClass;
         this.title = title;
         this.parentMenu = parentMenu;
+        this.menuIcon = menuIcon;
     }
 
     /**
@@ -117,5 +121,12 @@ public class ViewTemplateDefinition {
      */
     public String getParentMenu() {
         return parentMenu;
+    }
+
+    /**
+     * @return menu item icon id or an empty string if the menu item should have no icon
+     */
+    public String getMenuIcon() {
+        return menuIcon;
     }
 }

--- a/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/impl/ViewTemplateDefinitions.java
+++ b/jmix-flowui/flowui/src/main/java/io/jmix/flowui/view/template/impl/ViewTemplateDefinitions.java
@@ -219,7 +219,8 @@ public class ViewTemplateDefinitions {
                 routePath,
                 controllerClass,
                 title,
-                getStringAttribute(attributes, "parentMenu")
+                getStringAttribute(attributes, "parentMenu"),
+                getStringAttribute(attributes, "menuIcon")
         );
     }
 

--- a/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateTestEntity.java
+++ b/jmix-flowui/flowui/src/test/java/test_support/entity/viewtemplate/ViewTemplateTestEntity.java
@@ -32,10 +32,12 @@ import test_support.entity.TestBaseEntity;
 @Entity(name = "test_ViewTemplateEntity")
 @ListViewTemplate(
         parentMenu = "templateViews",
+        menuIcon = "vaadin:table",
         viewRoute = "templates/view-template/list"
 )
 @DetailViewTemplate(
         parentMenu = "templateViews",
+        menuIcon = "PENCIL",
         viewId = "test_ViewTemplateEntity.edit",
         viewTitle = "Template entity editor",
         viewRoute = "templates/view-template/detail"

--- a/jmix-flowui/flowui/src/test/java/view_template/ViewTemplateIntegrationTest.java
+++ b/jmix-flowui/flowui/src/test/java/view_template/ViewTemplateIntegrationTest.java
@@ -18,14 +18,16 @@ package view_template;
 
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.icon.FontIcon;
+import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteConfiguration;
 import com.vaadin.flow.router.RouteParameters;
 import io.jmix.core.DataManager;
 import io.jmix.core.Metadata;
 import io.jmix.core.metamodel.model.MetaClass;
-import io.jmix.flowui.Views;
 import io.jmix.flowui.ViewNavigators;
+import io.jmix.flowui.Views;
 import io.jmix.flowui.component.UiComponentUtils;
 import io.jmix.flowui.component.grid.DataGrid;
 import io.jmix.flowui.menu.MenuConfig;
@@ -35,13 +37,7 @@ import io.jmix.flowui.model.InstanceContainer;
 import io.jmix.flowui.testassist.FlowuiTestAssistConfiguration;
 import io.jmix.flowui.testassist.UiTest;
 import io.jmix.flowui.testassist.UiTestUtils;
-import io.jmix.flowui.view.ViewControllerUtils;
-import io.jmix.flowui.view.StandardDetailView;
-import io.jmix.flowui.view.View;
-import io.jmix.flowui.view.ViewInfo;
-import io.jmix.flowui.view.ViewController;
-import io.jmix.flowui.view.ViewDescriptor;
-import io.jmix.flowui.view.ViewRegistry;
+import io.jmix.flowui.view.*;
 import io.jmix.flowui.view.navigation.ViewNavigationSupport;
 import io.jmix.flowui.view.template.impl.TemplateDetailView;
 import io.jmix.flowui.view.template.impl.TemplateListView;
@@ -54,7 +50,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 import test_support.FlowuiTestConfiguration;
 import test_support.entity.viewtemplate.ViewTemplateBindingsEntity;
 import test_support.entity.viewtemplate.ViewTemplateFilteringEntity;
-import test_support.entity.viewtemplate.ViewTemplateLookupEntity;
 import test_support.entity.viewtemplate.ViewTemplateParamsEntity;
 import test_support.entity.viewtemplate.ViewTemplateTestEntity;
 
@@ -186,6 +181,33 @@ public class ViewTemplateIntegrationTest {
         assertEquals(DETAIL_VIEW_ID, detailItem.getView());
         assertEquals("Template entity editor", detailItem.getTitle());
         assertTrue(detailItem.getUrlQueryParameters().isEmpty());
+    }
+
+    @Test
+    void testMenuIconAppliedToTemplateMenuItems() {
+        MenuItem parentItem = findTemplateViewsRootItem().orElseThrow();
+
+        MenuItem listItem = findChildItem(parentItem, LIST_VIEW_ID).orElseThrow();
+        Component listIcon = listItem.getIcon();
+        assertInstanceOf(Icon.class, listIcon);
+        assertEquals("vaadin:table", listIcon.getElement().getAttribute("icon"));
+
+        // A name without the collection prefix is resolved through the predefined icon sets
+        MenuItem detailItem = findChildItem(parentItem, DETAIL_VIEW_ID).orElseThrow();
+        Component detailIcon = detailItem.getIcon();
+        assertInstanceOf(FontIcon.class, detailIcon);
+        assertTrue(List.of(((FontIcon) detailIcon).getIconClassNames()).contains("jmix-font-icon-pencil"));
+    }
+
+    @Test
+    void testMenuIconIsNotAppliedToParentMenuItem() {
+        assertNull(findTemplateViewsRootItem().orElseThrow().getIcon());
+    }
+
+    @Test
+    void testMenuItemHasNoIconWhenMenuIconIsNotSpecified() {
+        MenuItem listItem = findMenuItemByView(MSG_TITLE_LIST_VIEW_ID).orElseThrow();
+        assertNull(listItem.getIcon());
     }
 
     @Test


### PR DESCRIPTION
Closes jmix-framework/jmix#5665

### Summary

`@ListViewTemplate` and `@DetailViewTemplate` now accept a `menuIcon` parameter, so a menu item generated from a view template can have an icon like any item defined in `menu.xml`. The parameter is opt-in and existing applications are unaffected.

### What was done

- Added `String menuIcon() default ""` to `@ListViewTemplate` and `@DetailViewTemplate` (module `flowui`).
- `MenuConfig` resolves the value through the `Icons` bean and sets the resulting component as the icon of the menu item created for the template. If the value cannot be resolved, the icon is skipped and a warning is logged, so a mistake in one annotation does not break the rest of the menu.
- The icon applies only to the view's own menu item. A parent menu item that `MenuConfig` creates because `parentMenu` names a non-existing item stays without an icon.

### How it works

The value is passed through to the view template definition and resolved when `MenuConfig` builds the menu. Accepted values are the same icon ids used elsewhere in the framework (see https://docs.jmix.io/jmix/flow-ui/icons/default-icons.html): a collection-prefixed id such as `vaadin:table` produces a Vaadin `Icon`, and a bare name such as `PENCIL` is resolved through the predefined icon sets. `JmixListMenu` and `HorizontalMenu` already render `MenuItem.getIcon()`, so no rendering changes were needed.

When `menuIcon` is empty the item has no icon, as before. When `parentMenu` is empty no menu item is created at all and the value is ignored.

### How to use

```java
@JmixEntity
@Entity(name = "sample_Customer")
@ListViewTemplate(
        parentMenu = "application",
        menuIcon = "vaadin:table"
)
public class Customer {
    // ...
}
```

### Breaking changes

The `ViewTemplateDefinition` constructor gained a `menuIcon` parameter. The class is in an `impl` package and the whole view template API is `@Experimental`, so no released public API is affected.

### Test plan

Manually: add `menuIcon` to a template annotation on an entity and check that the icon appears on the generated menu item; set an invalid value and check that the application starts, the menu loads, and a warning is logged.
