### PR TITLE
Show dynamic model entities and attributes in Data Tools views

### DIFF
--- a/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/datamodel/DataModelListView.java
+++ b/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/datamodel/DataModelListView.java
@@ -75,6 +75,8 @@ public class DataModelListView extends StandardView {
     @ViewComponent
     protected DataGrid<EntityModel> entityModelsDataGrid;
     @ViewComponent
+    protected DataGrid<AttributeModel> attributeModelsDataGrid;
+    @ViewComponent
     protected JmixCheckbox showSystemCheckBox;
     @ViewComponent
     protected TypedTextField<String> entityFilter;
@@ -118,7 +120,26 @@ public class DataModelListView extends StandardView {
         urlQueryParametersFacet.registerBinder(new EntityNameUrlQueryParametersBinder());
         initDataStoreNames();
         initDataStoreColumnVisibility();
+        initDynamicColumnVisibility();
         initDiagramButtonAvailability();
+    }
+
+    /**
+     * Hides the {@code dynamic} columns unless a module contributes entities or attributes that JPA
+     * metadata cannot describe. With no contributor every entity and attribute is a static one, and
+     * the column would be a constant.
+     */
+    protected void initDynamicColumnVisibility() {
+        boolean visible = dataModelRegistry.hasContributors();
+        setColumnVisible(entityModelsDataGrid, "dynamic", visible);
+        setColumnVisible(attributeModelsDataGrid, "dynamic", visible);
+    }
+
+    protected void setColumnVisible(DataGrid<?> dataGrid, String columnKey, boolean visible) {
+        Grid.Column<?> column = dataGrid.getColumnByKey(columnKey);
+        if (column != null) {
+            column.setVisible(visible);
+        }
     }
 
     protected void initDiagramButtonAvailability() {

--- a/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/entityinspector/EntityInspectorDetailView.java
+++ b/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/entityinspector/EntityInspectorDetailView.java
@@ -31,6 +31,7 @@ import io.jmix.core.entity.EntityValues;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.data.PersistenceHints;
+import io.jmix.datatools.EntityInspectorSupport;
 import io.jmix.datatoolsflowui.action.EntityInspectorAddAction;
 import io.jmix.datatoolsflowui.action.EntityInspectorCreateAction;
 import io.jmix.datatoolsflowui.action.EntityInspectorEditAction;
@@ -55,6 +56,7 @@ import org.jspecify.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 
 import static io.jmix.core.metamodel.model.MetaProperty.Type.ASSOCIATION;
 import static io.jmix.core.metamodel.model.MetaProperty.Type.COMPOSITION;
@@ -96,6 +98,8 @@ public class EntityInspectorDetailView extends StandardDetailView<Object> {
     protected UrlParamSerializer urlParamSerializer;
     @Autowired
     protected EntityUpdateDispatcher entityUpdateDispatcher;
+    @Autowired
+    protected EntityInspectorSupport entityInspectorSupport;
 
     @ViewComponent
     protected MessageBundle messageBundle;
@@ -170,17 +174,29 @@ public class EntityInspectorDetailView extends StandardDetailView<Object> {
             if (keyProperty != null) {
                 Class<?> idType = keyProperty.getJavaType();
                 Object deserializedId = urlParamSerializer.deserialize(idType, metadataId);
-                String queryString = SINGLE_SELECT_QUERY.formatted(
-                        metaClass.getName(), metadataTools.getPrimaryKeyName(metaClass), deserializedId
-                );
-                Object entity = dataManager.load(metaClass.getJavaClass())
-                        .query(queryString)
-                        .hint(PersistenceHints.SOFT_DELETION, false)
-                        .one();
 
-                setEntityToEdit(entity);
+                setEntityToEdit(loadEntityById(deserializedId));
             }
         }
+    }
+
+    protected Object loadEntityById(Object entityId) {
+        if (!entityInspectorSupport.supportsJpqlQuery(metaClass)) {
+            // A store that does not accept a JPQL string is loaded by id. A store without soft
+            // deletion ignores the hint, so it is passed on both paths.
+            return dataManager.load(metaClass.getJavaClass())
+                    .id(entityId)
+                    .hint(PersistenceHints.SOFT_DELETION, false)
+                    .one();
+        }
+
+        String queryString = SINGLE_SELECT_QUERY.formatted(
+                metaClass.getName(), metadataTools.getPrimaryKeyName(metaClass), entityId
+        );
+        return dataManager.load(metaClass.getJavaClass())
+                .query(queryString)
+                .hint(PersistenceHints.SOFT_DELETION, false)
+                .one();
     }
 
     protected void createNewItemByMetaClass() {
@@ -377,28 +393,42 @@ public class EntityInspectorDetailView extends StandardDetailView<Object> {
 
         loader.setContainer(container);
         loader.setDataContext(dataContext);
-        loader.setLoadDelegate(loadContext -> {
-            String queryString = metadataTools.isSoftDeletable(meta.getJavaClass())
-                    ? SOFT_DELETABLE_SELECT_QUERY
-                    : BASE_SELECT_QUERY;
-
-            String query = String.format(queryString,
-                    childMeta.getDomain().getName(),
-                    childMeta.getName(),
-                    metadataTools.findDeletedDateProperty(meta.getJavaClass()));
-
-            Collection<?> loadedChild = dataManager.load(meta.getJavaClass())
-                    .query(query)
-                    .parameter("editEntity", parent.getItem())
-                    .fetchPlan(InspectorFetchPlanBuilder.of(getApplicationContext(), meta.getJavaClass())
-                            .build())
-                    .list();
-            return new ArrayList<>(loadedChild);
-        });
+        loader.setLoadDelegate(loadContext -> entityInspectorSupport.supportsJpqlQuery(meta)
+                ? loadChildrenByQuery(parent, childMeta, meta)
+                : readChildrenFromParent(parent, childMeta));
 
         loader.load();
         dataContext.setModified(parent.getItem(), false);
         return container;
+    }
+
+    protected List<Object> loadChildrenByQuery(InstanceContainer parent, MetaProperty childMeta, MetaClass meta) {
+        String queryString = metadataTools.isSoftDeletable(meta.getJavaClass())
+                ? SOFT_DELETABLE_SELECT_QUERY
+                : BASE_SELECT_QUERY;
+
+        String query = String.format(queryString,
+                childMeta.getDomain().getName(),
+                childMeta.getName(),
+                metadataTools.findDeletedDateProperty(meta.getJavaClass()));
+
+        Collection<?> loadedChild = dataManager.load(meta.getJavaClass())
+                .query(query)
+                .parameter("editEntity", parent.getItem())
+                .fetchPlan(InspectorFetchPlanBuilder.of(getApplicationContext(), meta.getJavaClass())
+                        .build())
+                .list();
+        return new ArrayList<>(loadedChild);
+    }
+
+    /**
+     * Reads the children from the edited entity itself, for a store that cannot run the JPQL query
+     * above. The entity is loaded with a fetch plan that includes its collections, so the property
+     * already holds exactly this parent's children.
+     */
+    protected List<Object> readChildrenFromParent(InstanceContainer parent, MetaProperty childMeta) {
+        Collection<?> children = EntityValues.getValue(parent.getItem(), childMeta.getName());
+        return children == null ? new ArrayList<>() : new ArrayList<>(children);
     }
 
     protected String getPropertyTitle(MetaClass metaClass, MetaProperty metaProperty) {

--- a/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/entityinspector/EntityInspectorListView.java
+++ b/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/entityinspector/EntityInspectorListView.java
@@ -40,6 +40,7 @@ import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.core.metamodel.model.Session;
 import io.jmix.core.security.EntityOp;
 import io.jmix.data.PersistenceHints;
+import io.jmix.datatools.EntityInspectorSupport;
 import io.jmix.datatools.EntityRestore;
 import io.jmix.datatoolsflowui.DatatoolsUiProperties;
 import io.jmix.datatoolsflowui.accesscontext.UiImportExportEntityContext;
@@ -187,6 +188,8 @@ public class EntityInspectorListView extends StandardListView<Object> {
     protected InspectorExportHelper exportHelper;
     @Autowired
     protected EntityUpdateDispatcher entityUpdateDispatcher;
+    @Autowired
+    protected EntityInspectorSupport entityInspectorSupport;
 
     protected DataGrid<Object> entitiesDataGrid;
     protected GenericFilter entitiesGenericFilter;
@@ -288,7 +291,7 @@ public class EntityInspectorListView extends StandardListView<Object> {
     protected Map<MetaClass, String> getEntitiesLookupFieldOptions() {
         Map<MetaClass, String> options = new TreeMap<>(Comparator.comparing(MetaClass::getName));
 
-        for (MetaClass metaClass : metadataTools.getAllJpaEntityMetaClasses()) {
+        for (MetaClass metaClass : entityInspectorSupport.getInspectableEntityMetaClasses()) {
             if (readPermitted(metaClass)) {
                 options.put(metaClass,
                         messageTools.getEntityCaption(metaClass) + " (" + metaClass.getName() + ")");
@@ -442,17 +445,23 @@ public class EntityInspectorListView extends StandardListView<Object> {
         entitiesDl.setFetchPlan(fetchPlan);
         entitiesDl.setContainer(entitiesDc);
 
+        boolean supportsJpqlQuery = entityInspectorSupport.supportsJpqlQuery(meta);
+
         switch (Objects.requireNonNull(showMode.getValue())) {
             case ALL:
                 entitiesDl.setHint(PersistenceHints.SOFT_DELETION, false);
-                entitiesDl.setQuery(String.format(BASE_SELECT_QUERY, meta.getName()));
+                if (supportsJpqlQuery) {
+                    entitiesDl.setQuery(String.format(BASE_SELECT_QUERY, meta.getName()));
+                }
                 break;
             case NON_REMOVED:
                 entitiesDl.setHint(PersistenceHints.SOFT_DELETION, true);
-                entitiesDl.setQuery(String.format(BASE_SELECT_QUERY, meta.getName()));
+                if (supportsJpqlQuery) {
+                    entitiesDl.setQuery(String.format(BASE_SELECT_QUERY, meta.getName()));
+                }
                 break;
             case REMOVED:
-                if (metadataTools.isSoftDeletable(meta.getJavaClass())) {
+                if (supportsJpqlQuery && metadataTools.isSoftDeletable(meta.getJavaClass())) {
                     entitiesDl.setHint(PersistenceHints.SOFT_DELETION, false);
                     entitiesDl.setQuery(
                             String.format(
@@ -582,7 +591,8 @@ public class EntityInspectorListView extends StandardListView<Object> {
         initExcelExportAction(dataGrid, button ->
                 buttonsPanel.addComponentAtIndex(buttonsPanel.indexOf(exportDropdownButton), button));
 
-        if (metadataTools.isSoftDeletable(selectedMeta.getJavaClass())) {
+        if (entityInspectorSupport.supportsJpqlQuery(selectedMeta)
+                && metadataTools.isSoftDeletable(selectedMeta.getJavaClass())) {
             JmixButton restoreButton = createRestoreButton(dataGrid);
             JmixButton wipeOutButton = createWipeOutButton(dataGrid);
             buttonsPanel.addToStart(restoreButton, wipeOutButton);

--- a/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/entityinspector/assistant/InspectorDataGridBuilder.java
+++ b/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/entityinspector/assistant/InspectorDataGridBuilder.java
@@ -27,6 +27,7 @@ import io.jmix.core.entity.EntityValues;
 import io.jmix.core.metamodel.model.MetaClass;
 import io.jmix.core.metamodel.model.MetaProperty;
 import io.jmix.core.metamodel.model.MetaPropertyPath;
+import io.jmix.datatools.EntityInspectorSupport;
 import io.jmix.datatoolsflowui.DatatoolsUiProperties;
 import io.jmix.datatoolsflowui.view.entityinspector.EntityFormLayoutUtils;
 import io.jmix.datatoolsflowui.view.entityinspector.EntityInspectorListView;
@@ -55,6 +56,7 @@ public class InspectorDataGridBuilder {
     protected UiComponents uiComponents;
     protected DatatoolsUiProperties datatoolsUiProperties;
     protected Messages messages;
+    protected EntityInspectorSupport entityInspectorSupport;
 
     private final MetaClass metaClass;
     private final CollectionContainer<?> collectionContainer;
@@ -91,6 +93,11 @@ public class InspectorDataGridBuilder {
         this.messages = messages;
     }
 
+    @Autowired
+    public void setEntityInspectorSupport(EntityInspectorSupport entityInspectorSupport) {
+        this.entityInspectorSupport = entityInspectorSupport;
+    }
+
     public static InspectorDataGridBuilder from(ApplicationContext applicationContext,
                                                 CollectionContainer<?> collectionContainer) {
         return applicationContext.getBean(InspectorDataGridBuilder.class, collectionContainer);
@@ -110,7 +117,8 @@ public class InspectorDataGridBuilder {
         List<MetaProperty> systemProperties = new ArrayList<>(10);
         for (MetaProperty metaProperty : metaClass.getProperties()) {
             //don't show embedded, transient & multiple referred entities
-            if (EntityFormLayoutUtils.isEmbedded(metaProperty) || !metadataTools.isJpa(metaProperty)) {
+            if (EntityFormLayoutUtils.isEmbedded(metaProperty)
+                    || !entityInspectorSupport.isStoredProperty(metaProperty)) {
                 continue;
             }
 
@@ -118,7 +126,9 @@ public class InspectorDataGridBuilder {
                 continue;
             }
 
-            if (metadataTools.isAnnotationPresent(metaClass.getJavaClass(), metaProperty.getName(), Convert.class)) {
+            if (metadataTools.isJpa(metaProperty)
+                    && metadataTools.isAnnotationPresent(metaClass.getJavaClass(),
+                    metaProperty.getName(), Convert.class)) {
                 continue;
             }
 

--- a/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/entityinspector/assistant/InspectorFormLayoutBuilder.java
+++ b/jmix-datatools/datatools-flowui/src/main/java/io/jmix/datatoolsflowui/view/entityinspector/assistant/InspectorFormLayoutBuilder.java
@@ -214,7 +214,10 @@ public class InspectorFormLayoutBuilder {
 
             isReadonly = isReadonly || (disabledProperties != null && disabledProperties.contains(metaProperty.getName()));
             if (range.isClass() && metaProperty.getType() != MetaProperty.Type.EMBEDDED) {
-                pickerField.setReadOnly(!metadataTools.isOwningSide(metaProperty) || isReadonly);
+                // isOwningSide() reads JPA annotations, which a non-JPA store's property lacks.
+                boolean notOwningSide = metadataTools.isJpa(metaProperty)
+                        && !metadataTools.isOwningSide(metaProperty);
+                pickerField.setReadOnly(notOwningSide || isReadonly);
             } else {
                 pickerField.setReadOnly(isReadonly);
             }

--- a/jmix-datatools/datatools-flowui/src/main/resources/io/jmix/datatoolsflowui/view/datamodel/data-model-list-view.xml
+++ b/jmix-datatools/datatools-flowui/src/main/resources/io/jmix/datatoolsflowui/view/datamodel/data-model-list-view.xml
@@ -83,6 +83,7 @@
                         <column property="name"/>
                         <column property="dataStore"/>
                         <column property="tableName"/>
+                        <column property="dynamic" textAlign="CENTER" flexGrow="0" autoWidth="true"/>
                     </columns>
                 </dataGrid>
             </vbox>
@@ -108,6 +109,7 @@
                         <column property="javaType"/>
                         <column property="columnName"/>
                         <column property="dbType" flexGrow="2"/>
+                        <column property="dynamic" textAlign="CENTER" flexGrow="0" autoWidth="true"/>
                         <column property="isMandatory" textAlign="CENTER" flexGrow="0" autoWidth="true"/>
                     </columns>
                 </dataGrid>

--- a/jmix-datatools/datatools-flowui/src/test/groovy/datamodel/DataModelRegistryTest.groovy
+++ b/jmix-datatools/datatools-flowui/src/test/groovy/datamodel/DataModelRegistryTest.groovy
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package datamodel
+
+import io.jmix.core.CoreConfiguration
+import io.jmix.data.DataConfiguration
+import io.jmix.datatools.datamodel.DataModel
+import io.jmix.datatools.datamodel.DataModelRegistry
+import io.jmix.datatools.datamodel.RelationType
+import io.jmix.eclipselink.EclipselinkConfiguration
+import io.jmix.security.SecurityConfiguration
+import io.jmix.securitydata.SecurityDataConfiguration
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+import test_support.DataModelTestConfiguration
+import test_support.StubDataModelContributor
+import test_support.TestContextInititalizer
+
+@ContextConfiguration(
+        classes = [CoreConfiguration, DataConfiguration, EclipselinkConfiguration,
+                   SecurityConfiguration, SecurityDataConfiguration,
+                   DataModelTestConfiguration],
+        initializers = [TestContextInititalizer]
+)
+class DataModelRegistryTest extends Specification {
+
+    @Autowired
+    DataModelRegistry dataModelRegistry
+
+    def "contributed entity appears in the data model with its physical store and table"() {
+        when:
+        DataModel dataModel = dataModelRegistry.getDataModels(StubDataModelContributor.STUB_STORE)
+                .get("test_DataModelStubEntity")
+
+        then:
+        dataModel != null
+        dataModel.dataStore() == StubDataModelContributor.STUB_STORE
+        dataModel.entityModel().tableName == StubDataModelContributor.STUB_TABLE
+        dataModel.entityModel().dynamic
+    }
+
+    def "a JPA entity is still reported as not dynamic"() {
+        when:
+        DataModel dataModel = dataModelRegistry.getDataModels("main").get("test_DataModelHostEntity")
+
+        then:
+        dataModel != null
+        dataModel.entityModel().tableName == "TEST_DATA_MODEL_HOST_ENTITY"
+        dataModel.entityModel().dynamic == false
+    }
+
+    def "a contributed attribute on a JPA entity is qualified by its own table"() {
+        when:
+        DataModel dataModel = dataModelRegistry.getDataModels("main").get("test_DataModelHostEntity")
+        def attribute = dataModel.attributeModels().find { it.attributeName == "sideValue" }
+
+        then:
+        attribute != null
+        attribute.columnName == "DYN_TEST_DATA_MODEL_HOST_ENTITY.SIDE_VALUE"
+        attribute.dbType == "varchar(100)"
+        attribute.dynamic
+    }
+
+    def "a contributed attribute in the entity's own table keeps a bare column name"() {
+        when:
+        DataModel dataModel = dataModelRegistry.getDataModels(StubDataModelContributor.STUB_STORE)
+                .get("test_DataModelStubEntity")
+        def attribute = dataModel.attributeModels().find { it.attributeName == "name" }
+
+        then:
+        attribute != null
+        attribute.columnName == "NAME"
+        attribute.dbType == "varchar(50)"
+        attribute.dynamic
+    }
+
+    def "an attribute with no column shows the explanatory text and no DB type"() {
+        when:
+        DataModel dataModel = dataModelRegistry.getDataModels(StubDataModelContributor.STUB_STORE)
+                .get("test_DataModelStubEntity")
+        def attribute = dataModel.attributeModels().find { it.attributeName == "calculatedName" }
+
+        then:
+        attribute != null
+        attribute.columnName == "calculated"
+        attribute.dbType == ""
+        attribute.dynamic
+    }
+
+    def "a contributed relation is registered"() {
+        when:
+        DataModel dataModel = dataModelRegistry.getDataModels(StubDataModelContributor.STUB_STORE)
+                .get("test_DataModelStubEntity")
+        def relations = dataModel.relations().get(RelationType.MANY_TO_ONE)
+
+        then:
+        relations != null
+        relations.any { it.referencedClass() == "test_DataModelHostEntity" }
+    }
+
+    def "an undescribed non-JPA property is skipped"() {
+        when:
+        DataModel dataModel = dataModelRegistry.getDataModels(StubDataModelContributor.STUB_STORE)
+                .get("test_DataModelStubEntity")
+
+        then:
+        dataModel.attributeModels().every { it.attributeName != "id" }
+    }
+
+    def "a contributor that throws does not stop the other contributors"() {
+        when: "a contributor whose every call throws is registered before the stub one"
+        DataModel contributed = dataModelRegistry.getDataModels(StubDataModelContributor.STUB_STORE)
+                .get("test_DataModelStubEntity")
+        DataModel jpa = dataModelRegistry.getDataModels("main").get("test_DataModelHostEntity")
+
+        then: "the entities and attributes of the working contributor are still in the data model"
+        contributed != null
+        contributed.entityModel().tableName == StubDataModelContributor.STUB_TABLE
+        jpa != null
+        jpa.attributeModels().any { it.attributeName == "sideValue" }
+    }
+
+    def "the diagram marks a dynamic attribute and leaves a static one plain"() {
+        when:
+        DataModel dataModel = dataModelRegistry.getDataModels("main").get("test_DataModelHostEntity")
+
+        then:
+        dataModel.entityDescription().contains("sideValue : String <<dynamic>>")
+        dataModel.entityDescription().contains("name : String\n")
+    }
+
+    def "the diagram marks a contributed dynamic entity and leaves its attributes plain"() {
+        when:
+        DataModel dataModel = dataModelRegistry.getDataModels(StubDataModelContributor.STUB_STORE)
+                .get("test_DataModelStubEntity")
+        def lines = dataModel.entityDescription().lines().toList()
+
+        then:
+        lines.first().startsWith("entity test_DataModelStubEntity")
+        lines.first().endsWith("<<dynamic>> {")
+        lines.tail().every { !it.contains("<<dynamic>>") }
+    }
+
+    def "contributors are reported as registered"() {
+        expect:
+        dataModelRegistry.hasContributors()
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/groovy/entityinspector/EntityInspectorSupportTest.groovy
+++ b/jmix-datatools/datatools-flowui/src/test/groovy/entityinspector/EntityInspectorSupportTest.groovy
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entityinspector
+
+import io.jmix.core.CoreConfiguration
+import io.jmix.core.Metadata
+import io.jmix.core.MetadataTools
+import io.jmix.core.metamodel.model.MetaClass
+import io.jmix.data.DataConfiguration
+import io.jmix.datatools.EntityInspectorSupport
+import io.jmix.eclipselink.EclipselinkConfiguration
+import io.jmix.security.SecurityConfiguration
+import io.jmix.securitydata.SecurityDataConfiguration
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.ContextConfiguration
+import spock.lang.Specification
+import test_support.DataModelTestConfiguration
+import test_support.TestContextInititalizer
+import io.jmix.securitydata.entity.RoleAssignmentEntity
+import test_support.entity.CustomStoreEntity
+import test_support.entity.CustomStoreSystemEntity
+import test_support.entity.DataModelHostEntity
+import test_support.entity.DataModelStubEntity
+import test_support.entity.InspectorPolicyEmbeddable
+
+@ContextConfiguration(
+        classes = [CoreConfiguration, DataConfiguration, EclipselinkConfiguration,
+                   SecurityConfiguration, SecurityDataConfiguration,
+                   DataModelTestConfiguration],
+        initializers = [TestContextInititalizer]
+)
+class EntityInspectorSupportTest extends Specification {
+
+    @Autowired
+    EntityInspectorSupport entityInspectorSupport
+
+    @Autowired
+    Metadata metadata
+
+    @Autowired
+    MetadataTools metadataTools
+
+    def "a JPA entity is inspectable"() {
+        expect:
+        entityInspectorSupport.getInspectableEntityMetaClasses()
+                .contains(metadata.getClass(DataModelHostEntity))
+    }
+
+    def "a non-persistent entity is not inspectable"() {
+        expect:
+        !entityInspectorSupport.getInspectableEntityMetaClasses()
+                .contains(metadata.getClass(DataModelStubEntity))
+    }
+
+    def "a JPA embeddable is not inspectable"() {
+        expect:
+        !entityInspectorSupport.getInspectableEntityMetaClasses()
+                .contains(metadata.getClass(InspectorPolicyEmbeddable))
+    }
+
+    def "a JPA entity accepts a JPQL query"() {
+        expect:
+        entityInspectorSupport.supportsJpqlQuery(metadata.getClass(DataModelHostEntity))
+    }
+
+    def "a JPA property is stored and a transient one is not"() {
+        given:
+        MetaClass metaClass = metadata.getClass(DataModelHostEntity)
+
+        expect:
+        entityInspectorSupport.isStoredProperty(metaClass.getProperty("name"))
+        !entityInspectorSupport.isStoredProperty(metaClass.getProperty("sideValue"))
+    }
+
+    def "an entity of a non-JPA store is inspectable and takes no JPQL query"() {
+        given:
+        MetaClass metaClass = metadata.getClass(CustomStoreEntity)
+
+        expect:
+        entityInspectorSupport.getInspectableEntityMetaClasses().contains(metaClass)
+        !entityInspectorSupport.supportsJpqlQuery(metaClass)
+    }
+
+    def "a system-level entity of a non-JPA store is not inspectable"() {
+        given:
+        MetaClass metaClass = metadata.getClass(CustomStoreSystemEntity)
+
+        expect:
+        metadataTools.isSystemLevel(metaClass)
+        !entityInspectorSupport.getInspectableEntityMetaClasses().contains(metaClass)
+    }
+
+    def "a system-level JPA entity stays inspectable"() {
+        given:
+        MetaClass metaClass = metadata.getClass(RoleAssignmentEntity)
+
+        expect:
+        metadataTools.isSystemLevel(metaClass)
+        entityInspectorSupport.getInspectableEntityMetaClasses().contains(metaClass)
+    }
+
+    def "every JPA entity with a table is still inspectable"() {
+        given:
+        def jpaEntities = metadataTools.getAllJpaEntityMetaClasses()
+
+        expect:
+        entityInspectorSupport.getInspectableEntityMetaClasses().containsAll(jpaEntities)
+    }
+
+    def "the identifier of a non-JPA store entity is a stored property"() {
+        given:
+        MetaClass metaClass = metadata.getClass(CustomStoreEntity)
+
+        expect:
+        entityInspectorSupport.isStoredProperty(metaClass.getProperty("id"))
+    }
+
+    def "the identifier of a JPA entity is still a stored property"() {
+        given:
+        MetaClass metaClass = metadata.getClass(DataModelHostEntity)
+
+        expect:
+        entityInspectorSupport.isStoredProperty(metaClass.getProperty("id"))
+    }
+
+    def "a plain attribute of a non-JPA store entity is a stored property"() {
+        given:
+        MetaClass metaClass = metadata.getClass(CustomStoreEntity)
+
+        expect: "its fields are persisted by its own store, so the list view must show them"
+        entityInspectorSupport.isStoredProperty(metaClass.getProperty("name"))
+    }
+
+    def "a transient property of a JPA entity is still not a stored property"() {
+        given:
+        MetaClass metaClass = metadata.getClass(DataModelHostEntity)
+
+        expect:
+        !entityInspectorSupport.isStoredProperty(metaClass.getProperty("sideValue"))
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/entity_inspector/EntityInspectorCustomStoreTest.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/entity_inspector/EntityInspectorCustomStoreTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package entity_inspector;
+
+import com.google.common.collect.ImmutableMap;
+import com.vaadin.flow.component.Component;
+import com.vaadin.flow.router.RouteParameters;
+import io.jmix.core.Metadata;
+import io.jmix.datatoolsflowui.view.entityinspector.EntityInspectorDetailView;
+import io.jmix.flowui.component.grid.DataGrid;
+import org.springframework.context.ApplicationContext;
+import io.jmix.flowui.model.DataComponents;
+import io.jmix.flowui.model.CollectionContainer;
+import io.jmix.datatoolsflowui.view.entityinspector.assistant.InspectorDataGridBuilder;
+import io.jmix.flowui.data.ContainerDataUnit;
+import io.jmix.flowui.testassist.UiTest;
+import io.jmix.flowui.testassist.UiTestUtils;
+import io.jmix.flowui.view.navigation.UrlParamSerializer;
+import io.jmix.flowui.view.navigation.ViewNavigationSupport;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import test_support.CustomDataStore;
+import test_support.EntityInspectorUiTestConfiguration;
+import test_support.TestFullAccessUiAuthenticator;
+import test_support.entity.CustomStoreChild;
+import test_support.entity.CustomStoreEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * The entity inspector opened on an entity of a store that does not accept a JPQL query string.
+ */
+@UiTest(authenticator = TestFullAccessUiAuthenticator.class)
+@SpringBootTest(classes = EntityInspectorUiTestConfiguration.class)
+public class EntityInspectorCustomStoreTest {
+
+    @Autowired
+    Metadata metadata;
+    @Autowired
+    DataComponents dataComponents;
+    @Autowired
+    ApplicationContext applicationContext;
+    @Autowired
+    CustomDataStore customDataStore;
+    @Autowired
+    ViewNavigationSupport navigationSupport;
+    @Autowired
+    UrlParamSerializer urlParamSerializer;
+
+    @AfterEach
+    void cleanup() {
+        customDataStore.clear();
+    }
+
+    @Test
+    void testEntityOfCustomStoreIsEditedById() {
+        CustomStoreEntity entity = createEntityWithOneChild();
+
+        EntityInspectorDetailView view = navigateToInspector(entity);
+
+        assertEquals(entity, view.getEditedEntity());
+    }
+
+    @Test
+    void testCollectionTabShowsOnlyTheChildrenOfTheEditedEntity() {
+        CustomStoreEntity entity = createEntityWithOneChild();
+        // another child that belongs to no entity: it must not reach the tab
+        CustomStoreChild strayChild = metadata.create(CustomStoreChild.class);
+        strayChild.setName("stray");
+        customDataStore.put(strayChild);
+
+        EntityInspectorDetailView view = navigateToInspector(entity);
+        DataGrid<Object> childrenDataGrid = findChildrenDataGrid(view);
+
+        List<Object> items = ((ContainerDataUnit<Object>) childrenDataGrid.getItems()).getContainer().getItems();
+
+        assertEquals(1, items.size());
+        assertEquals("child", ((CustomStoreChild) items.get(0)).getName());
+    }
+
+    @Test
+    void testListGridShowsPlainAttributesOfCustomStoreEntity() {
+        CollectionContainer<CustomStoreEntity> container =
+                dataComponents.createCollectionContainer(CustomStoreEntity.class);
+
+        DataGrid<?> dataGrid = InspectorDataGridBuilder.from(applicationContext, container)
+                .withSystem(true)
+                .build();
+
+        List<String> columns = dataGrid.getColumns().stream()
+                .map(column -> column.getKey())
+                .toList();
+
+        // The entity's own store persists these fields, so the list view must offer them as columns.
+        org.junit.jupiter.api.Assertions.assertTrue(columns.contains("name"),
+                "expected a 'name' column, got " + columns);
+        org.junit.jupiter.api.Assertions.assertTrue(columns.contains("id"),
+                "expected an 'id' column, got " + columns);
+    }
+
+    private CustomStoreEntity createEntityWithOneChild() {
+        CustomStoreChild child = metadata.create(CustomStoreChild.class);
+        child.setName("child");
+        customDataStore.put(child);
+
+        CustomStoreEntity entity = metadata.create(CustomStoreEntity.class);
+        entity.setName("parent");
+        entity.setChildren(new ArrayList<>(List.of(child)));
+        customDataStore.put(entity);
+
+        return entity;
+    }
+
+    private EntityInspectorDetailView navigateToInspector(CustomStoreEntity entity) {
+        String entityName = metadata.getClass(CustomStoreEntity.class).getName();
+        RouteParameters routeParameters = new RouteParameters(ImmutableMap.of(
+                EntityInspectorDetailView.ROUTE_PARAM_NAME, urlParamSerializer.serialize(entityName),
+                EntityInspectorDetailView.ROUTE_PARAM_ID, urlParamSerializer.serialize(entity.getId())
+        ));
+        navigationSupport.navigate(EntityInspectorDetailView.class, routeParameters);
+
+        return UiTestUtils.getCurrentView();
+    }
+
+    @SuppressWarnings("unchecked")
+    private DataGrid<Object> findChildrenDataGrid(EntityInspectorDetailView view) {
+        DataGrid<Object> dataGrid = (DataGrid<Object>) findDataGrid(view.getContent()).orElse(null);
+        assertNotNull(dataGrid, "The 'children' data grid is not created in the entity inspector");
+
+        return dataGrid;
+    }
+
+    private Optional<Component> findDataGrid(Component component) {
+        if (component instanceof DataGrid) {
+            return Optional.of(component);
+        }
+        return component.getChildren()
+                .map(this::findDataGrid)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst();
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/CustomDataStore.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/CustomDataStore.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support;
+
+import io.jmix.core.DataStore;
+import io.jmix.core.LoadContext;
+import io.jmix.core.SaveContext;
+import io.jmix.core.ValueLoadContext;
+import io.jmix.core.entity.EntitySystemAccess;
+import io.jmix.core.entity.EntityValues;
+import io.jmix.core.entity.KeyValueEntity;
+import org.jspecify.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An in-memory store that behaves the way a store without JPQL support behaves: a single entity can
+ * only be found by its id, and a query string means nothing to it and is ignored.
+ */
+public class CustomDataStore implements DataStore {
+
+    protected String name;
+
+    protected final Map<Object, Object> storage = new LinkedHashMap<>();
+
+    /**
+     * Puts an entity into the store and marks it as loaded, the way a real store does when it reads
+     * an existing row.
+     */
+    public void put(Object entity) {
+        EntitySystemAccess.getEntityEntry(entity).setNew(false);
+        storage.put(EntityValues.getId(entity), entity);
+    }
+
+    public void clear() {
+        storage.clear();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Nullable
+    @Override
+    public Object load(LoadContext<?> context) {
+        if (context.getId() == null) {
+            throw new IllegalArgumentException("Entity id is null");
+        }
+        return storage.get(context.getId());
+    }
+
+    @Override
+    public List<Object> loadList(LoadContext<?> context) {
+        // The query string is deliberately ignored, as it is by a store that does not speak JPQL.
+        Class<?> javaClass = context.getEntityMetaClass().getJavaClass();
+        List<Object> result = new ArrayList<>();
+        for (Object entity : storage.values()) {
+            if (javaClass.isInstance(entity)) {
+                result.add(entity);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public long getCount(LoadContext<?> context) {
+        return loadList(context).size();
+    }
+
+    @Override
+    public Set<?> save(SaveContext context) {
+        for (Object entity : context.getEntitiesToSave()) {
+            put(entity);
+        }
+        for (Object entity : context.getEntitiesToRemove()) {
+            storage.remove(EntityValues.getId(entity));
+        }
+        return Set.copyOf(context.getEntitiesToSave());
+    }
+
+    @Override
+    public List<KeyValueEntity> loadValues(ValueLoadContext context) {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public long getCount(ValueLoadContext context) {
+        return 0;
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/CustomStoreDescriptorProvider.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/CustomStoreDescriptorProvider.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support;
+
+import io.jmix.core.datastore.AdditionalStoreDescriptorProvider;
+import io.jmix.core.metamodel.model.StoreDescriptor;
+
+/**
+ * Registers a non-JPA data store, so that the store-based rules of the entity inspector can be
+ * checked without a JPA entity. Nothing is ever loaded from it: only its metadata is used.
+ */
+public class CustomStoreDescriptorProvider implements AdditionalStoreDescriptorProvider {
+
+    public static final String STORE_NAME = "custom";
+
+    @Override
+    public String getStoreName() {
+        return STORE_NAME;
+    }
+
+    @Override
+    public StoreDescriptor getStoreDescriptor() {
+        return new StoreDescriptor() {
+            @Override
+            public String getBeanName() {
+                return "test_CustomDataStore";
+            }
+
+            @Override
+            public boolean isJpa() {
+                return false;
+            }
+        };
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/DataModelTestConfiguration.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/DataModelTestConfiguration.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support;
+
+import io.jmix.core.annotation.JmixModule;
+import io.jmix.datatools.DatatoolsConfiguration;
+import io.jmix.eclipselink.EclipselinkConfiguration;
+import io.jmix.security.SecurityConfiguration;
+import io.jmix.securitydata.SecurityDataConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
+
+@Configuration
+@Import({EntityInspectorPolicyTestConfiguration.class, DatatoolsConfiguration.class})
+@JmixModule(id = "test_support.datamodel", dependsOn = {SecurityDataConfiguration.class,
+        EclipselinkConfiguration.class, SecurityConfiguration.class, DatatoolsConfiguration.class})
+public class DataModelTestConfiguration {
+
+    @Bean("test_ThrowingDataModelContributor")
+    @Order(1)
+    ThrowingDataModelContributor throwingDataModelContributor() {
+        return new ThrowingDataModelContributor();
+    }
+
+    @Bean("test_StubDataModelContributor")
+    @Order(2)
+    StubDataModelContributor stubDataModelContributor() {
+        return new StubDataModelContributor();
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/EntityInspectorPolicyTestConfiguration.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/EntityInspectorPolicyTestConfiguration.java
@@ -63,6 +63,16 @@ import javax.sql.DataSource;
 @EnableJmixDataRepositories
 public class EntityInspectorPolicyTestConfiguration {
 
+    @Bean("test_CustomDataStore")
+    CustomDataStore customDataStore() {
+        return new CustomDataStore();
+    }
+
+    @Bean("test_CustomStoreDescriptorProvider")
+    CustomStoreDescriptorProvider customStoreDescriptorProvider() {
+        return new CustomStoreDescriptorProvider();
+    }
+
     @Bean
     public UserRepository userRepository() {
         return new InMemoryUserRepository();

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/EntityInspectorUiTestConfiguration.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/EntityInspectorUiTestConfiguration.java
@@ -54,6 +54,16 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @JmixModule
 public class EntityInspectorUiTestConfiguration {
 
+    @Bean("test_CustomDataStore")
+    CustomDataStore customDataStore() {
+        return new CustomDataStore();
+    }
+
+    @Bean("test_CustomStoreDescriptorProvider")
+    CustomStoreDescriptorProvider customStoreDescriptorProvider() {
+        return new CustomStoreDescriptorProvider();
+    }
+
     @Bean
     UserRepository userRepository() {
         return new InMemoryUserRepository();

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/StubDataModelContributor.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/StubDataModelContributor.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support;
+
+import io.jmix.core.Metadata;
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.metamodel.model.MetaProperty;
+import io.jmix.datatools.datamodel.AttributeDescriptor;
+import io.jmix.datatools.datamodel.DataModelContributor;
+import io.jmix.datatools.datamodel.EntityDescriptor;
+import io.jmix.datatools.datamodel.RelationType;
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.annotation.Autowired;
+import test_support.entity.DataModelHostEntity;
+import test_support.entity.DataModelStubEntity;
+
+import java.util.Collection;
+import java.util.List;
+
+public class StubDataModelContributor implements DataModelContributor {
+
+    public static final String STUB_STORE = "main";
+    public static final String STUB_TABLE = "STUB_ENTITY";
+    public static final String HOST_SIDE_TABLE = "DYN_TEST_DATA_MODEL_HOST_ENTITY";
+
+    @Autowired
+    protected Metadata metadata;
+
+    @Override
+    public Collection<MetaClass> getAdditionalEntities() {
+        return List.of(metadata.getClass(DataModelStubEntity.class));
+    }
+
+    @Nullable
+    @Override
+    public EntityDescriptor describeEntity(MetaClass metaClass) {
+        if (!DataModelStubEntity.class.equals(metaClass.getJavaClass())) {
+            return null;
+        }
+        return new EntityDescriptor(STUB_STORE, STUB_TABLE, true);
+    }
+
+    @Nullable
+    @Override
+    public AttributeDescriptor describeAttribute(MetaClass entity, MetaProperty property) {
+        if (DataModelStubEntity.class.equals(entity.getJavaClass())) {
+            return describeStubAttribute(property);
+        }
+        if (DataModelHostEntity.class.equals(entity.getJavaClass())) {
+            return describeHostAttribute(property);
+        }
+        return null;
+    }
+
+    @Nullable
+    protected AttributeDescriptor describeStubAttribute(MetaProperty property) {
+        return switch (property.getName()) {
+            case "name" -> new AttributeDescriptor("name", "String", true, true,
+                    new AttributeDescriptor.ColumnDescriptor(STUB_TABLE, "NAME", "varchar(50)"),
+                    null,
+                    new AttributeDescriptor.RelationDescriptor(
+                            RelationType.MANY_TO_ONE, "test_DataModelHostEntity"));
+            case "calculatedName" -> new AttributeDescriptor("calculatedName", "String", false, true,
+                    null, "calculated", null);
+            default -> null;
+        };
+    }
+
+    @Nullable
+    protected AttributeDescriptor describeHostAttribute(MetaProperty property) {
+        if (!"sideValue".equals(property.getName())) {
+            return null;
+        }
+        return new AttributeDescriptor("sideValue", "String", false, true,
+                new AttributeDescriptor.ColumnDescriptor(HOST_SIDE_TABLE, "SIDE_VALUE", "varchar(100)"),
+                null, null);
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/ThrowingDataModelContributor.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/ThrowingDataModelContributor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support;
+
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.metamodel.model.MetaProperty;
+import io.jmix.datatools.datamodel.AttributeDescriptor;
+import io.jmix.datatools.datamodel.DataModelContributor;
+import io.jmix.datatools.datamodel.EntityDescriptor;
+
+import java.util.Collection;
+
+/**
+ * A misbehaving contributor: every call fails. It is registered before
+ * {@link StubDataModelContributor}, so the whole data model test suite runs with it in place and
+ * shows that one broken contributor does not affect the rest of the data model.
+ */
+public class ThrowingDataModelContributor implements DataModelContributor {
+
+    public static final String FAILURE_MESSAGE = "Deliberate contributor failure";
+
+    @Override
+    public Collection<MetaClass> getAdditionalEntities() {
+        throw new IllegalStateException(FAILURE_MESSAGE);
+    }
+
+    @Override
+    public EntityDescriptor describeEntity(MetaClass metaClass) {
+        throw new IllegalStateException(FAILURE_MESSAGE);
+    }
+
+    @Override
+    public AttributeDescriptor describeAttribute(MetaClass entity, MetaProperty property) {
+        throw new IllegalStateException(FAILURE_MESSAGE);
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/CustomStoreChild.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/CustomStoreChild.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.InstanceName;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.core.metamodel.annotation.Store;
+import test_support.CustomStoreDescriptorProvider;
+
+import java.util.UUID;
+
+@JmixEntity(name = "test_CustomStoreChild")
+@Store(name = CustomStoreDescriptorProvider.STORE_NAME)
+public class CustomStoreChild {
+
+    @JmixGeneratedValue
+    @JmixId
+    private UUID id;
+
+    @InstanceName
+    private String name;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/CustomStoreEntity.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/CustomStoreEntity.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.core.metamodel.annotation.Store;
+import test_support.CustomStoreDescriptorProvider;
+
+import java.util.List;
+import java.util.UUID;
+
+@JmixEntity(name = "test_CustomStoreEntity")
+@Store(name = CustomStoreDescriptorProvider.STORE_NAME)
+public class CustomStoreEntity {
+
+    @JmixGeneratedValue
+    @JmixId
+    private UUID id;
+
+    private String name;
+
+    private List<CustomStoreChild> children;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<CustomStoreChild> getChildren() {
+        return children;
+    }
+
+    public void setChildren(List<CustomStoreChild> children) {
+        this.children = children;
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/CustomStoreSystemEntity.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/CustomStoreSystemEntity.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.entity.annotation.SystemLevel;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.core.metamodel.annotation.Store;
+import test_support.CustomStoreDescriptorProvider;
+
+import java.util.UUID;
+
+@JmixEntity(name = "test_CustomStoreSystemEntity")
+@Store(name = CustomStoreDescriptorProvider.STORE_NAME)
+@SystemLevel
+public class CustomStoreSystemEntity {
+
+    @JmixGeneratedValue
+    @JmixId
+    private UUID id;
+
+    private String name;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/DataModelHostEntity.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/DataModelHostEntity.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+import io.jmix.core.metamodel.annotation.JmixProperty;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+
+import java.util.UUID;
+
+@JmixEntity
+@Entity(name = "test_DataModelHostEntity")
+@Table(name = "TEST_DATA_MODEL_HOST_ENTITY")
+public class DataModelHostEntity {
+
+    @JmixGeneratedValue
+    @Id
+    @Column(name = "ID", nullable = false)
+    private UUID id;
+
+    @Column(name = "NAME")
+    private String name;
+
+    @JmixProperty
+    @Transient
+    private String sideValue;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getSideValue() {
+        return sideValue;
+    }
+
+    public void setSideValue(String sideValue) {
+        this.sideValue = sideValue;
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/DataModelStubEntity.java
+++ b/jmix-datatools/datatools-flowui/src/test/java/test_support/entity/DataModelStubEntity.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test_support.entity;
+
+import io.jmix.core.entity.annotation.JmixGeneratedValue;
+import io.jmix.core.entity.annotation.JmixId;
+import io.jmix.core.metamodel.annotation.JmixEntity;
+
+import java.util.UUID;
+
+@JmixEntity(name = "test_DataModelStubEntity")
+public class DataModelStubEntity {
+
+    @JmixGeneratedValue
+    @JmixId
+    private UUID id;
+
+    private String name;
+
+    private String calculatedName;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCalculatedName() {
+        return calculatedName;
+    }
+
+    public void setCalculatedName(String calculatedName) {
+        this.calculatedName = calculatedName;
+    }
+}

--- a/jmix-datatools/datatools-flowui/src/test/resources/test_support/liquibase/changelog.xml
+++ b/jmix-datatools/datatools-flowui/src/test/resources/test_support/liquibase/changelog.xml
@@ -39,6 +39,15 @@
         </createTable>
     </changeSet>
 
+    <changeSet author="test" id="data-model-host-entity">
+        <createTable tableName="TEST_DATA_MODEL_HOST_ENTITY">
+            <column name="ID" type="${uuid.type}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="NAME" type="varchar(255)"/>
+        </createTable>
+    </changeSet>
+
     <changeSet author="test" id="inspector-policy-related-entity">
         <createTable tableName="TEST_INSPECTOR_POLICY_RELATED_ENTITY">
             <column name="ID" type="${uuid.type}">

--- a/jmix-datatools/datatools/src/main/java/io/jmix/datatools/EntityInspectorSupport.java
+++ b/jmix-datatools/datatools/src/main/java/io/jmix/datatools/EntityInspectorSupport.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.datatools;
+
+import io.jmix.core.Metadata;
+import io.jmix.core.MetadataTools;
+import io.jmix.core.Stores;
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.metamodel.model.MetaProperty;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+/**
+ * Decides which entities and properties the entity inspector can work with, based on their data
+ * store rather than on JPA annotations, so that entities of non-JPA stores are supported.
+ */
+@NullMarked
+@Component("datatl_EntityInspectorSupport")
+public class EntityInspectorSupport {
+
+    @Autowired
+    protected Metadata metadata;
+    @Autowired
+    protected MetadataTools metadataTools;
+
+    /**
+     * Returns the entities the inspector can browse: JPA entities, and entities of any other real
+     * data store. Classes without a store, JPA embeddables, and system-level classes of non-JPA
+     * stores are left out.
+     *
+     * @return inspectable meta-classes, empty if none
+     */
+    public Collection<MetaClass> getInspectableEntityMetaClasses() {
+        return metadata.getSession().getClasses().stream()
+                .filter(this::isInspectable)
+                .toList();
+    }
+
+    /**
+     * Returns whether the entity's data store accepts a JPQL query string. A store that does not
+     * must be loaded with conditions only.
+     *
+     * @param metaClass entity meta-class
+     * @return {@code true} if a JPQL query string can be used
+     */
+    public boolean supportsJpqlQuery(MetaClass metaClass) {
+        return metaClass.getStore().getDescriptor().isJpa();
+    }
+
+    /**
+     * Returns whether the property holds a value that its data store persists: a JPA attribute, or
+     * any property of a real store. A transient property has no store of its own and is left out.
+     *
+     * @param metaProperty property to check
+     * @return {@code true} if the property is stored
+     */
+    public boolean isStoredProperty(MetaProperty metaProperty) {
+        return metadataTools.isJpa(metaProperty)
+                || isRealStore(metaProperty.getStore().getName());
+    }
+
+    protected boolean isInspectable(MetaClass metaClass) {
+        if (!isRealStore(metaClass.getStore().getName())) {
+            return false;
+        }
+        if (metadataTools.isJpaEmbeddable(metaClass)) {
+            return false;
+        }
+        // A JPA store holds mapped entities only; any other real store manages whatever it registers.
+        if (metaClass.getStore().getDescriptor().isJpa()) {
+            return metadataTools.isJpaEntity(metaClass);
+        }
+        // A non-JPA store may register infrastructure classes holding no data, marked system-level.
+        return !metadataTools.isSystemLevel(metaClass);
+    }
+
+    protected boolean isRealStore(String storeName) {
+        return !Stores.NOOP.equals(storeName) && !Stores.UNDEFINED.equals(storeName);
+    }
+}

--- a/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/AttributeDescriptor.java
+++ b/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/AttributeDescriptor.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.datatools.datamodel;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Description of an attribute contributed to the data model.
+ *
+ * @param name         attribute name
+ * @param javaType     displayed Java type
+ * @param mandatory    whether a value is required
+ * @param dynamic      whether the attribute is defined at runtime rather than on the classpath
+ * @param column       physical column, or {@code null} when the attribute has no column of its own
+ * @param noColumnText text shown in place of a column name when {@code column} is {@code null}
+ * @param relation     relation to another entity, or {@code null} when the attribute is not a reference
+ */
+@NullMarked
+public record AttributeDescriptor(String name,
+                                  String javaType,
+                                  boolean mandatory,
+                                  boolean dynamic,
+                                  @Nullable ColumnDescriptor column,
+                                  @Nullable String noColumnText,
+                                  @Nullable RelationDescriptor relation) {
+
+    /**
+     * Physical column of a contributed attribute.
+     *
+     * @param tableName  table the column belongs to
+     * @param columnName column name
+     * @param dbType     database type, or {@code null} to look it up in the database metadata
+     */
+    public record ColumnDescriptor(String tableName, String columnName, @Nullable String dbType) {
+    }
+
+    /**
+     * Relation declared by a contributed attribute.
+     *
+     * @param type       relation type
+     * @param entityName name of the entity at the other end
+     */
+    public record RelationDescriptor(RelationType type, String entityName) {
+    }
+}

--- a/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/DataModelContributor.java
+++ b/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/DataModelContributor.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.datatools.datamodel;
+
+import io.jmix.core.metamodel.model.MetaClass;
+import io.jmix.core.metamodel.model.MetaProperty;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Describes entities and attributes that JPA metadata cannot describe, so that they take part in the
+ * data model. Implementations are consulted in bean order. For {@link #describeEntity(MetaClass)} and
+ * {@link #describeAttribute(MetaClass, MetaProperty)} the first one that handles an object wins; the
+ * entities of {@link #getAdditionalEntities()} are collected from all implementations and
+ * de-duplicated by entity name.
+ * <p>
+ * An implementation is expected not to throw: a call that fails is logged and skipped, and whatever
+ * that implementation would have contributed is missing from the data model.
+ */
+@NullMarked
+public interface DataModelContributor {
+
+    /**
+     * Returns entities to add to the data model in addition to JPA entities. The result is added to
+     * what the other implementations return, so an entity already in the model is not added twice.
+     *
+     * @return contributed entity meta-classes, empty if none
+     */
+    default Collection<MetaClass> getAdditionalEntities() {
+        return List.of();
+    }
+
+    /**
+     * Describes the physical placement of an entity.
+     *
+     * @param metaClass entity meta-class
+     * @return descriptor, or {@code null} if this contributor does not handle the entity
+     */
+    @Nullable
+    default EntityDescriptor describeEntity(MetaClass metaClass) {
+        return null;
+    }
+
+    /**
+     * Describes a property that is not a JPA attribute.
+     *
+     * @param entity   owner entity meta-class
+     * @param property property to describe
+     * @return descriptor, or {@code null} if this contributor does not handle the property
+     */
+    @Nullable
+    default AttributeDescriptor describeAttribute(MetaClass entity, MetaProperty property) {
+        return null;
+    }
+}

--- a/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/DataModelRegistry.java
+++ b/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/DataModelRegistry.java
@@ -52,6 +52,7 @@ import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
@@ -84,10 +85,24 @@ public class DataModelRegistry {
     @Autowired
     protected MetadataGenerationManager metadataGenerationManager;
 
+    @Autowired(required = false)
+    protected List<DataModelContributor> contributors = List.of();
+
     protected final GenerationStateStore<State> stateStore = new GenerationStateStore<>();
 
     protected State getState() {
         return stateStore.getOrCreate(metadataGenerationManager.getPinnedOrCurrentGenerationId(), State::new);
+    }
+
+    /**
+     * Returns whether any module contributes entities or attributes the JPA metadata cannot describe.
+     * When nothing does, the data model holds only JPA entities and the {@code dynamic} flag of every
+     * entity and attribute is {@code false}.
+     *
+     * @return {@code true} if at least one {@link DataModelContributor} is registered
+     */
+    public boolean hasContributors() {
+        return !contributors.isEmpty();
     }
 
     /**
@@ -143,18 +158,72 @@ public class DataModelRegistry {
                 createEntityDescription(state, metaClass, false);
             }
         }
+
+        for (DataModelContributor contributor : contributors) {
+            Collection<MetaClass> additionalEntities =
+                    callContributor(contributor, "getAdditionalEntities", DataModelContributor::getAdditionalEntities);
+            if (additionalEntities == null) {
+                continue;
+            }
+            for (MetaClass metaClass : additionalEntities) {
+                if (findDataModel(state, metaClass) == null) {
+                    createEntityDescription(state, metaClass, false);
+                }
+            }
+        }
+    }
+
+    /**
+     * Invokes a contributor, isolating the rest of the data model from its failure.
+     *
+     * @return the contributor's result, or {@code null} if it returned {@code null} or threw
+     */
+    @Nullable
+    protected <R> R callContributor(DataModelContributor contributor, String operation,
+                                    Function<DataModelContributor, R> call) {
+        try {
+            return call.apply(contributor);
+        } catch (RuntimeException e) {
+            log.warn("Data model contributor '{}' failed in {}, skipping its contribution",
+                    contributor.getClass().getName(), operation, e);
+            return null;
+        }
+    }
+
+    @Nullable
+    protected DataModel findDataModel(State state, MetaClass metaClass) {
+        return state.dataModels.values().stream()
+                .map(models -> models.get(metaClass.getName()))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+    }
+
+    protected EntityDescriptor resolveEntityDescriptor(MetaClass entity) {
+        for (DataModelContributor contributor : contributors) {
+            EntityDescriptor descriptor = callContributor(contributor, "describeEntity",
+                    c -> c.describeEntity(entity));
+            if (descriptor != null) {
+                return descriptor;
+            }
+        }
+        Table tableAnnotation = entity.getJavaClass().getAnnotation(Table.class);
+        return new EntityDescriptor(entity.getStore().getName(),
+                tableAnnotation != null ? tableAnnotation.name() : "", false);
     }
 
     protected DataModel createEntityDescription(State state, MetaClass entity, boolean isEmbeddable) {
         List<AttributeModel> attributeModelsList = new ArrayList<>();
         List<MetaProperty> fields = entity.getProperties().stream().toList();
         Map<RelationType, List<Relation>> relationsMap = new HashMap<>();
-        String dataStoreName = entity.getStore().getName();
+        EntityDescriptor entityDescriptor = resolveEntityDescriptor(entity);
+        String dataStoreName = entityDescriptor.storeName();
 
         for (MetaProperty field : fields) {
             String fieldName = field.getName();
 
             if (!metadataTools.isJpa(field)) {
+                addContributedAttribute(entity, field, entityDescriptor, attributeModelsList, relationsMap);
                 continue;
             }
 
@@ -192,12 +261,13 @@ public class DataModelRegistry {
 
         String currentEntityType = entity.getName();
         String entityDescription = diagramEngine
-                .constructEntityDescription(currentEntityType, dataStoreName, attributeModelsList);
+                .constructEntityDescription(currentEntityType, dataStoreName, attributeModelsList,
+                        entityDescriptor.dynamic());
 
-        EntityModel entityModel = constructEntityModel(entity, isSystem);
+        EntityModel entityModel = constructEntityModel(entity, isSystem, entityDescriptor);
         DataModel dataModel = new DataModel(
                 currentEntityType,
-                entity.getStore().getName(),
+                dataStoreName,
                 entityModel,
                 relationsMap,
                 entityDescription,
@@ -207,6 +277,64 @@ public class DataModelRegistry {
         putDataModel(state, dataModel);
 
         return dataModel;
+    }
+
+    protected void addContributedAttribute(MetaClass entity, MetaProperty field,
+                                           EntityDescriptor entityDescriptor,
+                                           List<AttributeModel> attributeModelsList,
+                                           Map<RelationType, List<Relation>> relationsMap) {
+        AttributeDescriptor descriptor = null;
+        for (DataModelContributor contributor : contributors) {
+            descriptor = callContributor(contributor, "describeAttribute",
+                    c -> c.describeAttribute(entity, field));
+            if (descriptor != null) {
+                break;
+            }
+        }
+        if (descriptor == null) {
+            log.debug("No data model contributor describes '{}'", field);
+            return;
+        }
+
+        attributeModelsList.add(constructContributedAttribute(descriptor, entityDescriptor));
+
+        AttributeDescriptor.RelationDescriptor relation = descriptor.relation();
+        if (relation != null) {
+            String dataStoreName = entityDescriptor.storeName();
+            String relationDescription = diagramEngine.constructRelationDescription(
+                    entity.getName(), relation.entityName(), relation.type(), dataStoreName);
+            putRelation(relationsMap, relation.type(),
+                    new Relation(dataStoreName, relation.entityName(), relationDescription));
+        }
+    }
+
+    protected AttributeModel constructContributedAttribute(AttributeDescriptor descriptor,
+                                                           EntityDescriptor entityDescriptor) {
+        AttributeModel attributeModel =
+                createAttributeModel(descriptor.name(), descriptor.javaType(), descriptor.dynamic());
+        attributeModel.setIsMandatory(descriptor.mandatory());
+
+        AttributeDescriptor.ColumnDescriptor column = descriptor.column();
+        if (column == null) {
+            attributeModel.setColumnName(descriptor.noColumnText());
+            attributeModel.setDbType("");
+            return attributeModel;
+        }
+
+        attributeModel.setColumnName(column.tableName().equals(entityDescriptor.tableName())
+                ? column.columnName()
+                : column.tableName() + "." + column.columnName());
+        attributeModel.setDbType(column.dbType() != null
+                ? column.dbType()
+                : getContributedColumnType(entityDescriptor.storeName(), column.tableName(),
+                        column.columnName()));
+
+        return attributeModel;
+    }
+
+    protected String getContributedColumnType(String storeName, String tableName, String columnName) {
+        return getDatabaseColumnType(storeName, null, null,
+                applyRegister(tableName, storeName), applyRegister(columnName, storeName));
     }
 
     protected void addDatatypeAttribute(MetaClass entity, boolean isEmbeddable, MetaProperty field,
@@ -403,15 +531,15 @@ public class DataModelRegistry {
         attributeModelsList.add(attributeModel);
     }
 
-    protected EntityModel constructEntityModel(MetaClass entity, boolean isSystem) {
+    protected EntityModel constructEntityModel(MetaClass entity, boolean isSystem,
+                                               EntityDescriptor descriptor) {
         EntityModel entityModel = metadata.create(EntityModel.class);
 
         entityModel.setName(entity.getName());
-        entityModel.setDataStore(entity.getStore().getName());
+        entityModel.setDataStore(descriptor.storeName());
         entityModel.setIsSystem(isSystem);
-        entityModel.setTableName(entity.getJavaClass().isAnnotationPresent(Table.class)
-                ? entity.getJavaClass().getAnnotation(Table.class).name()
-                : "");
+        entityModel.setTableName(descriptor.tableName());
+        entityModel.setDynamic(descriptor.dynamic());
 
         return entityModel;
     }
@@ -426,10 +554,15 @@ public class DataModelRegistry {
     }
 
     protected AttributeModel constructAttribute(String fieldName, String fieldType) {
+        return createAttributeModel(fieldName, fieldType, false);
+    }
+
+    protected AttributeModel createAttributeModel(String fieldName, String fieldType, boolean dynamic) {
         AttributeModel attributeModel = metadata.create(AttributeModel.class);
 
         attributeModel.setAttributeName(fieldName);
         attributeModel.setJavaType(fieldType);
+        attributeModel.setDynamic(dynamic);
 
         return attributeModel;
     }

--- a/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/EntityDescriptor.java
+++ b/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/EntityDescriptor.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Haulmont.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.jmix.datatools.datamodel;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Physical placement of an entity contributed to the data model.
+ *
+ * @param storeName physical data store name
+ * @param tableName physical table name
+ * @param dynamic   whether the entity is defined at runtime rather than on the classpath
+ */
+@NullMarked
+public record EntityDescriptor(String storeName, String tableName, boolean dynamic) {
+}

--- a/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/engine/DiagramEngine.java
+++ b/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/engine/DiagramEngine.java
@@ -41,6 +41,21 @@ public interface DiagramEngine {
     String constructEntityDescription(String entityName, String dataStoreName, List<AttributeModel> attributeModelList);
 
     /**
+     * Constructs a description of an entity, marking the entity itself when it is defined at runtime
+     * rather than on the classpath.
+     *
+     * @param entityName         the name of the entity to be described
+     * @param dataStoreName      the name of the data store where the entity resides
+     * @param attributeModelList a list of attributes that define the structure of the entity
+     * @param dynamic            whether the entity itself is dynamic
+     * @return a string representing the description of the entity in the required format
+     */
+    default String constructEntityDescription(String entityName, String dataStoreName,
+                                              List<AttributeModel> attributeModelList, boolean dynamic) {
+        return constructEntityDescription(entityName, dataStoreName, attributeModelList);
+    }
+
+    /**
      * Constructs a string representation of a relationship between two entities in a specific format
      * for use with a diagramming library.
      *

--- a/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/engine/plantuml/impl/PlantUmlDiagramEngine.java
+++ b/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/engine/plantuml/impl/PlantUmlDiagramEngine.java
@@ -48,6 +48,8 @@ public class PlantUmlDiagramEngine implements DiagramEngine {
     protected final String template;
     protected final String entityTemplate;
     protected final String attributeTemplate;
+    protected final String dynamicAttributeTemplate;
+    protected final String dynamicEntityTemplate;
     protected final String relationTemplate;
     protected final String urlTemplate;
     protected final RestClient restClient;
@@ -64,6 +66,8 @@ public class PlantUmlDiagramEngine implements DiagramEngine {
         this.urlTemplate = createURLTemplate();
         this.entityTemplate = createEntityTemplate();
         this.attributeTemplate = createAttributeTemplate();
+        this.dynamicAttributeTemplate = createDynamicAttributeTemplate();
+        this.dynamicEntityTemplate = createDynamicEntityTemplate();
         this.relationTemplate = createRelationTemplate();
         this.available = resolveAvailable(coreProperties);
 
@@ -123,6 +127,17 @@ public class PlantUmlDiagramEngine implements DiagramEngine {
         return "    %s : %s\n";
     }
 
+    protected String createDynamicAttributeTemplate() {
+        return "    %s : %s <<dynamic>>\n";
+    }
+
+    protected String createDynamicEntityTemplate() {
+        if (dataStoresCount > 1) {
+            return "entity %s:%s <<dynamic>> {\n";
+        }
+        return "entity %s <<dynamic>> {\n";
+    }
+
     protected String createRelationTemplate() {
         if (dataStoresCount > 1) {
             return "\"%s:%s\" %s \"%s:%s\"\n";
@@ -176,16 +191,28 @@ public class PlantUmlDiagramEngine implements DiagramEngine {
 
     @Override
     public String constructEntityDescription(String entityName, String dataStoreName, List<AttributeModel> attributeModelList) {
-        StringBuilder entityDescription;
+        return constructEntityDescription(entityName, dataStoreName, attributeModelList, false);
+    }
 
+    @Override
+    public String constructEntityDescription(String entityName, String dataStoreName,
+                                             List<AttributeModel> attributeModelList, boolean dynamic) {
+        String template = dynamic ? dynamicEntityTemplate : entityTemplate;
+
+        StringBuilder entityDescription;
         if (dataStoresCount > 1) {
-            entityDescription = new StringBuilder(String.format(entityTemplate, entityName, dataStoreName));
+            entityDescription = new StringBuilder(String.format(template, entityName, dataStoreName));
         } else {
-            entityDescription = new StringBuilder(String.format(entityTemplate, entityName));
+            entityDescription = new StringBuilder(String.format(template, entityName));
         }
 
         for (AttributeModel attribute : attributeModelList) {
-            entityDescription.append(String.format(attributeTemplate, attribute.getAttributeName(), attribute.getJavaType()));
+            // A dynamic entity is marked as a whole, so marking each of its attributes adds nothing.
+            String attributeTemplateToUse = !dynamic && Boolean.TRUE.equals(attribute.getDynamic())
+                    ? dynamicAttributeTemplate
+                    : attributeTemplate;
+            entityDescription.append(String.format(attributeTemplateToUse,
+                    attribute.getAttributeName(), attribute.getJavaType()));
         }
 
         entityDescription.append("}\n");

--- a/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/entity/AttributeModel.java
+++ b/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/entity/AttributeModel.java
@@ -46,12 +46,22 @@ public class AttributeModel {
 
     private Boolean isMandatory;
 
+    private Boolean dynamic;
+
     public void setIsMandatory(Boolean isMandatory) {
         this.isMandatory = isMandatory;
     }
 
     public Boolean getIsMandatory() {
         return isMandatory;
+    }
+
+    public Boolean getDynamic() {
+        return dynamic;
+    }
+
+    public void setDynamic(Boolean dynamic) {
+        this.dynamic = dynamic;
     }
 
     public String getDbType() {

--- a/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/entity/EntityModel.java
+++ b/jmix-datatools/datatools/src/main/java/io/jmix/datatools/datamodel/entity/EntityModel.java
@@ -48,6 +48,8 @@ public class EntityModel {
 
     private Boolean isSystem;
 
+    private Boolean dynamic;
+
     public String getDataStore() {
         return dataStore;
     }
@@ -62,6 +64,14 @@ public class EntityModel {
 
     public void setIsSystem(Boolean isSystem) {
         this.isSystem = isSystem;
+    }
+
+    public Boolean getDynamic() {
+        return dynamic;
+    }
+
+    public void setDynamic(Boolean dynamic) {
+        this.dynamic = dynamic;
     }
 
     public String getTableName() {

--- a/jmix-datatools/datatools/src/main/resources/io/jmix/datatools/messages.properties
+++ b/jmix-datatools/datatools/src/main/resources/io/jmix/datatools/messages.properties
@@ -25,12 +25,14 @@ io.jmix.datatools.datamodel.entity/AttributeModel=Attribute model
 io.jmix.datatools.datamodel.entity/AttributeModel.attributeName=Attribute name
 io.jmix.datatools.datamodel.entity/AttributeModel.columnName=Column name
 io.jmix.datatools.datamodel.entity/AttributeModel.dbType=DB type
+io.jmix.datatools.datamodel.entity/AttributeModel.dynamic=Dynamic
 io.jmix.datatools.datamodel.entity/AttributeModel.id=Id
 io.jmix.datatools.datamodel.entity/AttributeModel.isMandatory=Is mandatory
 io.jmix.datatools.datamodel.entity/AttributeModel.javaType=Java type
 
 io.jmix.datatools.datamodel.entity/EntityModel=Entity model
 io.jmix.datatools.datamodel.entity/EntityModel.attributeModels=Attribute models
+io.jmix.datatools.datamodel.entity/EntityModel.dynamic=Dynamic
 io.jmix.datatools.datamodel.entity/EntityModel.id=Id
 io.jmix.datatools.datamodel.entity/EntityModel.name=Entity name
 io.jmix.datatools.datamodel.entity/EntityModel.tableName=Table name


### PR DESCRIPTION
### Summary

Made the Data Tools views work with entities and attributes that JPA metadata cannot describe, so add-ons and custom data stores can appear in them. Adds one extension point for the Data model view and makes the Entity inspector decide what it can handle from an entity's data store rather than from JPA annotations.

### What was done

- Added `DataModelContributor` (module `datatools`), the extension point a module implements to describe entities and attributes the Data model view cannot derive from JPA metadata, with the `EntityDescriptor` and `AttributeDescriptor` records it returns. `DataModelRegistry` consults contributors alongside its JPA scan; a contributor that throws is logged and skipped rather than breaking the whole view.
- Added `EntityInspectorSupport` (module `datatools`), which answers three questions from an entity's data store: which entities the inspector can browse, whether the store accepts a JPQL query string, and whether a property is stored. `EntityInspectorListView`, `EntityInspectorDetailView` and `InspectorDataGridBuilder` now use it instead of their JPA checks — the loader sets a JPQL string only for stores that accept one, and the detail view loads a non-JPA root by id.
- `EntityModel` and `AttributeModel` carry a `dynamic` flag, shown as a grid column only when a contributor is registered. The diagram marks a contributed entity with `<<dynamic>>` on the entity, and a contributed attribute of a static entity on the attribute.
- The reference field of a non-JPA property is no longer forced read-only: the owning-side rule reads JPA mapping annotations, which such a property does not have.

### How it works

`DataModelRegistry` builds the data model from JPA entities as before, then adds the entities contributors offer and routes any property JPA metadata does not describe to them. A contributed column is qualified as `TABLE.COLUMN` when it lives in a table other than the entity's own; an attribute with no column of its own shows no column. The Entity inspector offers every entity of a real data store, so entities of non-JPA stores — dynamic entities, REST DTO stores, custom stores — are browsable and editable without any store-specific code.

### How to use

Implement `DataModelContributor` and register it as a bean to make a module's entities and attributes appear in the Data model view. Nothing is needed for the Entity inspector — an entity of any registered data store is offered automatically.

### Compatibility

Opt-in for the Data model view: with no contributor registered, the data model is built exactly as before and the `Dynamic` columns stay hidden. The Entity inspector's entity list widens by design — entities of non-JPA stores now appear where previously only JPA entities did.

### Test plan

- `./gradlew :datatools:test :datatools-flowui:test`
- Manually: open the Entity inspector on an entity of a non-JPA store — the list shows its fields, not only the id; edit a row and check reference fields are editable.
